### PR TITLE
Paqet Protocol Support - Raw Packet Proxy                                                                                       

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ ENABLE_TRUSTTUNNEL=true
 ENABLE_ADMIN_UI=true
 ENABLE_CONDUIT=true
 ENABLE_SNOWFLAKE=true
+ENABLE_PAQET=false
 # ENABLE_MONITORING=true  # Uncomment to enable Grafana monitoring (requires 2GB RAM)
 
 # =============================================================================
@@ -135,6 +136,7 @@ PORT_DNS=53          # DNS tunnel (dnstt)
 PORT_ADMIN=9443      # Admin dashboard
 PORT_CDN=2082        # CDN WebSocket (VLESS+WS)
 PORT_TRUSTTUNNEL=4443 # TrustTunnel (HTTP/2 + QUIC)
+PORT_PAQET=9999      # Paqet raw packet proxy
 PORT_GRAFANA=9444    # Grafana monitoring dashboard
 
 # =============================================================================
@@ -157,6 +159,15 @@ GRAFANA_SUBDOMAIN=grafana
 GRAFANA_APP_TITLE=
 
 # =============================================================================
+# PAQET CONFIGURATION (Raw Packet Proxy - Last Resort)
+# =============================================================================
+
+# Paqet advanced settings (optional)
+# PAQET_LOG_LEVEL=info     # Log level: debug, info, warn, error
+# PAQET_KCP_MODE=fast      # KCP mode: fast, normal, fast2, fast3
+# PAQET_ENCRYPTION=aes     # Encryption: aes, tea, xor, none
+
+# =============================================================================
 # CDN CONFIGURATION (Cloudflare CDN-fronted VLESS+WebSocket)
 # =============================================================================
 
@@ -172,7 +183,7 @@ CDN_WS_PATH=/ws
 # =============================================================================
 
 # Default profiles for 'moav start' (space-separated)
-# Options: proxy wireguard dnstt trusttunnel admin conduit snowflake monitoring
+# Options: proxy wireguard dnstt trusttunnel paqet admin conduit snowflake monitoring
 # Use 'all' for everything, or leave empty to be prompted
 DEFAULT_PROFILES=
 

--- a/README-fa.md
+++ b/README-fa.md
@@ -8,7 +8,7 @@
 
 ## ویژگی‌ها
 
-- **پروتکل‌های متعدد** - Reality (VLESS)، Trojan، Hysteria2، TrustTunnel، WireGuard (مستقیم و wstunnel)، تونل DNS
+- **پروتکل‌های متعدد** - Reality (VLESS)، Trojan، Hysteria2، TrustTunnel، WireGuard (مستقیم و wstunnel)، Paqet، تونل DNS
 - **اولویت پنهان‌کاری** - تمام ترافیک شبیه HTTPS معمولی، WebSocket، یا DNS به نظر می‌رسد
 - **اعتبارنامه‌های جداگانه برای هر کاربر** - ایجاد، لغو و مدیریت کاربران به صورت مستقل
 - **نصب آسان** - مبتنی بر Docker Compose، راه‌اندازی با یک دستور
@@ -153,6 +153,7 @@ docker compose --profile all up -d                 # شروع تمام سروی�
 | TrustTunnel | 4443/tcp+udp | ★★★★★ | ★★★★☆ | HTTP/2 و QUIC، شبیه HTTPS |
 | WireGuard (مستقیم) | 51820/udp | ★★★☆☆ | ★★★★★ | VPN کامل، نصب ساده |
 | WireGuard (wstunnel) | 8080/tcp | ★★★★☆ | ★★★★☆ | VPN وقتی UDP مسدود است |
+| Paqet | 9999/tcp | ★★★☆☆ | ★★★☆☆ | پکت خام، عبور از فایروال سیستم‌عامل |
 | تونل DNS | 53/udp | ★★★☆☆ | ★☆☆☆☆ | آخرین راه‌حل، سخت برای مسدود کردن |
 | Psiphon | - | ★★★★☆ | ★★★☆☆ | مستقل، نیازی به سرور ندارد |
 | Tor (Snowflake) | - | ★★★★☆ | ★★☆☆☆ | مستقل، از شبکه Tor استفاده می‌کند |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Multi-protocol censorship circumvention stack optimized for hostile network envi
 
 ## Features
 
-- **Multiple protocols** - Reality (VLESS), Trojan, Hysteria2, TrustTunnel, WireGuard (direct & wstunnel), DNS tunnel
+- **Multiple protocols** - Reality (VLESS), Trojan, Hysteria2, TrustTunnel, WireGuard (direct & wstunnel), Paqet, DNS tunnel
 - **Stealth-first** - All traffic looks like normal HTTPS, WebSocket, or DNS
 - **Per-user credentials** - Create, revoke, and manage users independently
 - **Easy deployment** - Docker Compose based, single command setup
@@ -132,6 +132,7 @@ See [docs/SETUP.md](docs/SETUP.md) for complete setup instructions.
 | TrustTunnel | 4443/tcp+udp | ★★★★★ | ★★★★☆ | HTTP/2 & QUIC, looks like HTTPS |
 | WireGuard (Direct) | 51820/udp | ★★★☆☆ | ★★★★★ | Full VPN, simple setup |
 | WireGuard (wstunnel) | 8080/tcp | ★★★★☆ | ★★★★☆ | VPN when UDP is blocked |
+| Paqet | 9999/tcp | ★★★☆☆ | ★★★☆☆ | Raw packet, bypasses OS firewall |
 | DNS Tunnel | 53/udp | ★★★☆☆ | ★☆☆☆☆ | Last resort, hard to block |
 | Psiphon | - | ★★★★☆ | ★★★☆☆ | Standalone, no server needed |
 | Tor (Snowflake) | - | ★★★★☆ | ★★☆☆☆ | Standalone, uses Tor network |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -325,6 +325,33 @@ services:
       - all
 
   # ===========================================================================
+  # PAQET: Raw packet-level proxy (last resort)
+  # Bypasses OS TCP/IP stack using pcap - requires host network + privileged
+  # ===========================================================================
+  paqet:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.paqet
+    container_name: moav-paqet
+    restart: unless-stopped
+    # REQUIRED: Host network mode for raw packet access
+    network_mode: host
+    # REQUIRED: Privileged mode for pcap/raw sockets
+    privileged: true
+    volumes:
+      - moav_state:/state
+      - ./configs/paqet:/etc/paqet
+    environment:
+      - TZ=${TZ:-UTC}
+      - PAQET_PORT=${PORT_PAQET:-9999}
+      - PAQET_LOG_LEVEL=${PAQET_LOG_LEVEL:-info}
+      - PAQET_KCP_MODE=${PAQET_KCP_MODE:-fast}
+      - PAQET_ENCRYPTION=${PAQET_ENCRYPTION:-aes}
+    profiles:
+      - paqet
+      - all
+
+  # ===========================================================================
   # ADMIN: Stats dashboard
   # ===========================================================================
   admin:
@@ -570,6 +597,8 @@ services:
       - ENABLE_WIREGUARD=${ENABLE_WIREGUARD:-true}
       - ENABLE_DNSTT=${ENABLE_DNSTT:-true}
       - ENABLE_TRUSTTUNNEL=${ENABLE_TRUSTTUNNEL:-true}
+      - ENABLE_PAQET=${ENABLE_PAQET:-false}
+      - PORT_PAQET=${PORT_PAQET:-9999}
       - ENABLE_ADMIN_UI=${ENABLE_ADMIN_UI:-true}
       - CDN_SUBDOMAIN=${CDN_SUBDOMAIN:-}
       - CDN_DOMAIN=${CDN_DOMAIN:-}

--- a/dockerfiles/Dockerfile.client
+++ b/dockerfiles/Dockerfile.client
@@ -24,6 +24,16 @@ RUN git clone https://www.bamsoftware.com/git/dnstt.git /tmp/dnstt && \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -o /dnstt-client . || touch /dnstt-client
 
 # =============================================================================
+# Builder stage - compile paqet (no official releases available)
+# =============================================================================
+FROM golang:1.23-alpine AS paqet-builder
+RUN apk add --no-cache git libpcap-dev gcc musl-dev
+ENV GOTOOLCHAIN=auto
+RUN git clone --depth 1 https://github.com/hanselime/paqet.git /src/paqet && \
+    cd /src/paqet && \
+    go build -o /paqet ./cmd || touch /paqet
+
+# =============================================================================
 # Final image - download pre-built binaries for correct architecture
 # =============================================================================
 FROM alpine:3.21
@@ -49,6 +59,7 @@ RUN apk add --no-cache \
     iproute2 \
     bind-tools \
     tor \
+    libpcap \
     && rm -rf /var/cache/apk/*
 
 # Architecture mapping helper script
@@ -98,6 +109,14 @@ RUN ARCH=$(cat /tmp/arch) && \
     chmod +x /usr/local/bin/snowflake-client && \
     echo "snowflake-client ${SNOWFLAKE_VERSION} installed (${ARCH})" || \
     echo "snowflake-client: download failed (optional, needed for Tor)"
+
+# paqet: copy built binary from builder (no official releases)
+COPY --from=paqet-builder /paqet /tmp/paqet-built
+RUN cp /tmp/paqet-built /usr/local/bin/paqet && \
+    chmod +x /usr/local/bin/paqet && \
+    echo "paqet: using locally built binary" || \
+    echo "paqet: build failed (optional)"
+RUN rm -f /tmp/paqet-built
 
 # dnstt-client: copy cross-compiled binary from builder
 COPY --from=dnstt-builder /dnstt-client /usr/local/bin/dnstt-client

--- a/dockerfiles/Dockerfile.paqet
+++ b/dockerfiles/Dockerfile.paqet
@@ -1,0 +1,56 @@
+# =============================================================================
+# MoaV Paqet - Raw Packet Level Proxy
+# =============================================================================
+# Paqet bypasses OS TCP/IP stack using pcap for packet capture/injection.
+# Requires: --network host --privileged (or NET_RAW + NET_ADMIN capabilities)
+# =============================================================================
+
+FROM golang:1.23-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git libpcap-dev gcc musl-dev
+
+# Enable toolchain auto-download for newer Go versions
+ENV GOTOOLCHAIN=auto
+
+# Clone paqet source
+ARG PAQET_VERSION=master
+RUN git clone --depth 1 --branch ${PAQET_VERSION} https://github.com/hanselime/paqet.git /src/paqet
+
+WORKDIR /src/paqet
+
+# Download dependencies first (better caching)
+RUN go mod download
+
+# Build paqet
+RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o /paqet ./cmd
+
+# =============================================================================
+# Final image
+# =============================================================================
+FROM alpine:3.20
+
+# Install runtime dependencies
+RUN apk add --no-cache \
+    libpcap \
+    iptables \
+    iproute2 \
+    bash \
+    curl \
+    jq \
+    && rm -rf /var/cache/apk/*
+
+# Copy paqet binary
+COPY --from=builder /paqet /usr/local/bin/paqet
+RUN chmod +x /usr/local/bin/paqet
+
+# Copy entrypoint
+COPY scripts/paqet-entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Create directories
+RUN mkdir -p /etc/paqet /state
+
+WORKDIR /app
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -249,6 +249,7 @@ moav start all                   # Everything
 - `wireguard` - WireGuard VPN + wstunnel
 - `dnstt` - DNS tunnel
 - `trusttunnel` - TrustTunnel VPN
+- `paqet` - Raw packet proxy (last resort, requires host network)
 - `admin` - Admin dashboard
 - `conduit` - Psiphon bandwidth donation
 - `snowflake` - Tor bandwidth donation

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -19,6 +19,8 @@ Common issues and their solutions.
   - [TrustTunnel not connecting](#trusttunnel-not-connecting)
   - [CDN VLESS+WS not working](#cdn-vlessws-not-working)
   - [DNS tunnel not working](#dns-tunnel-not-working)
+  - [Paqet not starting](#paqet-not-starting)
+  - [Paqet iptables rules not persisting](#paqet-iptables-rules-not-persisting)
 - [Registry/Build Issues](#registrybuild-issues)
   - [Container registry blocked (gcr.io, ghcr.io)](#container-registry-blocked-gcrio-ghcrio)
   - [Building images locally](#building-images-locally)
@@ -555,6 +557,86 @@ This usually means Cloudflare can't reach your origin on the correct port.
 1. Set SSL/TLS mode to **Flexible** in Cloudflare dashboard
 2. Verify sing-box container is running
 3. Check sing-box config has `vless-ws-in` inbound on port 2082
+
+### Paqet not starting
+
+Paqet requires special system capabilities. Common issues:
+
+1. **OpenVZ/LXC container detected:**
+   ```
+   OpenVZ detected - raw sockets not supported!
+   ```
+   **Solution:** Paqet requires KVM, Xen, or bare metal. OpenVZ/LXC don't support raw sockets.
+
+2. **Missing libpcap:**
+   ```
+   error loading libpcap
+   ```
+   **Solution:**
+   ```bash
+   # Debian/Ubuntu
+   apt install libpcap-dev
+
+   # Alpine (in container)
+   apk add libpcap
+   ```
+
+3. **Permission denied:**
+   ```
+   permission denied creating raw socket
+   ```
+   **Solution:** Paqet must run with root/admin privileges and the container needs:
+   - `--network host`
+   - `--privileged` (or `--cap-add NET_RAW --cap-add NET_ADMIN`)
+
+4. **Gateway MAC not detected:**
+   ```
+   Could not detect gateway MAC address
+   ```
+   **Solution:** The entrypoint script auto-detects network config. If it fails:
+   ```bash
+   # Check gateway IP
+   ip route | grep default
+
+   # Ping gateway to populate ARP table
+   ping -c 1 GATEWAY_IP
+
+   # Get MAC
+   ip neigh show GATEWAY_IP
+   ```
+
+5. **iptables rules not set:**
+   Paqet needs specific iptables rules to prevent kernel RST packets:
+   ```bash
+   # These should be set automatically by the entrypoint
+   iptables -t raw -A PREROUTING -p tcp --dport 9999 -j NOTRACK
+   iptables -t raw -A OUTPUT -p tcp --sport 9999 -j NOTRACK
+   iptables -t mangle -A OUTPUT -p tcp --sport 9999 --tcp-flags RST RST -j DROP
+   ```
+
+### Paqet iptables rules not persisting
+
+The iptables rules set by paqet's entrypoint are lost on reboot. To persist them:
+
+**Debian/Ubuntu:**
+```bash
+# Save rules
+iptables-save > /etc/iptables/rules.v4
+
+# Install iptables-persistent
+apt install iptables-persistent
+```
+
+**Alpine:**
+```bash
+# Save rules
+/etc/init.d/iptables save
+
+# Enable at boot
+rc-update add iptables
+```
+
+Or add the rules to your server's startup script.
 
 ### WireGuard connected but no traffic
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -198,6 +198,8 @@ export ENABLE_HYSTERIA2="${ENABLE_HYSTERIA2:-true}"
 export ENABLE_WIREGUARD="${ENABLE_WIREGUARD:-true}"
 export ENABLE_DNSTT="${ENABLE_DNSTT:-true}"
 export ENABLE_TRUSTTUNNEL="${ENABLE_TRUSTTUNNEL:-true}"
+export ENABLE_PAQET="${ENABLE_PAQET:-false}"
+export PORT_PAQET="${PORT_PAQET:-9999}"
 # Construct CDN_DOMAIN from CDN_SUBDOMAIN + DOMAIN if not explicitly set
 if [[ -z "${CDN_DOMAIN:-}" && -n "${CDN_SUBDOMAIN:-}" && -n "${DOMAIN:-}" ]]; then
     export CDN_DOMAIN="${CDN_SUBDOMAIN}.${DOMAIN}"
@@ -205,6 +207,24 @@ else
     export CDN_DOMAIN="${CDN_DOMAIN:-}"
 fi
 export CDN_WS_PATH="${CDN_WS_PATH:-/ws}"
+
+# -----------------------------------------------------------------------------
+# Generate Paqet encryption key (if enabled)
+# -----------------------------------------------------------------------------
+if [[ "${ENABLE_PAQET:-false}" == "true" ]]; then
+    if [[ ! -f "$STATE_DIR/keys/paqet.key" ]]; then
+        log_info "Generating Paqet encryption key..."
+        PAQET_KEY=$(pwgen -s 32 1)
+        echo "$PAQET_KEY" > "$STATE_DIR/keys/paqet.key"
+        chmod 600 "$STATE_DIR/keys/paqet.key"
+    else
+        PAQET_KEY=$(cat "$STATE_DIR/keys/paqet.key")
+        log_info "Using existing Paqet encryption key"
+    fi
+    export PAQET_KEY
+else
+    PAQET_KEY=""
+fi
 
 # -----------------------------------------------------------------------------
 # Generate WireGuard server config (before creating users)

--- a/scripts/client-connect.sh
+++ b/scripts/client-connect.sh
@@ -24,6 +24,7 @@ TEST_TIMEOUT="${TEST_TIMEOUT:-10}"
 
 # Protocol priority for auto mode
 # Note: psiphon excluded - requires embedded server list, not supported in client mode
+# Note: paqet excluded from auto - requires privileged mode and network config
 PROTOCOL_PRIORITY=(reality hysteria2 trojan trusttunnel wireguard tor dnstt)
 
 # State
@@ -674,6 +675,64 @@ EOF
     fi
 }
 
+# Connect using paqet (raw packet proxy)
+# NOTE: Requires privileged mode and host networking - normally run via moav client
+connect_paqet() {
+    local config_file=""
+
+    for f in "$CONFIG_DIR"/paqet*.yaml "$CONFIG_DIR"/paqet*.yml; do
+        [[ -f "$f" ]] && config_file="$f" && break
+    done
+
+    if [[ -z "$config_file" ]]; then
+        log_error "No paqet config found"
+        return 1
+    fi
+
+    # Check if config needs customization
+    if grep -q "CHANGE_ME" "$config_file"; then
+        log_error "Paqet config needs customization first"
+        log_info "Edit $config_file and fill in your network details:"
+        log_info "  - interface: your network interface (eth0, en0, etc.)"
+        log_info "  - addr: your local IP address"
+        log_info "  - router_mac: your gateway's MAC address"
+        log_info "See paqet-instructions.txt for help finding these values"
+        return 1
+    fi
+
+    # Check if paqet binary exists
+    if ! command -v paqet >/dev/null 2>&1; then
+        log_error "paqet binary not found"
+        log_info "Download from: https://github.com/hanselime/paqet/releases"
+        return 1
+    fi
+
+    # Extract server for logging
+    local server=$(grep -E "^\s*addr:" "$config_file" | grep -v "YOUR_LOCAL" | sed 's/.*addr:[[:space:]]*//' | tr -d '"' | head -1)
+
+    log_info "Starting paqet client to $server..."
+    log_warn "Note: paqet requires root/admin privileges and raw socket access"
+
+    paqet run -c "$config_file" &
+    CURRENT_PID=$!
+    CURRENT_PROTOCOL="paqet"
+
+    sleep 3
+
+    if ! kill -0 $CURRENT_PID 2>/dev/null; then
+        log_error "paqet failed to start"
+        log_info "Common issues:"
+        log_info "  - Not running as root/admin"
+        log_info "  - OpenVZ/LXC container (needs KVM or bare metal)"
+        log_info "  - libpcap not installed"
+        log_info "  - Incorrect network interface or gateway MAC"
+        return 1
+    fi
+
+    log_success "paqet tunnel established"
+    return 0
+}
+
 # Connect using Psiphon (standalone, doesn't need MoaV server)
 # NOTE: Not implemented - Psiphon tunnel-core requires embedded server lists
 # that are not publicly available. Use the official Psiphon apps instead:
@@ -835,6 +894,9 @@ main() {
             ;;
         dnstt)
             connect_dnstt && connected=true
+            ;;
+        paqet)
+            connect_paqet && connected=true
             ;;
         *)
             log_error "Unknown protocol: $PROTOCOL"

--- a/scripts/client-test.sh
+++ b/scripts/client-test.sh
@@ -1095,6 +1095,64 @@ EOF
     rm -f "$test_config"
 }
 
+# Test paqet (raw packet proxy - config validation only)
+test_paqet() {
+    log_info "Testing paqet (config validation)..."
+
+    local config_file=""
+    local detail=""
+
+    for f in "$CONFIG_DIR"/paqet*.yaml "$CONFIG_DIR"/paqet*.yml; do
+        [[ -f "$f" ]] && config_file="$f" && break
+    done
+
+    if [[ -z "$config_file" ]]; then
+        detail="No paqet config found in bundle"
+        log_warn "$detail"
+        RESULTS[paqet]="skip"
+        DETAILS[paqet]="$detail"
+        return
+    fi
+
+    log_debug "Using config: $config_file"
+
+    # Extract server address
+    local server=$(grep -E "^\s*addr:" "$config_file" | grep -v "YOUR_LOCAL" | sed 's/.*addr:[[:space:]]*//' | tr -d '"' | head -1)
+    local key=$(grep -E "^\s*key:" "$config_file" | sed 's/.*key:[[:space:]]*//' | tr -d '"' | head -1)
+
+    log_debug "Parsed: server=$server key=${key:0:10}..."
+
+    if [[ -z "$server" ]] || [[ -z "$key" ]]; then
+        detail="Could not parse paqet config (missing server or key)"
+        log_error "$detail"
+        RESULTS[paqet]="fail"
+        DETAILS[paqet]="$detail"
+        return
+    fi
+
+    # Check if config needs user customization
+    if grep -q "CHANGE_ME" "$config_file"; then
+        log_warn "Paqet config needs customization (network details required)"
+        RESULTS[paqet]="warn"
+        DETAILS[paqet]="Config valid, but needs network details (interface, router_mac)"
+        return
+    fi
+
+    # Validate paqet binary exists
+    if ! command -v paqet >/dev/null 2>&1; then
+        log_warn "paqet binary not available"
+        RESULTS[paqet]="warn"
+        DETAILS[paqet]="Config found, but paqet client not installed"
+        return
+    fi
+
+    # Note: We can't fully test paqet without raw socket access
+    # which requires host network mode and privileges
+    log_success "Paqet config valid, server: $server"
+    RESULTS[paqet]="warn"
+    DETAILS[paqet]="Config valid for $server (requires privileged mode to test)"
+}
+
 # =============================================================================
 # Output Functions
 # =============================================================================
@@ -1130,7 +1188,7 @@ output_json() {
 EOF
 
     local first=true
-    for protocol in reality trojan hysteria2 wireguard dnstt trusttunnel; do
+    for protocol in reality trojan hysteria2 wireguard dnstt trusttunnel paqet; do
         if [[ -n "${RESULTS[$protocol]:-}" ]]; then
             [[ "$first" != "true" ]] && echo ","
             first=false
@@ -1161,7 +1219,7 @@ output_human() {
     echo ""
     echo "───────────────────────────────────────────────────────────────"
 
-    for protocol in reality trojan hysteria2 wireguard dnstt trusttunnel; do
+    for protocol in reality trojan hysteria2 wireguard dnstt trusttunnel paqet; do
         if [[ -n "${RESULTS[$protocol]:-}" ]]; then
             local status="${RESULTS[$protocol]}"
             local detail="${DETAILS[$protocol]:-}"
@@ -1201,6 +1259,7 @@ main() {
     test_wireguard
     test_dnstt
     test_trusttunnel
+    test_paqet
 
     # Output results
     if [[ "${JSON_OUTPUT:-false}" == "true" ]]; then

--- a/scripts/generate-single-user.sh
+++ b/scripts/generate-single-user.sh
@@ -97,6 +97,8 @@ export ENABLE_WIREGUARD="${ENABLE_WIREGUARD:-true}"
 export ENABLE_DNSTT="${ENABLE_DNSTT:-true}"
 export ENABLE_HYSTERIA2="${ENABLE_HYSTERIA2:-true}"
 export ENABLE_TRUSTTUNNEL="${ENABLE_TRUSTTUNNEL:-true}"
+export ENABLE_PAQET="${ENABLE_PAQET:-false}"
+export PORT_PAQET="${PORT_PAQET:-9999}"
 export DNSTT_SUBDOMAIN="${DNSTT_SUBDOMAIN:-t}"
 # Construct CDN_DOMAIN from CDN_SUBDOMAIN + DOMAIN if not explicitly set
 if [[ -z "${CDN_DOMAIN:-}" && -n "${CDN_SUBDOMAIN:-}" && -n "${DOMAIN:-}" ]]; then

--- a/scripts/generate-user.sh
+++ b/scripts/generate-user.sh
@@ -372,6 +372,127 @@ if [[ "${ENABLE_DNSTT:-true}" == "true" ]]; then
 fi
 
 # -----------------------------------------------------------------------------
+# Generate Paqet client config (if enabled)
+# -----------------------------------------------------------------------------
+if [[ "${ENABLE_PAQET:-false}" == "true" ]]; then
+    PAQET_KEY_FILE="/state/keys/paqet.key"
+    PAQET_PORT="${PORT_PAQET:-9999}"
+
+    if [[ -f "$PAQET_KEY_FILE" ]]; then
+        PAQET_KEY=$(cat "$PAQET_KEY_FILE")
+
+        # Generate client config template (user needs to fill in their network details)
+        cat > "$OUTPUT_DIR/paqet-client.yaml" <<EOF
+# Paqet Client Configuration
+# ==========================
+# IMPORTANT: You must fill in YOUR network details below!
+# See paqet-instructions.txt for how to find these values.
+
+role: "client"
+
+log:
+  level: "info"
+
+socks5:
+  - listen: "127.0.0.1:1080"
+
+network:
+  interface: "CHANGE_ME"           # Your network interface (en0, eth0, wlan0)
+  ipv4:
+    addr: "YOUR_LOCAL_IP:0"        # Your local IP address (port 0 = auto)
+    router_mac: "CHANGE_ME"        # Your gateway/router MAC address
+
+server:
+  addr: "${SERVER_IP}:${PAQET_PORT}"
+
+transport:
+  protocol: "kcp"
+  kcp:
+    mode: "fast"
+    block: "aes"
+    key: "${PAQET_KEY}"
+EOF
+
+        # Generate instructions
+        cat > "$OUTPUT_DIR/paqet-instructions.txt" <<EOF
+# Paqet Client Setup Instructions
+# ================================
+# Paqet is a raw packet-level proxy that bypasses OS firewalls.
+# Use this as a LAST RESORT when other protocols are blocked.
+
+# Requirements:
+# - libpcap installed
+# - Root/administrator privileges
+# - NOT OpenVZ/LXC container (requires KVM or bare metal)
+
+# Step 1: Install paqet
+# ---------------------
+# Download from: https://github.com/hanselime/paqet/releases
+# Or build from source: go install github.com/hanselime/paqet/cmd/paqet@latest
+
+# Step 2: Install libpcap
+# -----------------------
+# Debian/Ubuntu: sudo apt install libpcap-dev
+# macOS: Comes pre-installed (or: brew install libpcap)
+# Windows: Install Npcap from https://npcap.com
+
+# Step 3: Find YOUR network details
+# ---------------------------------
+# Linux:
+#   Interface: ip a (look for eth0, wlan0, etc.)
+#   Local IP:  ip -4 addr show <interface> | grep inet
+#   Gateway:   ip route | grep default
+#   Gateway MAC: arp -n <gateway_ip>
+#
+# macOS:
+#   Interface: ifconfig (look for en0)
+#   Local IP:  ifconfig <interface> | grep inet
+#   Gateway:   netstat -rn | grep default
+#   Gateway MAC: arp -n <gateway_ip>
+#
+# Windows:
+#   Interface: Get-NetAdapter | Select-Object Name, InterfaceGuid
+#   Local IP:  ipconfig
+#   Gateway:   ipconfig | findstr Gateway
+#   Gateway MAC: arp -a <gateway_ip>
+
+# Step 4: Edit paqet-client.yaml
+# ------------------------------
+# Replace CHANGE_ME values with your network details:
+#   - interface: your network interface name
+#   - addr: your local IP (keep :0 for auto port)
+#   - router_mac: your gateway's MAC address
+
+# Step 5: Run paqet
+# -----------------
+# Linux/macOS: sudo paqet run -c paqet-client.yaml
+# Windows: Run as Administrator: paqet run -c paqet-client.yaml
+
+# Step 6: Use the proxy
+# ---------------------
+# Configure applications to use SOCKS5 proxy at 127.0.0.1:1080
+
+# Server Connection Info:
+# -----------------------
+# Server: ${SERVER_IP}:${PAQET_PORT}
+# Protocol: KCP over raw TCP packets
+# Encryption: AES
+
+# Troubleshooting:
+# ----------------
+# - "permission denied" → Run as root/admin
+# - "no route to host" → Check firewall, gateway MAC
+# - "pcap error" → Install libpcap, check interface name
+# - OpenVZ/LXC error → Use KVM VPS or bare metal instead
+EOF
+
+        log_info "  - Paqet config generated"
+    else
+        log_warn "  - Paqet key not found, skipping config generation"
+    fi
+fi
+
+# -----------------------------------------------------------------------------
 # Generate README.html from template
 # -----------------------------------------------------------------------------
 TEMPLATE_FILE="/docs/client-guide-template.html"

--- a/scripts/paqet-entrypoint.sh
+++ b/scripts/paqet-entrypoint.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# =============================================================================
+# Paqet Server Entrypoint
+# Auto-detects network configuration and starts paqet server
+# =============================================================================
+
+# Note: We don't use pipefail here because commands like `cmd | head -1`
+# cause SIGPIPE when head exits after reading one line, which pipefail
+# treats as an error (exit code 141).
+set -eu
+
+# Colors for logging
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[paqet]${NC} $1"; }
+log_success() { echo -e "${GREEN}[paqet]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[paqet]${NC} $1"; }
+log_error() { echo -e "${RED}[paqet]${NC} $1"; }
+
+# =============================================================================
+# VPS Compatibility Check
+# =============================================================================
+check_vps_compatibility() {
+    log_info "Checking VPS compatibility..."
+
+    # Check for OpenVZ (doesn't support raw sockets)
+    if [[ -f /proc/user_beancounters ]]; then
+        log_error "OpenVZ detected - raw sockets not supported!"
+        log_error "Paqet requires KVM, Xen, or bare metal servers."
+        exit 1
+    fi
+
+    # Check for LXC/container environment
+    if [[ -f /proc/1/environ ]] && grep -q "container=" /proc/1/environ 2>/dev/null; then
+        log_warn "Container environment detected - raw sockets may not work"
+    fi
+
+    # Test raw socket capability
+    if ! capsh --print 2>/dev/null | grep -q "cap_net_raw"; then
+        # Try alternative check
+        if [[ ! -w /dev/net/tun ]] && [[ "$(id -u)" != "0" ]]; then
+            log_warn "May not have raw socket capabilities"
+        fi
+    fi
+
+    log_success "VPS compatibility check passed"
+}
+
+# =============================================================================
+# Network Auto-Detection
+# =============================================================================
+detect_interface() {
+    # Find the default route interface
+    local iface=$(ip route | grep default | awk '{print $5}' | head -1)
+
+    if [[ -z "$iface" ]]; then
+        # Fallback: find first non-lo interface with an IP
+        iface=$(ip -o -4 addr show | grep -v ' lo ' | awk '{print $2}' | head -1)
+    fi
+
+    echo "$iface"
+}
+
+detect_server_ip() {
+    local iface="$1"
+    ip -4 addr show "$iface" | awk '/inet / {print $2}' | cut -d/ -f1 | head -1
+}
+
+detect_gateway_ip() {
+    ip route | grep default | awk '{print $3}' | head -1
+}
+
+detect_gateway_mac() {
+    local gateway_ip="$1"
+
+    # Ping gateway to ensure ARP entry exists
+    ping -c 1 -W 1 "$gateway_ip" >/dev/null 2>&1 || true
+
+    # Get MAC from ARP table
+    local mac=$(ip neigh show "$gateway_ip" 2>/dev/null | awk '{print $5}' | head -1)
+
+    # Fallback to arp command
+    if [[ -z "$mac" ]] || [[ "$mac" == "FAILED" ]]; then
+        mac=$(arp -n "$gateway_ip" 2>/dev/null | tail -1 | awk '{print $3}')
+    fi
+
+    echo "$mac"
+}
+
+# =============================================================================
+# iptables Setup
+# =============================================================================
+setup_iptables() {
+    local port="$1"
+
+    log_info "Setting up iptables rules for port $port..."
+
+    # Check if rules already exist
+    if iptables -t raw -C PREROUTING -p tcp --dport "$port" -j NOTRACK 2>/dev/null; then
+        log_info "iptables rules already configured"
+        return 0
+    fi
+
+    # Bypass connection tracking (essential for paqet)
+    iptables -t raw -A PREROUTING -p tcp --dport "$port" -j NOTRACK || log_warn "Failed to add PREROUTING NOTRACK rule"
+    iptables -t raw -A OUTPUT -p tcp --sport "$port" -j NOTRACK || log_warn "Failed to add OUTPUT NOTRACK rule"
+
+    # Prevent kernel from sending RST packets
+    iptables -t mangle -A OUTPUT -p tcp --sport "$port" --tcp-flags RST RST -j DROP || log_warn "Failed to add RST DROP rule"
+
+    # Allow traffic on the port
+    iptables -t filter -A INPUT -p tcp --dport "$port" -j ACCEPT 2>/dev/null || true
+    iptables -t filter -A OUTPUT -p tcp --sport "$port" -j ACCEPT 2>/dev/null || true
+
+    log_success "iptables rules configured"
+}
+
+# =============================================================================
+# Configuration Generation
+# =============================================================================
+generate_config() {
+    local config_file="$1"
+    local interface="$2"
+    local server_ip="$3"
+    local gateway_mac="$4"
+    local port="$5"
+    local key="$6"
+
+    log_info "Generating paqet server configuration..."
+
+    cat > "$config_file" <<EOF
+# Paqet Server Configuration (auto-generated)
+role: "server"
+
+log:
+  level: "${PAQET_LOG_LEVEL:-info}"
+
+listen:
+  addr: ":${port}"
+
+network:
+  interface: "${interface}"
+  ipv4:
+    addr: "${server_ip}:${port}"
+    router_mac: "${gateway_mac}"
+
+transport:
+  protocol: "kcp"
+  conn: 1
+  kcp:
+    mode: "${PAQET_KCP_MODE:-fast}"
+    block: "${PAQET_ENCRYPTION:-aes}"
+    key: "${key}"
+EOF
+
+    log_success "Configuration generated: $config_file"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+    log_info "Starting Paqet server..."
+
+    # Configuration
+    PORT="${PAQET_PORT:-9999}"
+    CONFIG_FILE="/etc/paqet/server.yaml"
+    KEY_FILE="/state/keys/paqet.key"
+
+    # Check VPS compatibility
+    check_vps_compatibility
+
+    # Load or generate key
+    if [[ -f "$KEY_FILE" ]]; then
+        PAQET_KEY=$(cat "$KEY_FILE")
+        log_info "Loaded encryption key from $KEY_FILE"
+    else
+        log_error "No encryption key found at $KEY_FILE"
+        log_error "Run bootstrap first: docker compose --profile setup run --rm bootstrap"
+        exit 1
+    fi
+
+    # Auto-detect network configuration
+    log_info "Auto-detecting network configuration..."
+
+    INTERFACE=$(detect_interface)
+    if [[ -z "$INTERFACE" ]]; then
+        log_error "Could not detect network interface"
+        exit 1
+    fi
+    log_info "  Interface: $INTERFACE"
+
+    SERVER_IP=$(detect_server_ip "$INTERFACE")
+    if [[ -z "$SERVER_IP" ]]; then
+        log_error "Could not detect server IP"
+        exit 1
+    fi
+    log_info "  Server IP: $SERVER_IP"
+
+    GATEWAY_IP=$(detect_gateway_ip)
+    if [[ -z "$GATEWAY_IP" ]]; then
+        log_error "Could not detect gateway IP"
+        exit 1
+    fi
+    log_info "  Gateway IP: $GATEWAY_IP"
+
+    GATEWAY_MAC=$(detect_gateway_mac "$GATEWAY_IP")
+    if [[ -z "$GATEWAY_MAC" ]] || [[ "$GATEWAY_MAC" == "(incomplete)" ]]; then
+        log_error "Could not detect gateway MAC address"
+        log_error "Try setting PAQET_GATEWAY_MAC environment variable"
+        exit 1
+    fi
+    log_info "  Gateway MAC: $GATEWAY_MAC"
+
+    # Setup iptables
+    setup_iptables "$PORT"
+
+    # Generate configuration
+    mkdir -p "$(dirname "$CONFIG_FILE")"
+    generate_config "$CONFIG_FILE" "$INTERFACE" "$SERVER_IP" "$GATEWAY_MAC" "$PORT" "$PAQET_KEY"
+
+    # Display config for debugging
+    if [[ "${PAQET_DEBUG:-false}" == "true" ]]; then
+        log_info "Configuration:"
+        cat "$CONFIG_FILE"
+    fi
+
+    log_success "Starting paqet server on port $PORT..."
+    exec paqet run -c "$CONFIG_FILE"
+}
+
+main "$@"


### PR DESCRIPTION
This PR is porting the old Paqet integration (https://github.com/shayanb/MoaV/pull/16) to the new MoaV structure and replacing the old PR.

---
                                               
Adds Paqet as an optional "last resort" protocol. Paqet bypasses the OS TCP/IP stack using pcap for raw packet capture/injection, making it effective when deep packet inspection defeats all standard protocols.                              
                                                                                                                                  
  Note: This is a full rewrite of the original paqet branch, ported onto current main to match the restructured codebase          
  (dockerfiles moved, moav.sh rewritten, TrustTunnel pattern, monitoring stack, etc).                                             

 ### What's included                                                                                                                 
                                                                                                                                  
  - Docker service (dockerfiles/Dockerfile.paqet) - Built from source, multi-stage golang + alpine
  - Auto-configuration entrypoint - Detects network interface, server IP, gateway MAC, sets iptables rules
  - Profile integration - moav start paqet, menu option 9, ENABLE_PAQET flag
  - Per-user config generation - paqet-client.yaml + paqet-instructions.txt in bundles
  - Client container support - paqet binary built into Dockerfile.client
  - Test & connect - moav test USER validates paqet config, moav client connect USER --protocol paqet
  - Documentation - CLIENTS.md setup guide, TROUBLESHOOTING.md, SETUP.md profile list

  ### Requirements

  - KVM, Xen, or bare metal - Does NOT work on OpenVZ/LXC
  - Host network + privileged - Required for raw socket access
  - Disabled by default (ENABLE_PAQET=false)

 ###  How to run

  1. Enable paqet in .env
  `echo "ENABLE_PAQET=true" >> .env`

  2. Bootstrap (generates encryption key)
  `moav bootstrap`

  3. Start with paqet profile
  `moav start paqet proxy admin`

  4. Verify container is running
  `docker ps | grep paqet`

  5. Check logs
  `moav logs paqet`


   ### How to test

  Server side:

- Check paqet container health
  `docker logs moav-paqet`
  
```
  # Expected output:
  # [paqet] Checking VPS compatibility...
  # [paqet] VPS compatibility check passed
  # [paqet] Auto-detecting network configuration...
  # [paqet]   Interface: eth0
  # [paqet]   Server IP: x.x.x.x
  # [paqet]   Gateway MAC: aa:bb:cc:dd:ee:ff
  # [paqet] iptables rules configured
  # [paqet] Configuration generated: /etc/paqet/server.yaml
  # [paqet] Starting paqet server on port 9999...
```

- Verify iptables rules were set
```
  docker exec moav-paqet iptables -t raw -L -n | grep 9999
  docker exec moav-paqet iptables -t mangle -L -n | grep RST
```

- Client side (user bundle):

```
  # Check bundle contains paqet configs
  ls outputs/bundles/demouser/paqet-*
  # → paqet-client.yaml, paqet-instructions.txt
```

```
  # Test config validation via moav test
  moav test demouser
  # → paqet: ⚠ Config valid, but needs network details (interface, router_mac)
```

 Manual client test (on a separate machine with root):
  1. Copy paqet-client.yaml to client machine
  2. Edit CHANGE_ME values (interface, local IP, gateway MAC)
  3. sudo paqet run -c paqet-client.yaml
  4. curl --socks5 127.0.0.1:1080 https://ifconfig.me


  ### Profile integration:

```
  # Verify profile appears in menu
  moav profiles
  # → Option 9: paqet (disabled by default, shown as dimmed)
```

```
  # Verify moav.sh syntax
  bash -n moav.sh
```

```
  # Verify docker-compose config
  docker compose --profile paqet config --services | grep paqet
```

 ### Configuration

  ```
┌──────────────────┬─────────┬────────────────────────────────────┐
  │     Variable     │ Default │            Description             │
  ├──────────────────┼─────────┼────────────────────────────────────┤
  │ ENABLE_PAQET     │ false   │ Enable/disable paqet               │
  ├──────────────────┼─────────┼────────────────────────────────────┤
  │ PORT_PAQET       │ 9999    │ Server listen port                 │
  ├──────────────────┼─────────┼────────────────────────────────────┤
  │ PAQET_LOG_LEVEL  │ info    │ Log level (debug/info/warn/error)  │
  ├──────────────────┼─────────┼────────────────────────────────────┤
  │ PAQET_KCP_MODE   │ fast    │ KCP mode (fast/normal/fast2/fast3) │
  ├──────────────────┼─────────┼────────────────────────────────────┤
  │ PAQET_ENCRYPTION │ aes     │ Encryption (aes/tea/xor/none)      │
  └──────────────────┴─────────┴────────────────────────────────────┘
```

 ###  Files changed

  - New: dockerfiles/Dockerfile.paqet, scripts/paqet-entrypoint.sh, configs/paqet/.gitkeep
  - Modified: docker-compose.yml, .env.example, moav.sh, scripts/bootstrap.sh, scripts/generate-user.sh, scripts/generate-single-user.sh, dockerfiles/Dockerfile.client, scripts/client-connect.sh, scripts/client-test.sh, README.md, README-fa.md, docs/CLIENTS.md, docs/SETUP.md, docs/TROUBLESHOOTING.md