### PR TITLE
feat(net): v1.8.5 network-tuning followups — tcp_max_syn_backlog + post-apply summary + doctor net extended checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Monitoring-stack opt-in default is now RAM-aware** — both confirm prompts (first-time + re-enable) default to `N` on hosts with `<2 GB` RAM, `Y` otherwise. Matches the doctor's existing "<2 GB + monitoring = hang risk" warning and the build-concurrency tier model. Operators on 2 GB+ hosts see no change; operators on small VPSes no longer get a default-yes monitoring stack competing for memory with the proxy containers
 
+### Added
+- **`net.ipv4.tcp_max_syn_backlog = 8192` in the network-tuning bundle** — Linux default is 1024 (128 on small hosts), which drops SYNs under coordinated reconnect bursts (post-censorship-blip waves) or Reality probe floods. Adding it to `/etc/sysctl.d/99-moav-net.conf` and to the installer's first-time bundle. Picked up on next `moav net apply`
+- **`moav net apply` prints a verification summary after applying** — calls `nt_status` at the end so the operator sees `✓ bbr active ✓ fq active ✓ rmem_max=32 MiB ...` immediately instead of having to run a second command to confirm the sysctl reload worked
+- **`moav doctor net` extended with packet-drop / PMTU / CGNAT / MTU checks** — reads `/proc/net/snmp` + `/proc/net/netstat` for TCP `ListenDrops` + `ListenOverflows` (SYN queue overflow → recommends raising `somaxconn`/`tcp_max_syn_backlog`) and UDP `RcvbufErrors` + `SndbufErrors` (Hysteria2/WireGuard buffer overflow → recommends raising `{r,w}mem_max`). Verifies `tcp_mtu_probing` is on (silent PMTU black-hole recovery). Detects CGNAT (100.64/10 on the default route — hard failure for inbound proxy traffic) and RFC1918 (NAT — warns with the `SERVER_IP` from `.env` for forwarding context). Prints egress + WireGuard MTU with the WG-1420 / Hysteria-1450-1472 recommendations. When the sysctl bundle isn't applied (or kernel doesn't support BBR), the extended checks skip silently rather than fail-flagging a fresh install
+
 ## [1.8.4] - 2026-06-05
 
 ### Added

--- a/docs/OPSEC.md
+++ b/docs/OPSEC.md
@@ -286,6 +286,7 @@ The installer offers a one-time kernel-level network tuning bundle aimed at the 
 | `net.core.{r,w}mem_default` | 1 MiB | Default UDP socket buffer (Hysteria2 / WireGuard) |
 | `net.core.netdev_max_backlog` | 16384 | Queue depth — UDP drops hurt circumvention more than TCP drops |
 | `net.core.somaxconn` | 8192 | Listen backlog for high-concurrency inbounds |
+| `net.ipv4.tcp_max_syn_backlog` | 8192 | SYN queue depth — prevents drops on coordinated reconnect bursts |
 | `net.ipv4.tcp_slow_start_after_idle` | 0 | Avoid restarting at congestion-window 1 on idle long-lived proxies |
 | `net.ipv4.tcp_mtu_probing` | 1 | Recover gracefully if a path silently has a smaller MTU |
 | `net.ipv4.tcp_notsent_lowat` | 131072 | Smaller send buffers to reduce HOL latency for interactive flows |
@@ -296,10 +297,17 @@ The installer offers a one-time kernel-level network tuning bundle aimed at the 
 
 ```bash
 moav net status   # show current vs recommended values
-moav net apply    # write 99-moav-net.conf + reload sysctl
+moav net apply    # write 99-moav-net.conf + reload sysctl + print verification
 moav net revert   # remove the file + reload sysctl (clean rollback)
-moav doctor net   # same check that runs in the full doctor sweep
+moav doctor net   # sysctl + packet drops + PMTU + CGNAT + per-interface MTU
 ```
+
+`moav doctor net` extends the sysctl check with:
+
+- **Packet drops**: reads `/proc/net/snmp` + `/proc/net/netstat` for TCP `ListenDrops` / `ListenOverflows` (SYN queue overflows) and UDP `RcvbufErrors` / `SndbufErrors` (Hysteria2/WireGuard buffer overflows). Counters are since-boot; non-zero values name the matching sysctl knob to raise.
+- **PMTU**: confirms `tcp_mtu_probing` is enabled so silent black-hole paths recover instead of stalling.
+- **CGNAT / NAT**: looks at the default route's source address. CGNAT (100.64/10) is reported as a hard failure for inbound proxy traffic; RFC1918 addresses are flagged as "behind NAT" with the public `SERVER_IP` from `.env` for context.
+- **MTU**: prints egress MTU + WireGuard `wg0` MTU (recommends 1420). Informational.
 
 **When it skips silently:** kernel <4.9 (no BBR), OpenVZ guests (shared kernel, no sysctl writes), or already-applied installs.
 

--- a/moav.sh
+++ b/moav.sh
@@ -2622,6 +2622,7 @@ net.core.wmem_default           = 1048576
 
 net.core.netdev_max_backlog     = 16384
 net.core.somaxconn              = 8192
+net.ipv4.tcp_max_syn_backlog    = 8192
 
 net.ipv4.tcp_slow_start_after_idle = 0
 net.ipv4.tcp_mtu_probing           = 1
@@ -2666,11 +2667,12 @@ nt_apply() {
 
     if $SUDO sysctl -p "$NT_CONF_PATH" >/dev/null 2>&1; then
         success "Network tuning applied → $NT_CONF_PATH (buffer max: $((bmax / 1048576)) MiB)"
-        return 0
     else
         warn "Wrote $NT_CONF_PATH but sysctl reload failed — will activate on next boot."
-        return 0
     fi
+    echo ""
+    nt_status
+    return 0
 }
 
 # Idempotent — returns 0 even if NT_CONF_PATH doesn't exist.
@@ -2747,6 +2749,15 @@ nt_status() {
         [[ "$applied" == "true" ]] && pass=false
     fi
 
+    local syn_backlog
+    syn_backlog=$(cat /proc/sys/net/ipv4/tcp_max_syn_backlog 2>/dev/null || echo 0)
+    if [[ "$syn_backlog" -ge 8192 ]]; then
+        echo -e "    ${GREEN}✓${NC} tcp_max_syn_backlog = $syn_backlog"
+    else
+        echo -e "    ${YELLOW}!${NC} tcp_max_syn_backlog = $syn_backlog (expected ≥ 8192)"
+        [[ "$applied" == "true" ]] && pass=false
+    fi
+
     if [[ "$applied" == "true" ]]; then
         $pass && return 0 || return 1
     else
@@ -2810,13 +2821,150 @@ DOCTOR_CHECKS=(
     "ports:Check required ports are available"
     "conflicts:Check for conflicting services (e.g. DNS tunnels on port 53)"
     "reality:Check Reality fallback targets resolve and are reachable"
-    "net:Check BBR / kernel network tuning is applied"
+    "net:Check BBR/sysctl tuning + packet drops + PMTU + CGNAT + MTU"
     "env:Compare .env with .env.example for missing vars"
     "updates:Check for MoaV updates"
 )
 
+# Read a key from /proc/net/snmp or /proc/net/netstat. Returns 0 if not found.
+nt_proc_counter() {
+    local proto="$1" key="$2"
+    local v=""
+    v=$(awk -v p="$proto:" -v k="$key" '
+        $1 == p {
+            if ($0 ~ /[A-Za-z]/ && header == "") { header = $0; next }
+            if (header != "") {
+                n = split(header, h, " "); split($0, v, " ")
+                for (i = 2; i <= n; i++) if (h[i] == k) { print v[i]; exit }
+                header = ""
+            }
+        }' /proc/net/snmp /proc/net/netstat 2>/dev/null | head -1)
+    echo "${v:-0}"
+}
+
+nt_check_drops() {
+    local pass=true
+    local listen_drops syn_overflow rcvbuf_err sndbuf_err retrans
+    listen_drops=$(nt_proc_counter "TcpExt" "ListenDrops")
+    syn_overflow=$(nt_proc_counter "TcpExt" "ListenOverflows")
+    rcvbuf_err=$(nt_proc_counter   "Udp"    "RcvbufErrors")
+    sndbuf_err=$(nt_proc_counter   "Udp"    "SndbufErrors")
+    retrans=$(nt_proc_counter      "Tcp"    "RetransSegs")
+
+    # Counters are since-boot. Operator-actionable thresholds — anything non-trivial.
+    local report=()
+    [[ "$listen_drops" -gt 0   ]] && report+=("TCP ListenDrops=$listen_drops (somaxconn / tcp_max_syn_backlog too small or SYN flood)")
+    [[ "$syn_overflow" -gt 0   ]] && report+=("TCP ListenOverflows=$syn_overflow (accept queue overflow)")
+    [[ "$rcvbuf_err"   -gt 100 ]] && report+=("UDP RcvbufErrors=$rcvbuf_err (raise rmem_max — affects Hysteria2/WG)")
+    [[ "$sndbuf_err"   -gt 100 ]] && report+=("UDP SndbufErrors=$sndbuf_err (raise wmem_max)")
+
+    if [[ ${#report[@]} -eq 0 ]]; then
+        echo -e "    ${GREEN}✓${NC} No notable packet drops (TCP retrans=$retrans since boot)"
+    else
+        local line
+        for line in "${report[@]}"; do
+            echo -e "    ${YELLOW}!${NC} $line"
+            pass=false
+        done
+    fi
+    $pass && return 0 || return 1
+}
+
+nt_check_pmtu() {
+    local probing
+    probing=$(cat /proc/sys/net/ipv4/tcp_mtu_probing 2>/dev/null || echo "?")
+    if [[ "$probing" == "1" || "$probing" == "2" ]]; then
+        echo -e "    ${GREEN}✓${NC} tcp_mtu_probing = $probing (PMTU black-hole recovery enabled)"
+        return 0
+    fi
+    echo -e "    ${YELLOW}!${NC} tcp_mtu_probing = $probing (PMTU black holes will silently stall TCP)"
+    echo -e "      ${DIM}Fix: moav net apply${NC}"
+    return 1
+}
+
+nt_check_cgnat() {
+    # Local IP on the default route. Empty → no route → upstream broken, not our problem here.
+    local local_ip iface
+    local_ip=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '/src/ {for(i=1;i<=NF;i++) if($i=="src") {print $(i+1); exit}}')
+    iface=$(ip -4 route get 1.1.1.1 2>/dev/null   | awk '/dev/ {for(i=1;i<=NF;i++) if($i=="dev") {print $(i+1); exit}}')
+    if [[ -z "$local_ip" ]]; then
+        echo -e "    ${DIM}○${NC} CGNAT/NAT check skipped (no default route detected)"
+        return 2
+    fi
+
+    local cgnat=false private=false
+    # CGNAT = 100.64.0.0/10
+    if [[ "$local_ip" =~ ^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\. ]]; then cgnat=true; fi
+    # RFC1918: 10/8, 172.16/12, 192.168/16
+    if [[ "$local_ip" =~ ^10\. ]] || \
+       [[ "$local_ip" =~ ^192\.168\. ]] || \
+       [[ "$local_ip" =~ ^172\.(1[6-9]|2[0-9]|3[01])\. ]]; then private=true; fi
+
+    local public_ip
+    public_ip=$(get_env_val "SERVER_IP" "$SCRIPT_DIR/.env" "")
+
+    if $cgnat; then
+        echo -e "    ${RED}✗${NC} Default route uses CGNAT address ($local_ip on $iface)"
+        echo -e "      ${DIM}Inbound proxy traffic from the public internet can't reach this host directly.${NC}"
+        [[ -n "$public_ip" ]] && echo -e "      ${DIM}SERVER_IP=$public_ip — verify port-forwarding upstream.${NC}"
+        return 1
+    fi
+    if $private; then
+        if [[ -n "$public_ip" && "$public_ip" != "$local_ip" ]]; then
+            echo -e "    ${YELLOW}!${NC} Server is behind NAT (local=$local_ip, public=$public_ip on $iface)"
+            echo -e "      ${DIM}Make sure ports are forwarded from $public_ip to $local_ip.${NC}"
+            return 1
+        fi
+        echo -e "    ${DIM}○${NC} Local address $local_ip is RFC1918 but SERVER_IP not set — can't tell if NAT'd"
+        return 2
+    fi
+    echo -e "    ${GREEN}✓${NC} Default route uses public address ($local_ip on $iface)"
+    return 0
+}
+
+nt_check_mtu() {
+    local enable_wg enable_hy2
+    enable_wg=$(get_env_val  "ENABLE_WIREGUARD" "$SCRIPT_DIR/.env" "true")
+    enable_hy2=$(get_env_val "ENABLE_HYSTERIA2" "$SCRIPT_DIR/.env" "true")
+
+    # Default-egress MTU.
+    local egress_mtu="?"
+    local egress_iface
+    egress_iface=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '/dev/ {for(i=1;i<=NF;i++) if($i=="dev") {print $(i+1); exit}}')
+    if [[ -n "$egress_iface" ]]; then
+        egress_mtu=$(ip link show "$egress_iface" 2>/dev/null | awk '/mtu/ {for(i=1;i<=NF;i++) if($i=="mtu") {print $(i+1); exit}}')
+    fi
+    echo -e "    ${DIM}○${NC} Egress MTU on ${egress_iface:-?}: ${egress_mtu:-?} (Hysteria2 best near 1450–1472, WireGuard 1420)"
+
+    if [[ "$enable_wg" == "true" ]]; then
+        if ip link show wg0 >/dev/null 2>&1; then
+            local wg_mtu
+            wg_mtu=$(ip link show wg0 2>/dev/null | awk '/mtu/ {for(i=1;i<=NF;i++) if($i=="mtu") {print $(i+1); exit}}')
+            if [[ "$wg_mtu" == "1420" ]]; then
+                echo -e "    ${GREEN}✓${NC} wg0 MTU = $wg_mtu (recommended)"
+            else
+                echo -e "    ${YELLOW}!${NC} wg0 MTU = $wg_mtu (recommend 1420 for IPv4-over-UDP overhead)"
+            fi
+        fi
+    fi
+}
+
 doctor_check_net() {
-    nt_status
+    local rc=0
+    nt_status || rc=$?
+    # rc=2 → bundle not applied or kernel unsupported. Skip extended checks.
+    [[ "$rc" -eq 2 ]] && return 2
+
+    local pass=true
+    [[ "$rc" -eq 1 ]] && pass=false
+    nt_check_pmtu  || pass=false
+    nt_check_drops || pass=false
+    # CGNAT returns 2 (unknown — no route or RFC1918 without SERVER_IP), don't fail on that
+    local cgnat=0; nt_check_cgnat || cgnat=$?
+    [[ "$cgnat" -eq 1 ]] && pass=false
+    nt_check_mtu   # informational only
+
+    $pass && return 0 || return 1
 }
 
 doctor_is_enabled() {

--- a/site/install.sh
+++ b/site/install.sh
@@ -582,6 +582,7 @@ net.core.wmem_default           = 1048576
 
 net.core.netdev_max_backlog     = 16384
 net.core.somaxconn              = 8192
+net.ipv4.tcp_max_syn_backlog    = 8192
 
 net.ipv4.tcp_slow_start_after_idle = 0
 net.ipv4.tcp_mtu_probing           = 1


### PR DESCRIPTION
Closes task #46. Three followups bundled, all opt-in via the existing `moav net apply` flow — no behavior change for operators who haven't applied the network tuning.

## 1. `tcp_max_syn_backlog = 8192` added to the bundle

Linux default is 1024 (128 on small hosts), which drops SYNs under coordinated reconnect bursts (post-censorship-blip waves) or Reality probe floods. One line in `nt_render_config` and the corresponding `site/install.sh` bundle. Picked up on next `moav net apply`. Checked by `nt_status`.

## 2. `moav net apply` prints a verification grid after applying

Calls `nt_status` at the end of `nt_apply`, so the operator sees the `✓ bbr active ✓ fq active ✓ rmem_max=32 MiB ...` summary immediately instead of running a second command to confirm the sysctl reload took. 6-line behavior change in `nt_apply`.

## 3. `moav doctor net` extended with packet-drop / PMTU / CGNAT / MTU checks

Four new helpers, called from `doctor_check_net` only when the sysctl bundle is applied (so fresh installs aren't fail-flagged):

| Helper | What it does | Failure means |
|---|---|---|
| `nt_check_drops` | Parses `/proc/net/snmp` + `/proc/net/netstat` for TCP `ListenDrops` + `ListenOverflows` and UDP `RcvbufErrors` + `SndbufErrors`. | Non-zero values → recommends raising the matching sysctl knob |
| `nt_check_pmtu` | Verifies `tcp_mtu_probing` is `1` or `2`. | Silent PMTU black-hole recovery is off — long-RTT WireGuard paths stall |
| `nt_check_cgnat` | Looks at the default route's source address. | CGNAT (`100.64/10`) → hard failure for inbound; RFC1918 → warns with `SERVER_IP` from `.env` for forwarding context |
| `nt_check_mtu` | Prints egress MTU + WireGuard `wg0` MTU. | Informational — flags `wg0` ≠ 1420 |

`doctor_check_net` returns 2 (skip) when `nt_status` returns 2 (bundle not applied OR kernel doesn't support BBR), so the regular `moav doctor` sweep doesn't report a fresh, un-tuned install as a failure.

## Verified

- `bash -n moav.sh site/install.sh` clean
- `nt_render_config` emits the new `tcp_max_syn_backlog` line
- `site/install.sh` bundle gets the same addition
- `nt_proc_counter` parses a realistic `/proc/net/snmp` fixture correctly:
  ```
  Tcp:RetransSegs  = 9 (PASS, expected 9)
  Udp:RcvbufErrors = 0 (PASS, expected 0)
  ```
- Helpers degrade gracefully on a host without `/proc` (macOS) — `tcp_mtu_probing = ?` reports cleanly without crashing

## Docs

- `docs/OPSEC.md` — `tcp_max_syn_backlog` row added to the sysctl table; "Commands" section gains the `moav doctor net` extended-check feature list.
- `CHANGELOG.md` — three bullets under `[Unreleased]` `### Added`.

## What this PR does NOT do

Per the v1.8.4 review of ChatGPT's tuning suggestions:

- **No `--safe / --recommended / --aggressive` profiles** — opinionated single bundle is the right balance
- **No 64/128 MiB UDP buffers** — overkill, wastes RAM on small VPSes
- **No `irqbalance` management** — userspace daemon, not in scope for a sysctl tuner
- **No RPS tuning** — negligible on virtio NICs (the VPS common case)
- **No `moav benchmark` with iperf3** — operationally heavy, doesn't fit doctor pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)