### PR TITLE
feat(anytls): add AnyTLS protocol (sing-box native)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ SERVER_IPV6=
 ENABLE_REALITY=true
 ENABLE_TROJAN=true
 ENABLE_HYSTERIA2=true
+# AnyTLS (sing-box native, defeats TLS-in-TLS fingerprinting). Opt-in: narrower
+# client support than Trojan/VLESS (Hiddify, sing-box SFA/SFI, NekoBox, mihomo,
+# Shadowrocket 2.2.65+). Reuses the Trojan TLS cert/domain. Refs: github.com/anytls/anytls-go
+ENABLE_ANYTLS=false
 # Shadowsocks-2022 (AEAD-2022, anti-active-probing). Compatible with NekoBox,
 # Hiddify, Streisand, sing-box clients via standard ss:// URI.
 # Refs: github.com/shayanb/MoaV/issues/93
@@ -317,6 +321,7 @@ MAHSANET_POOL=mahsa
 
 PORT_HTTPS=443       # Reality (VLESS) + Hysteria2 (UDP)
 PORT_TROJAN=8443     # Trojan fallback
+PORT_ANYTLS=8445     # AnyTLS (sing-box native, only if ENABLE_ANYTLS=true)
 PORT_WIREGUARD=51820 # WireGuard (UDP)
 PORT_WSTUNNEL=8080   # WebSocket tunnel for WireGuard
 PORT_DNS=53          # dns-router public port — all DNS tunnels share this (dnstt/Slipstream/MasterDNS/XDNS)

--- a/README-fa.md
+++ b/README-fa.md
@@ -149,6 +149,7 @@ moav help                 # نمایش تمام دستورات
 | Reality (VLESS) | 443/tcp | ★★★★★ | ★★★★☆ | ✅ | اصلی، قابل اعتمادترین |
 | Hysteria2 | 443/udp | ★★★★☆ | ★★★★★ | ✅ | سریع، کار می‌کند وقتی TCP محدود است |
 | Trojan | 8443/tcp | ★★★★☆ | ★★★★☆ | ✅ | پشتیبان، از دامنه شما استفاده می‌کند |
+| AnyTLS | 8445/tcp | ★★★★★ | ★★★★☆ | ⬜ | خنثی‌سازی اثرانگشت TLS-in-TLS، از دامنه شما استفاده می‌کند |
 | Shadowsocks-2022 | 8388/tcp+udp | ★★★★☆ | ★★★★☆ | ⬜ | AEAD-2022 ضد پروب فعال؛ سازگار با اپ Outline |
 | CDN (VLESS+WS) | 443 از Cloudflare | ★★★★★ | ★★★☆☆ | ✅ | وقتی IP سرور مسدود است |
 | TrustTunnel | 4443/tcp+udp | ★★★★★ | ★★★★☆ | ✅ | HTTP/2 و QUIC، شبیه HTTPS |
@@ -283,6 +284,7 @@ moav client connect user1 # اتصال به عنوان کاربر (پراکسی 
 | 443/tcp | TCP | Reality (VLESS) | بله |
 | 443/udp | UDP | Hysteria2 | بله |
 | 8443/tcp | TCP | Trojan | بله |
+| 8445/tcp | TCP | AnyTLS | بله |
 | 8388/tcp+udp | TCP+UDP | Shadowsocks-2022 | خیر |
 | 4443/tcp+udp | TCP+UDP | TrustTunnel | بله |
 | 2082/tcp | TCP | CDN WebSocket | بله (Cloudflare) |

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See the [Setup Guide](docs/SETUP.md) for complete instructions, the [CLI Referen
 | Reality (VLESS) | 443/tcp | ★★★★★ | ★★★★☆ | ✅ | Primary, most reliable |
 | Hysteria2 | 443/udp | ★★★★☆ | ★★★★★ | ✅ | Fast, works when TCP throttled |
 | Trojan | 8443/tcp | ★★★★☆ | ★★★★☆ | ✅ | Backup, uses your domain |
+| AnyTLS | 8445/tcp | ★★★★★ | ★★★★☆ | ⬜ | Defeats TLS-in-TLS fingerprinting, uses your domain |
 | Shadowsocks-2022 | 8388/tcp+udp | ★★★★☆ | ★★★★☆ | ⬜ | AEAD-2022 anti-probing; Outline-app compatible |
 | CDN (VLESS+WS) | 443 via Cloudflare | ★★★★★ | ★★★☆☆ | ✅ | When server IP is blocked |
 | TrustTunnel | 4443/tcp+udp | ★★★★★ | ★★★★☆ | ✅ | HTTP/2 & QUIC, looks like HTTPS |
@@ -252,6 +253,7 @@ See [docs/CLIENTS.md](docs/CLIENTS.md) for complete list and setup instructions.
 | 443/tcp | TCP | Reality (VLESS) | Yes |
 | 443/udp | UDP | Hysteria2 | Yes |
 | 8443/tcp | TCP | Trojan | Yes |
+| 8445/tcp | TCP | AnyTLS | Yes |
 | 8388/tcp+udp | TCP+UDP | Shadowsocks-2022 | No |
 | 4443/tcp+udp | TCP+UDP | TrustTunnel | Yes |
 | 2082/tcp | TCP | CDN WebSocket | Yes (Cloudflare) |

--- a/configs/sing-box/config.json.template
+++ b/configs/sing-box/config.json.template
@@ -66,6 +66,19 @@
       }
     },
     {
+      "type": "anytls",
+      "tag": "anytls-in",
+      "listen": "::",
+      "listen_port": ${PORT_ANYTLS},
+      "users": ${ANYTLS_USERS_JSON},
+      "tls": {
+        "enabled": true,
+        "server_name": "${DOMAIN}",
+        "certificate_path": "/certs/live/${DOMAIN}/fullchain.pem",
+        "key_path": "/certs/live/${DOMAIN}/privkey.pem"
+      }
+    },
+    {
       "type": "hysteria2",
       "tag": "hysteria2-in",
       "listen": "::",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     ports:
       - "${PORT_HTTPS:-443}:443/tcp"      # Reality (VLESS)
       - "${PORT_TROJAN:-8443}:8443/tcp"   # Trojan (backup)
+      - "${PORT_ANYTLS:-8445}:8445/tcp"   # AnyTLS (only if ENABLE_ANYTLS=true)
       - "${PORT_HYSTERIA:-443}:443/udp"   # Hysteria2 (QUIC)
       - "${PORT_CDN:-2082}:2082/tcp"      # CDN WebSocket (VLESS+WS)
       - "${PORT_SS:-8388}:${PORT_SS:-8388}/tcp"  # Shadowsocks-2022 (only if ENABLE_SS=true)
@@ -1251,6 +1252,8 @@ services:
       - REALITY_PRIVATE_KEY=${REALITY_PRIVATE_KEY:-}
       - ENABLE_REALITY=${ENABLE_REALITY:-true}
       - ENABLE_TROJAN=${ENABLE_TROJAN:-true}
+      - ENABLE_ANYTLS=${ENABLE_ANYTLS:-false}
+      - PORT_ANYTLS=${PORT_ANYTLS:-8445}
       - ENABLE_HYSTERIA2=${ENABLE_HYSTERIA2:-true}
       - ENABLE_WIREGUARD=${ENABLE_WIREGUARD:-true}
       - ENABLE_DNSTT=${ENABLE_DNSTT:-true}

--- a/dockerfiles/Dockerfile.client
+++ b/dockerfiles/Dockerfile.client
@@ -1,7 +1,7 @@
 # =============================================================================
 # MoaV Client - Multi-protocol client for testing and connecting
 # =============================================================================
-# Supports: Reality, Trojan, Hysteria2, XHTTP, WireGuard (via wstunnel),
+# Supports: Reality, Trojan, AnyTLS, Hysteria2, XHTTP, WireGuard (via wstunnel),
 #           AmneziaWG, dnstt, Slipstream, TrustTunnel, Tor/Snowflake
 #
 # Strategy: Download pre-built binaries with proper architecture detection

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -16,6 +16,7 @@ This guide explains how to connect to MoaV from various devices.
 - [WireGuard Setup](#wireguard-setup)
 - [AmneziaWG Setup](#amneziawg-setup)
 - [Hysteria2 Setup](#hysteria2-setup)
+- [AnyTLS Setup](#anytls-setup)
 - [CDN VLESS+WS Setup (When IP Blocked)](#cdn-vlessws-setup-when-ip-blocked)
 - [TrustTunnel Setup](#trusttunnel-setup)
 - [DNS Tunnel Setup (Last Resort)](#dns-tunnel-setup-last-resort)
@@ -36,6 +37,7 @@ This guide explains how to connect to MoaV from various devices.
 |----------|------|-------------|
 | [Reality (VLESS)](https://github.com/XTLS/REALITY) | 443/tcp | TLS camouflage, virtually undetectable |
 | [Trojan](https://trojan-gfw.github.io/trojan/) | 8443/tcp | HTTPS mimicry, battle-tested |
+| [AnyTLS](https://github.com/anytls/anytls-go) | 8445/tcp | Defeats TLS-in-TLS fingerprinting, very high stealth |
 | [Shadowsocks-2022](https://github.com/shadowsocks/shadowsocks-org/blob/main/docs/doc/sip022.md) | 8388/tcp+udp | AEAD-2022 anti-active-probing; same protocol Outline VPN uses |
 | [Hysteria2](https://v2.hysteria.network/) | 443/udp | QUIC-based, fast on lossy networks |
 | CDN (VLESS+WS) | 443 via Cloudflare | When server IP is blocked |
@@ -56,11 +58,11 @@ This guide explains how to connect to MoaV from various devices.
 
 | App | Protocols | Link |
 |-----|-----------|------|
-| [Shadowrocket](https://apps.apple.com/us/app/shadowrocket/id932747118) | VLESS, VMess, Trojan, Hysteria2, WireGuard | [App Store ($2.99)](https://apps.apple.com/us/app/shadowrocket/id932747118) |
+| [Shadowrocket](https://apps.apple.com/us/app/shadowrocket/id932747118) | VLESS, VMess, Trojan, Hysteria2, AnyTLS (2.2.65+), WireGuard | [App Store ($2.99)](https://apps.apple.com/us/app/shadowrocket/id932747118) |
 | [Streisand](https://apps.apple.com/us/app/streisand/id6450534064) | VLESS/Reality, VMess, Trojan, Hysteria2, WireGuard | [App Store (Free)](https://apps.apple.com/us/app/streisand/id6450534064) |
-| [Hiddify](https://apps.apple.com/us/app/hiddify-proxy-vpn/id6596777532) | VLESS, VMess, Hysteria2, Trojan, Reality, SSH | [App Store (Free)](https://apps.apple.com/us/app/hiddify-proxy-vpn/id6596777532) |
+| [Hiddify](https://apps.apple.com/us/app/hiddify-proxy-vpn/id6596777532) | VLESS, VMess, Hysteria2, Trojan, AnyTLS, Reality, SSH | [App Store (Free)](https://apps.apple.com/us/app/hiddify-proxy-vpn/id6596777532) |
 | [V2Box](https://apps.apple.com/ca/app/v2box-v2ray-client/id6446814690) | VLESS, VMess, Trojan, Hysteria2, Reality | [App Store](https://apps.apple.com/ca/app/v2box-v2ray-client/id6446814690) |
-| [sing-box](https://apps.apple.com/us/app/sing-box-vt/id6673731168) | VLESS, VMess, Trojan, Hysteria2, WireGuard | [App Store (Free)](https://apps.apple.com/us/app/sing-box-vt/id6673731168) |
+| [sing-box](https://apps.apple.com/us/app/sing-box-vt/id6673731168) | VLESS, VMess, Trojan, Hysteria2, AnyTLS, WireGuard | [App Store (Free)](https://apps.apple.com/us/app/sing-box-vt/id6673731168) |
 | [Loon](https://apps.apple.com/us/app/loon/id1373567447) | VLESS/Reality, Hysteria2, Trojan, WireGuard | [App Store](https://apps.apple.com/us/app/loon/id1373567447) |
 | [Pharos Pro](https://apps.apple.com/us/app/pharos-pro/id1456610173) | VLESS, Hysteria2, Trojan, TUIC | [App Store ($2.99)](https://apps.apple.com/us/app/pharos-pro/id1456610173) |
 | [Onion Browser](https://apps.apple.com/us/app/onion-browser/id519296448) | Tor | [App Store (Free)](https://apps.apple.com/us/app/onion-browser/id519296448) |
@@ -74,10 +76,10 @@ This guide explains how to connect to MoaV from various devices.
 | App | Protocols | Link |
 |-----|-----------|------|
 | [v2rayNG](https://github.com/2dust/v2rayNG) | VLESS, VMess, Trojan, Shadowsocks | [GitHub](https://github.com/2dust/v2rayNG/releases) |
-| [Hiddify](https://hiddify.com/) | VLESS, VMess, Hysteria2, Trojan, Reality, SSH | [GitHub](https://github.com/hiddify/hiddify-app/releases) |
-| [NekoBox](https://github.com/MatsuriDayo/NekoBoxForAndroid) | VLESS, VMess, Trojan, Hysteria2 (sing-box) | [GitHub](https://github.com/MatsuriDayo/NekoBoxForAndroid/releases) |
+| [Hiddify](https://hiddify.com/) | VLESS, VMess, Hysteria2, Trojan, AnyTLS, Reality, SSH | [GitHub](https://github.com/hiddify/hiddify-app/releases) |
+| [NekoBox](https://github.com/MatsuriDayo/NekoBoxForAndroid) | VLESS, VMess, Trojan, Hysteria2, AnyTLS (sing-box) | [GitHub](https://github.com/MatsuriDayo/NekoBoxForAndroid/releases) |
 | [V2Box](https://play.google.com/store/apps/details?id=dev.hexasoftware.v2box) | VLESS, VMess, Trojan, Hysteria2, Reality | [Play Store](https://play.google.com/store/apps/details?id=dev.hexasoftware.v2box) |
-| [sing-box](https://github.com/SagerNet/sing-box) | VLESS, VMess, Trojan, Hysteria2, WireGuard | [F-Droid](https://f-droid.org/packages/io.nekohasekai.sfa/) / [GitHub](https://github.com/SagerNet/sing-box/releases) |
+| [sing-box](https://github.com/SagerNet/sing-box) | VLESS, VMess, Trojan, Hysteria2, AnyTLS, WireGuard | [F-Droid](https://f-droid.org/packages/io.nekohasekai.sfa/) / [GitHub](https://github.com/SagerNet/sing-box/releases) |
 | [HTTP Injector](https://play.google.com/store/apps/details?id=com.evozi.injector) | VLESS, Hysteria, DNS Tunnel, WireGuard, SSH | [Play Store](https://play.google.com/store/apps/details?id=com.evozi.injector) |
 | [Clash Meta](https://github.com/MetaCubeX/ClashMetaForAndroid) | VLESS, VMess, Hysteria2, Trojan | [GitHub](https://github.com/MetaCubeX/ClashMetaForAndroid/releases) |
 | [Tor Browser](https://www.torproject.org/download/) | Tor | [Play Store](https://play.google.com/store/apps/details?id=org.torproject.torbrowser) / [Official](https://www.torproject.org/download/) |
@@ -91,9 +93,9 @@ This guide explains how to connect to MoaV from various devices.
 | App | Protocols | Link |
 |-----|-----------|------|
 | [v2rayN](https://github.com/2dust/v2rayN) | VLESS, VMess, Trojan, Hysteria2, TUIC | [GitHub](https://github.com/2dust/v2rayN/releases) |
-| [Hiddify](https://hiddify.com/) | VLESS, VMess, Hysteria2, Trojan, Reality | [GitHub](https://github.com/hiddify/hiddify-app/releases) |
-| [NekoRay](https://github.com/MatsuriDayo/nekoray) | VLESS, VMess, Trojan, Hysteria2 (sing-box) | [GitHub](https://github.com/MatsuriDayo/nekoray/releases) ¹ |
-| [Mihomo Party](https://github.com/mihomo-party-org/mihomo-party) | VLESS, VMess, Hysteria2, Trojan | [GitHub](https://github.com/mihomo-party-org/mihomo-party/releases) |
+| [Hiddify](https://hiddify.com/) | VLESS, VMess, Hysteria2, Trojan, AnyTLS, Reality | [GitHub](https://github.com/hiddify/hiddify-app/releases) |
+| [NekoRay](https://github.com/MatsuriDayo/nekoray) | VLESS, VMess, Trojan, Hysteria2, AnyTLS (sing-box) | [GitHub](https://github.com/MatsuriDayo/nekoray/releases) ¹ |
+| [Mihomo Party](https://github.com/mihomo-party-org/mihomo-party) | VLESS, VMess, Hysteria2, Trojan, AnyTLS | [GitHub](https://github.com/mihomo-party-org/mihomo-party/releases) |
 | [Clash Verge](https://github.com/clash-verge-rev/clash-verge-rev) | VLESS, VMess, Hysteria2, Trojan | [GitHub](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
 | [Tor Browser](https://www.torproject.org/download/) | Tor | [Official](https://www.torproject.org/download/) |
 | [Psiphon](https://psiphon.ca/) | Psiphon | [Official](https://psiphon.ca/en/download.html) |
@@ -107,10 +109,10 @@ This guide explains how to connect to MoaV from various devices.
 |-----|-----------|------|
 | [Streisand](https://apps.apple.com/us/app/streisand/id6450534064) | VLESS/Reality, VMess, Trojan, Hysteria2, WireGuard | [App Store (Free)](https://apps.apple.com/us/app/streisand/id6450534064) |
 | [v2rayN](https://github.com/2dust/v2rayN) | VLESS, VMess, Trojan, Hysteria2 | [GitHub](https://github.com/2dust/v2rayN/releases) |
-| [Hiddify](https://hiddify.com/) | VLESS, VMess, Hysteria2, Trojan, Reality | [GitHub](https://github.com/hiddify/hiddify-app/releases) |
-| [NekoRay](https://github.com/MatsuriDayo/nekoray) | VLESS, VMess, Trojan, Hysteria2 (sing-box) | [GitHub](https://github.com/MatsuriDayo/nekoray/releases) ¹ |
+| [Hiddify](https://hiddify.com/) | VLESS, VMess, Hysteria2, Trojan, AnyTLS, Reality | [GitHub](https://github.com/hiddify/hiddify-app/releases) |
+| [NekoRay](https://github.com/MatsuriDayo/nekoray) | VLESS, VMess, Trojan, Hysteria2, AnyTLS (sing-box) | [GitHub](https://github.com/MatsuriDayo/nekoray/releases) ¹ |
 | [Clash Verge](https://github.com/clash-verge-rev/clash-verge-rev) | VLESS, VMess, Hysteria2, Trojan | [GitHub](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
-| [sing-box](https://sing-box.sagernet.org/) | VLESS, VMess, Trojan, Hysteria2, WireGuard | [Homebrew](https://formulae.brew.sh/formula/sing-box) / [GitHub](https://github.com/SagerNet/sing-box) |
+| [sing-box](https://sing-box.sagernet.org/) | VLESS, VMess, Trojan, Hysteria2, AnyTLS, WireGuard | [Homebrew](https://formulae.brew.sh/formula/sing-box) / [GitHub](https://github.com/SagerNet/sing-box) |
 | [Tor Browser](https://www.torproject.org/download/) | Tor | [Official](https://www.torproject.org/download/) |
 | [Psiphon](https://psiphon.ca/) | Psiphon | [App Store (Apple Silicon)](https://apps.apple.com/us/app/psiphon/id1276263909) |
 | [WireGuard](https://www.wireguard.com/) | WireGuard | [App Store](https://apps.apple.com/us/app/wireguard/id1451685025) |
@@ -121,11 +123,11 @@ This guide explains how to connect to MoaV from various devices.
 
 | App | Protocols | Link |
 |-----|-----------|------|
-| [Hiddify](https://hiddify.com/) | VLESS, VMess, Hysteria2, Trojan, Reality | [GitHub](https://github.com/hiddify/hiddify-app/releases) |
+| [Hiddify](https://hiddify.com/) | VLESS, VMess, Hysteria2, Trojan, AnyTLS, Reality | [GitHub](https://github.com/hiddify/hiddify-app/releases) |
 | [v2rayN](https://github.com/2dust/v2rayN) | VLESS, VMess, Trojan, Hysteria2 | [GitHub](https://github.com/2dust/v2rayN/releases) |
-| [sing-box](https://sing-box.sagernet.org/) | VLESS, VMess, Trojan, Hysteria2, WireGuard, DNS | [GitHub](https://github.com/SagerNet/sing-box) |
+| [sing-box](https://sing-box.sagernet.org/) | VLESS, VMess, Trojan, Hysteria2, AnyTLS, WireGuard, DNS | [GitHub](https://github.com/SagerNet/sing-box) |
 | [Clash Verge](https://github.com/clash-verge-rev/clash-verge-rev) | VLESS, VMess, Hysteria2, Trojan | [GitHub](https://github.com/clash-verge-rev/clash-verge-rev/releases) |
-| [Mihomo Party](https://github.com/mihomo-party-org/mihomo-party) | VLESS, VMess, Hysteria2, Trojan | [GitHub](https://github.com/mihomo-party-org/mihomo-party/releases) |
+| [Mihomo Party](https://github.com/mihomo-party-org/mihomo-party) | VLESS, VMess, Hysteria2, Trojan, AnyTLS | [GitHub](https://github.com/mihomo-party-org/mihomo-party/releases) |
 | [Tor Browser](https://www.torproject.org/download/) | Tor | [Official](https://www.torproject.org/download/) |
 | [WireGuard](https://www.wireguard.com/) | WireGuard | [Official](https://www.wireguard.com/install/) |
 | [AmneziaWG](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) | AmneziaWG | `awg-quick` CLI (awg-tools) |
@@ -533,6 +535,58 @@ This creates a local proxy on:
 - HTTP: `127.0.0.1:8080`
 
 Configure your browser/apps to use this proxy.
+
+---
+
+## AnyTLS Setup
+
+AnyTLS is a password-authenticated TLS proxy that defeats **TLS-in-TLS fingerprinting** for very high stealth. It runs on the same sing-box engine as Trojan and reuses your domain's TLS certificate. It is **opt-in** (enabled with `ENABLE_ANYTLS=true` on the server) and uses the same per-user password as your Trojan/Hysteria2 entries.
+
+**Your config file:** `anytls.txt`
+
+**Important:** AnyTLS is a newer protocol with **narrower client support** than VLESS/Trojan. Use a recent build of one of these apps:
+
+- **Hiddify** (iOS, Android, macOS, Windows)
+- **sing-box** (SFA on Android, SFI on iOS, CLI on desktop)
+- **NekoBox** (Android) / **NekoRay** (desktop)
+- **Mihomo Party** (macOS, Windows)
+- **Shadowrocket** 2.2.65 or newer (iOS)
+
+Clients without AnyTLS support (e.g., v2rayNG, Streisand, V2Box, Clash Verge) will fail to import the link — switch to one of the apps above.
+
+### Import the link
+
+The `anytls.txt` link works in any of the supported apps:
+
+1. Copy the link from `anytls.txt`
+2. Import into your client app (paste from clipboard, or scan `anytls-qr.png` if present)
+3. Connect
+
+**Link format:**
+```
+anytls://password@yourdomain.com:8445?sni=yourdomain.com&insecure=0#MoaV-AnyTLS-username
+```
+
+### iOS (Shadowrocket 2.2.65+ / Hiddify)
+
+1. Open Shadowrocket or Hiddify
+2. Tap the scanner icon → scan `anytls-qr.png`, or paste the link from `anytls.txt`
+3. Toggle ON to connect
+
+### Android (NekoBox / Hiddify / sing-box)
+
+1. Open NekoBox, Hiddify, or sing-box (SFA)
+2. Tap "+" → "Import from clipboard"
+3. Paste the link from `anytls.txt`
+4. Connect
+
+### Desktop (NekoRay / Mihomo Party / sing-box)
+
+1. Open NekoRay, Mihomo Party, or the sing-box CLI
+2. Import the link from `anytls.txt`
+3. Connect
+
+**Note:** AnyTLS requires a domain (TLS) and shares the Trojan certificate. If import fails, confirm your client actually supports AnyTLS (see the list above) and is up to date.
 
 ---
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -39,7 +39,7 @@ Complete guide to deploy MoaV on a VPS or home server.
 - Public IPv6 address (optional, see [IPv6 Support](#ipv6-support))
 
 **Domain (Optional but Recommended):**
-- Required for: Reality, Trojan, Hysteria2, TrustTunnel, CDN mode, DNS tunnels (dnstt, Slipstream, XDNS)
+- Required for: Reality, Trojan, AnyTLS, Hysteria2, TrustTunnel, CDN mode, DNS tunnels (dnstt, Slipstream, XDNS)
 - Not required for: Reality, WireGuard, AmneziaWG, Telegram MTProxy, Admin dashboard, Conduit, Snowflake
 - See [Domainless Mode](#domainless-mode) if you don't have a domain
 
@@ -50,6 +50,7 @@ Complete guide to deploy MoaV on a VPS or home server.
 | 443/tcp | TCP | Reality (VLESS) | Yes |
 | 443/udp | UDP | Hysteria2 | Yes |
 | 8443/tcp | TCP | Trojan | Yes |
+| 8445/tcp | TCP | AnyTLS | Yes |
 | 8388/tcp+udp | TCP+UDP | Shadowsocks-2022 | No |
 | 4443/tcp+udp | TCP+UDP | TrustTunnel | Yes |
 | 2082/tcp | TCP | CDN WebSocket | Yes (Cloudflare) or No (CloudFront) |
@@ -267,6 +268,7 @@ See [CLI Reference → Profiles](CLI.md#profiles) for the full profile/service/`
 ufw allow 443/tcp    # Reality
 ufw allow 443/udp    # Hysteria2
 ufw allow 8443/tcp   # Trojan
+ufw allow 8445/tcp   # AnyTLS
 ufw allow 8388       # Shadowsocks-2022
 
 # TrustTunnel
@@ -317,6 +319,7 @@ ls outputs/bundles/
 - `README.html` - User instructions (English + Farsi)
 - `reality.txt` - Reality share link + QR code
 - `trojan.txt` - Trojan share link
+- `anytls.txt` - AnyTLS share link (if `ENABLE_ANYTLS=true`)
 - `shadowsocks.txt` / `shadowsocks-qr.png` - Shadowsocks-2022 `ss://` URI + QR
 - `hysteria2.txt` - Hysteria2 share link
 - `cdn-vless.txt` - CDN share link (if CDN_DOMAIN set)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -49,6 +49,7 @@ If `moav doctor` identifies the issue, follow its hints. If not, continue below.
   - [sing-box crashes](#sing-box-crashes)
   - [WireGuard connected but no traffic](#wireguard-connected-but-no-traffic)
   - [Hysteria2 not working](#hysteria2-not-working)
+  - [AnyTLS not connecting](#anytls-not-connecting)
   - [TrustTunnel not connecting](#trusttunnel-not-connecting)
   - [AmneziaWG not connecting](#amneziawg-not-connecting)
   - [CDN VLESS+WS not working](#cdn-vlessws-not-working)
@@ -612,6 +613,41 @@ docker compose logs sing-box | grep -i hysteria
 # Test UDP connectivity (from another machine)
 nc -vuz YOUR_SERVER_IP 443
 ```
+
+### AnyTLS not connecting
+
+AnyTLS runs inside the existing **sing-box** container on **TCP port 8445** and shares the Trojan TLS certificate for your `DOMAIN`. It is opt-in — make sure `ENABLE_ANYTLS=true` is set in `.env` and that you have re-run `moav restart sing-box` (or `moav bootstrap`).
+
+**Check the container is running:**
+```bash
+docker compose ps sing-box
+```
+
+**Check the logs for the AnyTLS inbound:**
+```bash
+docker compose logs sing-box | grep -i anytls
+# Look for the "anytls-in" inbound starting without errors
+```
+
+**Common issues:**
+
+1. **Port not open:**
+   ```bash
+   ufw allow 8445/tcp
+   ```
+   Verify from another machine: `nc -vz YOUR_SERVER_IP 8445`
+
+2. **Certificate issue:**
+   - AnyTLS uses the same Let's Encrypt certificate as Trojan (for your `DOMAIN`)
+   - If the cert is missing or expired, see [Certificate issues](#certificate-issues) and re-run `moav bootstrap`
+
+3. **Client config error:**
+   - Verify the password matches `anytls.txt` in the user bundle (same password as Trojan/Hysteria2)
+   - Confirm the link points to your domain on port 8445 with `sni=<DOMAIN>` and `insecure=0`
+
+4. **Client does not support AnyTLS (most common):**
+   - AnyTLS has narrower client support than VLESS/Trojan. Use a recent build of **Hiddify**, **sing-box (SFA/SFI)**, **NekoBox/NekoRay**, **Mihomo Party**, or **Shadowrocket 2.2.65+**
+   - Clients such as v2rayNG, Streisand, V2Box, and Clash Verge do **not** support AnyTLS and will fail to import the link — switch to a supported client or use another protocol (Reality, Trojan, Hysteria2)
 
 ### TrustTunnel not connecting
 

--- a/docs/client-guide-template.html
+++ b/docs/client-guide-template.html
@@ -622,6 +622,7 @@
                 <li><a href="#en" onclick="scrollToSection('reality-en')">1. Reality (VLESS) <span class="toc-badge badge-primary">Primary</span></a></li>
                 <li><a href="#en" onclick="scrollToSection('hysteria2-en')">2. Hysteria2 <span class="toc-badge badge-secondary">Fast</span></a></li>
                 <li><a href="#en" onclick="scrollToSection('trojan-en')">3. Trojan <span class="toc-badge badge-secondary">Backup</span></a></li>
+                <li><a href="#en" onclick="scrollToSection('anytls-en')">3c. AnyTLS <span class="toc-badge badge-secondary">Anti-Fingerprint</span></a></li>
                 <li><a href="#en" onclick="scrollToSection('shadowsocks-en')">3b. Shadowsocks-2022</a></li>
                 <li><a href="#en" onclick="scrollToSection('cdn-en')">4. CDN VLESS+WS <span class="toc-badge badge-secondary">IP Blocked?</span></a></li>
                 <li><a href="#en" onclick="scrollToSection('xhttp-en')">4b. XHTTP <span class="toc-badge badge-secondary">Xray-core</span></a></li>
@@ -777,6 +778,41 @@
                     <p>Enable <strong>TLS Fragment</strong> to bypass DPI, and <strong>MUX</strong> to multiplex connections (fewer handshakes, harder to fingerprint).</p>
                     <p style="margin-top: 6px;"><strong>Hiddify:</strong> Settings → Config Options → TLS Fragment (Size: <code>10-100</code>, Sleep: <code>10-50</code>) and MUX (Protocol: <code>h2mux</code>, Max Connections: <code>2</code>, Padding: On)</p>
                     <p><strong>v2rayNG:</strong> Settings → TLS Fragment (Length: <code>50-200</code>, Interval: <code>10-50</code>) and MUX (Concurrency: <code>2-4</code>)</p>
+                </div>
+            </div>
+        </details>
+
+        <!-- AnyTLS -->
+        <details class="protocol-section" id="anytls-en">
+            <summary class="protocol-header">
+                <div class="protocol-title">
+                    <h2>3c. AnyTLS</h2>
+                    <span class="protocol-badge badge-secondary">Anti-Fingerprint</span>
+                </div>
+                <span class="protocol-port">Port 8445/tcp</span>
+            </summary>
+            <div class="protocol-content">
+                <p class="protocol-desc">A sing-box-native protocol that reuses real TLS on the server domain with password authentication. Its padding scheme defeats <strong>TLS-in-TLS fingerprinting</strong>, giving higher stealth than Trojan.</p>
+                <div class="extra-section" style="margin-top: 16px; border: 1px solid var(--border-color); padding: 12px; border-radius: 6px;">
+                    <h4>When to use</h4>
+                    <p>Choose AnyTLS when you want <strong>stronger anti-fingerprinting than Trojan</strong> and your client supports it. Client support is narrower than VLESS/Trojan — use one of the apps listed below.</p>
+                </div>
+                <div class="qr-section">
+                    <div class="qr-code">
+                        <img src="data:image/png;base64,{{QR_ANYTLS}}" alt="AnyTLS QR Code" onerror="this.parentElement.classList.add('qr-missing'); this.parentElement.innerHTML='QR not available<br>Use config below';">
+                    </div>
+                    <div class="qr-instructions">
+                        <h4>How to connect:</h4>
+                        <ol>
+                            <li>Install <strong>Hiddify</strong>, <strong>sing-box (SFA/SFI)</strong>, <strong>NekoBox/NekoRay</strong>, <strong>Mihomo Party</strong>, or <strong>Shadowrocket 2.2.65+</strong></li>
+                            <li>Scan the QR code or copy the config link</li>
+                            <li>Enable the connection</li>
+                        </ol>
+                    </div>
+                </div>
+                <div class="config-box">
+                    <h4>Config Link (click to copy)</h4>
+                    <div class="config-value multiline">{{CONFIG_ANYTLS}}</div>
                 </div>
             </div>
         </details>
@@ -1353,7 +1389,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://apps.apple.com/us/app/hiddify-proxy-vpn/id6596777532" target="_blank">Hiddify</a> (Free)</td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, AnyTLS</td>
                     </tr>
                     <tr>
                         <td><a href="https://apps.apple.com/ca/app/v2box-v2ray-client/id6446814690" target="_blank">V2Box</a> (Free)</td>
@@ -1377,7 +1413,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://apps.apple.com/us/app/shadowrocket/id932747118" target="_blank">Shadowrocket</a> ($2.99)</td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, WireGuard</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, WireGuard, AnyTLS</td>
                     </tr>
                     <tr>
                         <td rowspan="9"><span class="platform-icon">🤖</span>Android</td>
@@ -1394,7 +1430,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://github.com/hiddify/hiddify-app/releases" target="_blank">Hiddify</a></td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, AnyTLS</td>
                     </tr>
                     <tr>
                         <td><a href="https://play.google.com/store/apps/details?id=com.wireguard.android" target="_blank">WireGuard</a></td>
@@ -1427,7 +1463,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://github.com/hiddify/hiddify-app/releases" target="_blank">Hiddify</a></td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, AnyTLS</td>
                     </tr>
                     <tr>
                         <td><a href="https://www.wireguard.com/install/" target="_blank">WireGuard</a></td>
@@ -1452,7 +1488,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://github.com/hiddify/hiddify-app/releases" target="_blank">Hiddify</a></td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, AnyTLS</td>
                     </tr>
                     <tr>
                         <td><a href="https://github.com/clash-verge-rev/clash-verge-rev/releases" target="_blank">Clash Verge</a></td>
@@ -1477,7 +1513,7 @@
                     <tr>
                         <td rowspan="5"><span class="platform-icon">🐧</span>Linux</td>
                         <td><a href="https://github.com/hiddify/hiddify-app/releases" target="_blank">Hiddify</a></td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, AnyTLS</td>
                     </tr>
                     <tr>
                         <td><a href="https://www.wireguard.com/install/" target="_blank">WireGuard</a></td>
@@ -1523,6 +1559,7 @@
                 <li><a href="#fa" onclick="scrollToSection('reality-fa')">۱. Reality (VLESS) <span class="toc-badge badge-primary">اصلی</span></a></li>
                 <li><a href="#fa" onclick="scrollToSection('hysteria2-fa')">۲. Hysteria2 <span class="toc-badge badge-secondary">سریع</span></a></li>
                 <li><a href="#fa" onclick="scrollToSection('trojan-fa')">۳. Trojan <span class="toc-badge badge-secondary">پشتیبان</span></a></li>
+                <li><a href="#fa" onclick="scrollToSection('anytls-fa')">۳پ. AnyTLS <span class="toc-badge badge-secondary">ضد اثرانگشت</span></a></li>
                 <li><a href="#fa" onclick="scrollToSection('shadowsocks-fa')">۳ب. Shadowsocks-2022</a></li>
                 <li><a href="#fa" onclick="scrollToSection('cdn-fa')">۴. CDN VLESS+WS <span class="toc-badge badge-secondary">IP مسدود؟</span></a></li>
                 <li><a href="#fa" onclick="scrollToSection('xhttp-fa')">۴ب. XHTTP <span class="toc-badge badge-secondary">Xray-core</span></a></li>
@@ -1678,6 +1715,41 @@
                     <p><strong>TLS Fragment</strong> را برای عبور از DPI و <strong>MUX</strong> را برای ادغام اتصالات فعال کنید (Handshake کمتر، شناسایی سخت‌تر).</p>
                     <p style="margin-top: 6px;"><strong>Hiddify:</strong> Settings → Config Options → TLS Fragment (Size: <code>10-100</code>، Sleep: <code>10-50</code>) و MUX (Protocol: <code>h2mux</code>، Max Connections: <code>2</code>، Padding: روشن)</p>
                     <p><strong>v2rayNG:</strong> Settings → TLS Fragment (Length: <code>50-200</code>، Interval: <code>10-50</code>) و MUX (Concurrency: <code>2-4</code>)</p>
+                </div>
+            </div>
+        </details>
+
+        <!-- AnyTLS -->
+        <details class="protocol-section" id="anytls-fa">
+            <summary class="protocol-header">
+                <div class="protocol-title">
+                    <h2>۳پ. AnyTLS</h2>
+                    <span class="protocol-badge badge-secondary">ضد اثرانگشت</span>
+                </div>
+                <span class="protocol-port">پورت 8445/tcp</span>
+            </summary>
+            <div class="protocol-content">
+                <p class="protocol-desc">یک پروتکل بومی sing-box که از TLS واقعی روی دامنه سرور با احراز هویت رمز عبور استفاده می‌کند. طرح padding آن <strong>اثرانگشت TLS-in-TLS</strong> را خنثی می‌کند و مخفی‌کاری بالاتری نسبت به Trojan دارد.</p>
+                <div class="extra-section" style="margin-top: 16px; border: 1px solid var(--border-color); padding: 12px; border-radius: 6px;">
+                    <h4>چه زمانی استفاده شود</h4>
+                    <p>زمانی AnyTLS را انتخاب کنید که به <strong>ضد اثرانگشت قوی‌تر از Trojan</strong> نیاز دارید و کلاینت شما از آن پشتیبانی می‌کند. پشتیبانی کلاینت‌ها محدودتر از VLESS/Trojan است — از یکی از اپ‌های فهرست‌شده زیر استفاده کنید.</p>
+                </div>
+                <div class="qr-section">
+                    <div class="qr-code">
+                        <img src="data:image/png;base64,{{QR_ANYTLS}}" alt="QR Code AnyTLS" onerror="this.parentElement.classList.add('qr-missing'); this.parentElement.innerHTML='QR در دسترس نیست<br>از لینک زیر استفاده کنید';">
+                    </div>
+                    <div class="qr-instructions">
+                        <h4>نحوه اتصال:</h4>
+                        <ol>
+                            <li><strong>Hiddify</strong>، <strong>sing-box (SFA/SFI)</strong>، <strong>NekoBox/NekoRay</strong>، <strong>Mihomo Party</strong> یا <strong>Shadowrocket 2.2.65+</strong> را نصب کنید</li>
+                            <li>کد QR را اسکن کنید یا لینک کانفیگ را کپی کنید</li>
+                            <li>اتصال را فعال کنید</li>
+                        </ol>
+                    </div>
+                </div>
+                <div class="config-box">
+                    <h4>لینک کانفیگ (کلیک برای کپی)</h4>
+                    <div class="config-value multiline">{{CONFIG_ANYTLS}}</div>
                 </div>
             </div>
         </details>
@@ -2243,7 +2315,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://apps.apple.com/us/app/hiddify-proxy-vpn/id6596777532" target="_blank">Hiddify</a></td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, AnyTLS</td>
                     </tr>
                     <tr>
                         <td><a href="https://apps.apple.com/us/app/wireguard/id1441195209" target="_blank">WireGuard</a></td>
@@ -2263,7 +2335,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://apps.apple.com/us/app/shadowrocket/id932747118" target="_blank">Shadowrocket</a></td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, WireGuard</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, WireGuard, AnyTLS</td>
                     </tr>
                     <tr>
                         <td rowspan="8"><span class="platform-icon">🤖</span>Android</td>
@@ -2280,7 +2352,7 @@
                     </tr>
                     <tr>
                         <td><a href="https://github.com/hiddify/hiddify-app/releases" target="_blank">Hiddify</a></td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, AnyTLS</td>
                     </tr>
                     <tr>
                         <td><a href="https://play.google.com/store/apps/details?id=com.wireguard.android" target="_blank">WireGuard</a></td>
@@ -2326,7 +2398,7 @@
                     <tr>
                         <td rowspan="6"><span class="platform-icon">🍎</span>macOS</td>
                         <td><a href="https://github.com/hiddify/hiddify-app/releases" target="_blank">Hiddify</a></td>
-                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP</td>
+                        <td class="protocols">Reality, Trojan, Hysteria2, XHTTP, AnyTLS</td>
                     </tr>
                     <tr>
                         <td><a href="https://apps.apple.com/us/app/streisand/id6450534064" target="_blank">Streisand</a></td>

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -8,6 +8,7 @@ MoaV deploys 16+ protocols, each with different stealth characteristics, speed p
 |----------|------|---------|-------|-----------------|
 | [Reality (VLESS)](#reality-vless) | 443/tcp | Very High | High | No |
 | [Trojan](#trojan) | 8443/tcp | High | High | Yes |
+| [AnyTLS](#anytls) | 8445/tcp | Very High | High | Yes |
 | [Hysteria2](#hysteria2) | 443/udp | High | Very High | Yes |
 | [CDN (VLESS+WS)](#cdn-vlessws) | 443 via CDN | Very High | Medium | Yes (Cloudflare) |
 | [TrustTunnel](#trusttunnel) | 4443/tcp+udp | Very High | High | Yes |
@@ -42,6 +43,15 @@ Password-authenticated TLS proxy. Traffic looks like normal HTTPS. Uses your dom
 - **Port:** 8443/tcp
 - **Engine:** [sing-box](https://github.com/SagerNet/sing-box)
 - **Clients:** Streisand, Hiddify, v2rayNG, v2rayN, Shadowrocket
+
+### AnyTLS
+
+Password-authenticated TLS proxy designed to defeat **TLS-in-TLS fingerprinting**. By varying record sizes and padding, AnyTLS removes the tell-tale TLS-inside-TLS pattern that DPI uses to detect TLS-tunneling proxies, giving it very high stealth. Reuses the same sing-box engine, the Trojan TLS certificate, and your server domain.
+
+- **Port:** 8445/tcp
+- **Engine:** [sing-box](https://github.com/SagerNet/sing-box) (1.13.x)
+- **Clients:** Hiddify, sing-box (SFA/SFI), NekoBox/NekoRay, Mihomo Party, Shadowrocket 2.2.65+
+- **Note:** Opt-in — enable with `ENABLE_ANYTLS=true`. Requires a domain (TLS). Client support is narrower than VLESS/Trojan; older or Clash-only clients (v2rayNG, Streisand, V2Box, Clash Verge) do **not** support AnyTLS.
 
 ### Hysteria2
 

--- a/moav.sh
+++ b/moav.sh
@@ -784,7 +784,7 @@ check_prerequisites() {
                     warn "No domain provided!"
                     echo ""
                     echo -e "  ${YELLOW}Services that require a domain (will be disabled):${NC}"
-                    echo "    • Trojan, Hysteria2, CDN VLESS (need TLS certificates)"
+                    echo "    • Trojan, AnyTLS, Hysteria2, CDN VLESS (need TLS certificates)"
                     echo "    • TrustTunnel"
                     echo "    • DNS tunnels (dnstt, Slipstream, MasterDNS, XDNS)"
                     echo ""
@@ -807,7 +807,7 @@ check_prerequisites() {
                         # 41-46. XDNS is added here so dns-router (in the dnstunnel
                         # profile) doesn't fight systemd-resolved for port 53 with
                         # nothing to route; direct-mode XDNS can be re-enabled manually.
-                        for var in ENABLE_TROJAN ENABLE_HYSTERIA2 ENABLE_DNSTT ENABLE_SLIPSTREAM ENABLE_MASTERDNS ENABLE_XDNS ENABLE_TRUSTTUNNEL; do
+                        for var in ENABLE_TROJAN ENABLE_ANYTLS ENABLE_HYSTERIA2 ENABLE_DNSTT ENABLE_SLIPSTREAM ENABLE_MASTERDNS ENABLE_XDNS ENABLE_TRUSTTUNNEL; do
                             update_env_var ".env" "$var" "false"
                         done
                         # Derive DEFAULT_PROFILES from the mutated ENABLE_* set (issue #106).
@@ -4000,14 +4000,15 @@ show_status() {
     if [[ -f "$env_file" ]]; then
         local enable_reality=$(get_env_val "ENABLE_REALITY" "$env_file" "true")
         local enable_trojan=$(get_env_val "ENABLE_TROJAN" "$env_file" "true")
+        local enable_anytls=$(get_env_val "ENABLE_ANYTLS" "$env_file" "false")
         local enable_hysteria2=$(get_env_val "ENABLE_HYSTERIA2" "$env_file" "true")
         local enable_wireguard=$(get_env_val "ENABLE_WIREGUARD" "$env_file" "true")
         local enable_dnstt=$(get_env_val "ENABLE_DNSTT" "$env_file" "true")
         local enable_admin=$(get_env_val "ENABLE_ADMIN_UI" "$env_file" "true")
 
         # Mark services as disabled based on ENABLE_* settings
-        # sing-box handles Reality, Trojan, Hysteria2
-        if [[ "$enable_reality" != "true" ]] && [[ "$enable_trojan" != "true" ]] && [[ "$enable_hysteria2" != "true" ]]; then
+        # sing-box handles Reality, Trojan, AnyTLS, Hysteria2
+        if [[ "$enable_reality" != "true" ]] && [[ "$enable_trojan" != "true" ]] && [[ "$enable_anytls" != "true" ]] && [[ "$enable_hysteria2" != "true" ]]; then
             disabled_services["sing-box"]=1
             disabled_services["decoy"]=1
         fi
@@ -4202,6 +4203,7 @@ select_profiles() {
     if [[ -f "$env_file" ]]; then
         local enable_reality=$(get_env_val "ENABLE_REALITY" "$env_file" "true")
         local enable_trojan=$(get_env_val "ENABLE_TROJAN" "$env_file" "true")
+        local enable_anytls=$(get_env_val "ENABLE_ANYTLS" "$env_file" "false")
         local enable_hysteria2=$(get_env_val "ENABLE_HYSTERIA2" "$env_file" "true")
         local enable_wireguard=$(get_env_val "ENABLE_WIREGUARD" "$env_file" "true")
         local enable_amneziawg=$(get_env_val "ENABLE_AMNEZIAWG" "$env_file" "true")
@@ -4212,8 +4214,8 @@ select_profiles() {
         local enable_admin=$(get_env_val "ENABLE_ADMIN_UI" "$env_file" "true")
         local enable_xhttp=$(get_env_val "ENABLE_XHTTP" "$env_file" "true")
 
-        # proxy is disabled if all three protocols are disabled
-        if [[ "$enable_reality" != "true" ]] && [[ "$enable_trojan" != "true" ]] && [[ "$enable_hysteria2" != "true" ]]; then
+        # proxy is disabled if all sing-box protocols are disabled
+        if [[ "$enable_reality" != "true" ]] && [[ "$enable_trojan" != "true" ]] && [[ "$enable_anytls" != "true" ]] && [[ "$enable_hysteria2" != "true" ]]; then
             proxy_enabled=false
         fi
         [[ "$enable_wireguard" != "true" ]] && wg_enabled=false
@@ -4320,6 +4322,7 @@ select_profiles() {
         # Check which protocols are enabled
         local enable_reality=$(get_env_val "ENABLE_REALITY" "$env_file" "true")
         local enable_trojan=$(get_env_val "ENABLE_TROJAN" "$env_file" "true")
+        local enable_anytls=$(get_env_val "ENABLE_ANYTLS" "$env_file" "false")
         local enable_hysteria2=$(get_env_val "ENABLE_HYSTERIA2" "$env_file" "true")
         local enable_wireguard=$(get_env_val "ENABLE_WIREGUARD" "$env_file" "true")
         local enable_amneziawg=$(get_env_val "ENABLE_AMNEZIAWG" "$env_file" "true")
@@ -4333,8 +4336,8 @@ select_profiles() {
         # Build profiles list based on enabled services
         SELECTED_PROFILES=()
 
-        # proxy profile (Reality, Trojan, Hysteria2)
-        if [[ "$enable_reality" == "true" ]] || [[ "$enable_trojan" == "true" ]] || [[ "$enable_hysteria2" == "true" ]]; then
+        # proxy profile (Reality, Trojan, AnyTLS, Hysteria2)
+        if [[ "$enable_reality" == "true" ]] || [[ "$enable_trojan" == "true" ]] || [[ "$enable_anytls" == "true" ]] || [[ "$enable_hysteria2" == "true" ]]; then
             SELECTED_PROFILES+=("proxy")
         fi
 
@@ -4512,12 +4515,13 @@ profile_enabled() {
     local profile="$1" env_file="${2:-$SCRIPT_DIR/.env}"
     case "$profile" in
         proxy)
-            local _r _t _h _s
+            local _r _t _a _h _s
             _r=$(get_env_val "ENABLE_REALITY"   "$env_file" "true")
             _t=$(get_env_val "ENABLE_TROJAN"    "$env_file" "true")
+            _a=$(get_env_val "ENABLE_ANYTLS"    "$env_file" "false")
             _h=$(get_env_val "ENABLE_HYSTERIA2" "$env_file" "true")
             _s=$(get_env_val "ENABLE_SS"        "$env_file" "true")
-            [[ "$_r" == "true" || "$_t" == "true" || "$_h" == "true" || "$_s" == "true" ]] \
+            [[ "$_r" == "true" || "$_t" == "true" || "$_a" == "true" || "$_h" == "true" || "$_s" == "true" ]] \
                 && echo true || echo false ;;
         wireguard)   [[ "$(get_env_val "ENABLE_WIREGUARD"   "$env_file" "true")"  == "true" ]] && echo true || echo false ;;
         amneziawg)   [[ "$(get_env_val "ENABLE_AMNEZIAWG"   "$env_file" "true")"  == "true" ]] && echo true || echo false ;;
@@ -4591,7 +4595,7 @@ confirm_disabled_profile() {
         snowflake)   enable_var="ENABLE_SNOWFLAKE" ;;
         gooserelay)  enable_var="ENABLE_GOOSERELAY" ;;
         monitoring)  enable_var="ENABLE_MONITORING" ;;
-        proxy)       multi_flag_hint="ENABLE_REALITY, ENABLE_TROJAN, ENABLE_HYSTERIA2, ENABLE_SS" ;;
+        proxy)       multi_flag_hint="ENABLE_REALITY, ENABLE_TROJAN, ENABLE_ANYTLS, ENABLE_HYSTERIA2, ENABLE_SS" ;;
         dnstunnel)   multi_flag_hint="ENABLE_DNSTT, ENABLE_SLIPSTREAM, ENABLE_MASTERDNS, ENABLE_XDNS" ;;
     esac
 
@@ -6671,7 +6675,7 @@ cmd_domainless() {
     # Disable cert-needing protocols. TROJAN..TRUSTTUNNEL must match
     # bootstrap.sh:41-46; XDNS is added to keep dns-router off port 53 in
     # domainless mode (direct-mode XDNS can be re-enabled manually).
-    for var in ENABLE_TROJAN ENABLE_HYSTERIA2 ENABLE_DNSTT ENABLE_SLIPSTREAM ENABLE_MASTERDNS ENABLE_XDNS ENABLE_TRUSTTUNNEL; do
+    for var in ENABLE_TROJAN ENABLE_ANYTLS ENABLE_HYSTERIA2 ENABLE_DNSTT ENABLE_SLIPSTREAM ENABLE_MASTERDNS ENABLE_XDNS ENABLE_TRUSTTUNNEL; do
         update_env_var ".env" "$var" "false"
     done
 
@@ -8614,6 +8618,8 @@ cmd_regenerate_users() {
     # Load ENABLE_* settings from .env
     local enable_reality=$(get_env_val "ENABLE_REALITY" .env "true")
     local enable_trojan=$(get_env_val "ENABLE_TROJAN" .env "true")
+    local enable_anytls=$(get_env_val "ENABLE_ANYTLS" .env "false")
+    local port_anytls=$(get_env_val "PORT_ANYTLS" .env "8445")
     local enable_hysteria2=$(get_env_val "ENABLE_HYSTERIA2" .env "true")
     local enable_wireguard=$(get_env_val "ENABLE_WIREGUARD" .env "true")
     local enable_amneziawg=$(get_env_val "ENABLE_AMNEZIAWG" .env "true")
@@ -8663,6 +8669,8 @@ cmd_regenerate_users() {
             -e "CDN_ADDRESS=$cdn_address" \
             -e "ENABLE_REALITY=${enable_reality:-true}" \
             -e "ENABLE_TROJAN=${enable_trojan:-true}" \
+            -e "ENABLE_ANYTLS=${enable_anytls:-false}" \
+            -e "PORT_ANYTLS=${port_anytls:-8445}" \
             -e "ENABLE_HYSTERIA2=${enable_hysteria2:-true}" \
             -e "ENABLE_WIREGUARD=${enable_wireguard:-true}" \
             -e "ENABLE_AMNEZIAWG=${enable_amneziawg:-true}" \

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -39,6 +39,7 @@ done
 # Note: Telegram MTProxy works without domain (IP only + fake-TLS)
 domain_required=false
 [[ "${ENABLE_TROJAN:-true}" == "true" ]] && domain_required=true
+[[ "${ENABLE_ANYTLS:-false}" == "true" ]] && domain_required=true
 [[ "${ENABLE_HYSTERIA2:-true}" == "true" ]] && domain_required=true
 [[ "${ENABLE_DNSTT:-true}" == "true" ]] && domain_required=true
 [[ "${ENABLE_SLIPSTREAM:-true}" == "true" ]] && domain_required=true
@@ -56,6 +57,7 @@ if [[ "$domain_required" == "true" ]] && [[ -z "${DOMAIN:-}" ]]; then
     log_error "  WireGuard, AmneziaWG, Telegram, Admin, Conduit, Snowflake still"
     log_error "  work without a domain):"
     log_error "    ENABLE_TROJAN=false"
+    log_error "    ENABLE_ANYTLS=false"
     log_error "    ENABLE_HYSTERIA2=false"
     log_error "    ENABLE_DNSTT=false"
     log_error "    ENABLE_SLIPSTREAM=false"
@@ -251,6 +253,8 @@ export DOMAIN="${DOMAIN:-}"
 export DNSTT_SUBDOMAIN="${DNSTT_SUBDOMAIN:-t}"
 export ENABLE_REALITY="${ENABLE_REALITY:-true}"
 export ENABLE_TROJAN="${ENABLE_TROJAN:-true}"
+export ENABLE_ANYTLS="${ENABLE_ANYTLS:-false}"
+export PORT_ANYTLS="${PORT_ANYTLS:-8445}"
 export ENABLE_HYSTERIA2="${ENABLE_HYSTERIA2:-true}"
 export ENABLE_WIREGUARD="${ENABLE_WIREGUARD:-true}"
 export ENABLE_AMNEZIAWG="${ENABLE_AMNEZIAWG:-true}"
@@ -509,6 +513,7 @@ log_info "Creating $INITIAL_USERS initial users..."
 
 REALITY_USERS_JSON="["
 TROJAN_USERS_JSON="["
+ANYTLS_USERS_JSON="["
 HYSTERIA2_USERS_JSON="["
 VLESS_WS_USERS_JSON="["
 SHADOWSOCKS_USERS_JSON="["
@@ -551,12 +556,14 @@ EOF
     # Build JSON arrays for sing-box config
     [[ $i -gt 1 ]] && REALITY_USERS_JSON+=","
     [[ $i -gt 1 ]] && TROJAN_USERS_JSON+=","
+    [[ $i -gt 1 ]] && ANYTLS_USERS_JSON+=","
     [[ $i -gt 1 ]] && HYSTERIA2_USERS_JSON+=","
     [[ $i -gt 1 ]] && VLESS_WS_USERS_JSON+=","
     [[ $i -gt 1 ]] && SHADOWSOCKS_USERS_JSON+=","
 
     REALITY_USERS_JSON+="{\"name\":\"$USER_ID\",\"uuid\":\"$USER_UUID\",\"flow\":\"xtls-rprx-vision\"}"
     TROJAN_USERS_JSON+="{\"name\":\"$USER_ID\",\"password\":\"$USER_PASSWORD\"}"
+    ANYTLS_USERS_JSON+="{\"name\":\"$USER_ID\",\"password\":\"$USER_PASSWORD\"}"
     HYSTERIA2_USERS_JSON+="{\"name\":\"$USER_ID\",\"password\":\"$USER_PASSWORD\"}"
     VLESS_WS_USERS_JSON+="{\"name\":\"$USER_ID\",\"uuid\":\"$USER_UUID\"}"
 
@@ -680,6 +687,7 @@ for user_dir in "$STATE_DIR"/users/*/; do
     # Add to sing-box JSON arrays (need comma separator)
     REALITY_USERS_JSON+=",{\"name\":\"$EXTRA_USER_ID\",\"uuid\":\"$USER_UUID\",\"flow\":\"xtls-rprx-vision\"}"
     TROJAN_USERS_JSON+=",{\"name\":\"$EXTRA_USER_ID\",\"password\":\"$USER_PASSWORD\"}"
+    ANYTLS_USERS_JSON+=",{\"name\":\"$EXTRA_USER_ID\",\"password\":\"$USER_PASSWORD\"}"
     HYSTERIA2_USERS_JSON+=",{\"name\":\"$EXTRA_USER_ID\",\"password\":\"$USER_PASSWORD\"}"
     VLESS_WS_USERS_JSON+=",{\"name\":\"$EXTRA_USER_ID\",\"uuid\":\"$USER_UUID\"}"
 
@@ -721,6 +729,7 @@ fi
 
 REALITY_USERS_JSON+="]"
 TROJAN_USERS_JSON+="]"
+ANYTLS_USERS_JSON+="]"
 HYSTERIA2_USERS_JSON+="]"
 VLESS_WS_USERS_JSON+="]"
 SHADOWSOCKS_USERS_JSON+="]"
@@ -829,6 +838,7 @@ fi
 singbox_needed=false
 [[ "${ENABLE_REALITY:-true}" == "true" ]] && singbox_needed=true
 [[ "${ENABLE_TROJAN:-true}" == "true" ]] && singbox_needed=true
+[[ "${ENABLE_ANYTLS:-false}" == "true" ]] && singbox_needed=true
 [[ "${ENABLE_HYSTERIA2:-true}" == "true" ]] && singbox_needed=true
 [[ "${ENABLE_SS:-true}" == "true" ]] && singbox_needed=true
 
@@ -837,6 +847,8 @@ if [[ "$singbox_needed" == "true" ]]; then
 
     export REALITY_USERS_JSON
     export TROJAN_USERS_JSON
+    export ANYTLS_USERS_JSON="${ANYTLS_USERS_JSON:-[]}"
+    export PORT_ANYTLS="${PORT_ANYTLS:-8445}"
     export HYSTERIA2_USERS_JSON
     export VLESS_WS_USERS_JSON
     export SHADOWSOCKS_USERS_JSON="${SHADOWSOCKS_USERS_JSON:-[]}"
@@ -861,6 +873,10 @@ if [[ "$singbox_needed" == "true" ]]; then
     if [[ "${ENABLE_TROJAN:-true}" != "true" ]]; then
         jq 'del(.inbounds[] | select(.tag == "trojan-tls-in"))' "$config_file" > "${config_file}.tmp" && mv -f "${config_file}.tmp" "$config_file"
         log_info "  Removed Trojan inbound (disabled)"
+    fi
+    if [[ "${ENABLE_ANYTLS:-false}" != "true" ]]; then
+        jq 'del(.inbounds[] | select(.tag == "anytls-in"))' "$config_file" > "${config_file}.tmp" && mv -f "${config_file}.tmp" "$config_file"
+        log_info "  Removed AnyTLS inbound (disabled)"
     fi
     if [[ "${ENABLE_HYSTERIA2:-true}" != "true" ]]; then
         jq 'del(.inbounds[] | select(.tag == "hysteria2-in"))' "$config_file" > "${config_file}.tmp" && mv -f "${config_file}.tmp" "$config_file"

--- a/scripts/client-connect.sh
+++ b/scripts/client-connect.sh
@@ -24,7 +24,7 @@ TEST_TIMEOUT="${TEST_TIMEOUT:-10}"
 
 # Protocol priority for auto mode
 # Note: psiphon excluded - requires embedded server list, not supported in client mode
-PROTOCOL_PRIORITY=(reality hysteria2 trojan xhttp trusttunnel wireguard amneziawg tor dnstt slipstream)
+PROTOCOL_PRIORITY=(reality hysteria2 trojan anytls xhttp trusttunnel wireguard amneziawg tor dnstt slipstream)
 
 # State
 CURRENT_PID=""
@@ -124,6 +124,16 @@ generate_singbox_config() {
             done
             if [[ -z "$config_file" ]]; then
                 for f in "$CONFIG_DIR"/trojan*.txt "$CONFIG_DIR"/trojan*.json; do
+                    [[ -f "$f" ]] && config_file="$f" && break
+                done
+            fi
+            ;;
+        anytls)
+            for f in "$CONFIG_DIR"/anytls.txt "$CONFIG_DIR"/anytls.json; do
+                [[ -f "$f" ]] && config_file="$f" && break
+            done
+            if [[ -z "$config_file" ]]; then
+                for f in "$CONFIG_DIR"/anytls*.txt "$CONFIG_DIR"/anytls*.json; do
                     [[ -f "$f" ]] && config_file="$f" && break
                 done
             fi
@@ -259,6 +269,55 @@ EOF
       "tls": {
         "enabled": true,
         "server_name": "$sni"
+      }
+    }
+  ],
+  "route": {"final": "proxy"}
+}
+EOF
+            else
+                jq --argjson inbounds "$inbounds" '. + {"inbounds": $inbounds, "log": {"level": "info", "timestamp": true}, "route": {"final": "proxy"}}' "$config_file" > "$output_file"
+            fi
+            ;;
+
+        anytls)
+            if [[ "$config_file" == *.txt ]]; then
+                local uri=$(cat "$config_file" | tr -d '\n\r')
+                local password=$(extract_auth "$uri" "anytls")
+                local server=$(extract_host "$uri")
+                local port=$(extract_port "$uri")
+                local sni=$(extract_param "$uri" "sni")
+
+                [[ -z "$sni" ]] && sni="$server"
+
+                # Ensure port is numeric
+                port=$(echo "$port" | tr -cd '0-9')
+                [[ -z "$port" ]] && port="8445"
+
+                # Validate required fields
+                if [[ -z "$server" ]] || [[ -z "$password" ]]; then
+                    log_error "Failed to parse AnyTLS URI (missing required fields)"
+                    log_debug "server='$server' password='${password:0:8}...'"
+                    return 1
+                fi
+
+                log_debug "AnyTLS config: server=$server port=$port sni=$sni"
+
+                cat > "$output_file" << EOF
+{
+  "log": {"level": "info", "timestamp": true},
+  "inbounds": $inbounds,
+  "outbounds": [
+    {
+      "type": "anytls",
+      "tag": "proxy",
+      "server": "$server",
+      "server_port": $port,
+      "password": "$password",
+      "tls": {
+        "enabled": true,
+        "server_name": "$sni",
+        "utls": {"enabled": true, "fingerprint": "random"}
       }
     }
   ],
@@ -977,7 +1036,7 @@ connect_auto() {
         log_info "Trying $protocol..."
 
         case "$protocol" in
-            reality|trojan|hysteria2)
+            reality|trojan|anytls|hysteria2)
                 if connect_singbox "$protocol"; then
                     log_success "Connected via $protocol"
                     return 0
@@ -1064,7 +1123,7 @@ main() {
         auto)
             connect_auto && connected=true
             ;;
-        reality|trojan|hysteria2)
+        reality|trojan|anytls|hysteria2)
             connect_singbox "$PROTOCOL" && connected=true
             ;;
         wireguard)

--- a/scripts/client-test.sh
+++ b/scripts/client-test.sh
@@ -452,6 +452,175 @@ EOF
     wait $pid 2>/dev/null || true
 }
 
+# Test AnyTLS protocol (sing-box native, password-auth TLS, reuses Trojan cert)
+test_anytls() {
+    log_info "Testing AnyTLS..."
+
+    local config_file=""
+    local detail=""
+    local is_ipv6=false
+
+    # Find AnyTLS config - prefer IPv4 over IPv6
+    for f in "$CONFIG_DIR"/anytls.txt "$CONFIG_DIR"/anytls.json; do
+        [[ -f "$f" ]] && config_file="$f" && break
+    done
+    if [[ -z "$config_file" ]]; then
+        for f in "$CONFIG_DIR"/anytls*.txt "$CONFIG_DIR"/anytls*.json; do
+            [[ -f "$f" ]] && config_file="$f" && break
+        done
+    fi
+    [[ "$config_file" == *ipv6* ]] && is_ipv6=true
+
+    if [[ -z "$config_file" ]]; then
+        detail="No AnyTLS config found in bundle"
+        log_warn "$detail"
+        log_debug "Searched in: $CONFIG_DIR for anytls*.txt, anytls*.json"
+        RESULTS[anytls]="skip"
+        DETAILS[anytls]="$detail"
+        return
+    fi
+
+    log_debug "Using config: $config_file"
+    log_debug "Config content: $(cat "$config_file" | head -1 | cut -c1-80)..."
+
+    local client_config="$TEMP_DIR/anytls-client.json"
+
+    if [[ "$config_file" == *.txt ]]; then
+        local uri=$(cat "$config_file" | tr -d '\n\r')
+
+        local password=$(extract_auth "$uri" "anytls")
+        local server=$(extract_host "$uri")
+        local port=$(extract_port "$uri")
+        local sni=$(extract_param "$uri" "sni")
+
+        [[ -z "$sni" ]] && sni="$server"
+        [[ -z "$port" ]] && port="8445"
+
+        # Ensure port is numeric
+        port=$(echo "$port" | tr -cd '0-9')
+        [[ -z "$port" ]] && port="8445"
+
+        log_debug "Parsed: server=$server port=$port sni=$sni"
+
+        # Validate required fields
+        if [[ -z "$server" ]] || [[ -z "$password" ]]; then
+            detail="Failed to parse AnyTLS URI (missing required fields). Run with -v for details."
+            log_error "$detail"
+            log_error "server='$server' password='${password:0:8}...'"
+            RESULTS[anytls]="fail"
+            DETAILS[anytls]="$detail"
+            return
+        fi
+
+        cat > "$client_config" << EOF
+{
+  "log": {"level": "error"},
+  "inbounds": [
+    {"type": "socks", "listen": "127.0.0.1", "listen_port": 10805}
+  ],
+  "outbounds": [
+    {
+      "type": "anytls",
+      "tag": "proxy",
+      "server": "$server",
+      "server_port": $port,
+      "password": "$password",
+      "tls": {
+        "enabled": true,
+        "server_name": "$sni",
+        "utls": {"enabled": true, "fingerprint": "random"}
+      }
+    }
+  ],
+  "route": {
+    "final": "proxy"
+  }
+}
+EOF
+    else
+        jq '. + {
+          "log": {"level": "error"},
+          "inbounds": [{"type": "socks", "listen": "127.0.0.1", "listen_port": 10805}],
+          "route": {"final": "proxy"}
+        }' "$config_file" > "$client_config" 2>/dev/null || {
+            detail="Failed to parse JSON config"
+            log_error "$detail"
+            RESULTS[anytls]="fail"
+            DETAILS[anytls]="$detail"
+            return
+        }
+    fi
+
+    # Validate JSON before running
+    if ! jq empty "$client_config" 2>/dev/null; then
+        detail="Generated invalid JSON config"
+        log_error "$detail"
+        RESULTS[anytls]="fail"
+        DETAILS[anytls]="$detail"
+        return
+    fi
+
+    # Start sing-box and capture errors
+    local error_log="$TEMP_DIR/anytls-error.log"
+    sing-box run -c "$client_config" 2>"$error_log" &
+    local pid=$!
+    sleep 3
+
+    if ! kill -0 $pid 2>/dev/null; then
+        detail="sing-box failed to start"
+        if [[ -s "$error_log" ]]; then
+            local error_msg=$(tail -5 "$error_log" 2>/dev/null | tr '\n' ' ' || true)
+            detail="sing-box error: $error_msg"
+        fi
+        log_error "$detail"
+        log_debug "Generated config was: $(cat "$client_config" 2>/dev/null | tr '\n' ' ')"
+        RESULTS[anytls]="fail"
+        DETAILS[anytls]="$detail"
+        return
+    fi
+
+    log_debug "sing-box started successfully (PID: $pid)"
+    log_debug "Testing connectivity via SOCKS5 on port 10805..."
+
+    if curl -sf --socks5 127.0.0.1:10805 --max-time "$TEST_TIMEOUT" "$TEST_URL" >/dev/null 2>&1; then
+        # Verify we can access the internet and get exit IP
+        local exit_ip=""
+        exit_ip=$(curl -sf --socks5 127.0.0.1:10805 --max-time "$TEST_TIMEOUT" https://api.ipify.org 2>/dev/null || \
+                  curl -sf --socks5 127.0.0.1:10805 --max-time "$TEST_TIMEOUT" https://ifconfig.me 2>/dev/null || true)
+        if [[ -n "$exit_ip" ]]; then
+            log_success "AnyTLS connection successful (exit IP: $exit_ip)"
+            RESULTS[anytls]="pass"
+            DETAILS[anytls]="Connected via AnyTLS, exit IP: $exit_ip"
+        else
+            log_success "AnyTLS connection successful"
+            RESULTS[anytls]="pass"
+            DETAILS[anytls]="Connected via AnyTLS"
+        fi
+    else
+        detail="Connection test failed"
+        # Check for sing-box errors during operation
+        if [[ -s "$error_log" ]]; then
+            local error_msg=$(grep -i "error\|fail\|unreachable\|timeout\|refused" "$error_log" 2>/dev/null | tail -3 | tr '\n' ' ' || true)
+            [[ -n "$error_msg" ]] && detail="$error_msg"
+        fi
+        log_debug "Full error log: $(cat "$error_log" 2>/dev/null | tail -10 | tr '\n' ' ')"
+        log_debug "Server: $server:$port, SNI: $sni"
+        # If IPv6 config and network unreachable, warn instead of fail
+        if [[ "$is_ipv6" == "true" ]] && echo "$detail" | grep -qi "unreachable\|network"; then
+            log_warn "IPv6 config - $detail"
+            RESULTS[anytls]="warn"
+            DETAILS[anytls]="IPv6 network may not be available: $detail"
+        else
+            log_error "$detail"
+            RESULTS[anytls]="fail"
+            DETAILS[anytls]="$detail"
+        fi
+    fi
+
+    kill $pid 2>/dev/null || true
+    wait $pid 2>/dev/null || true
+}
+
 # Test Hysteria2 protocol
 test_hysteria2() {
     log_info "Testing Hysteria2..."
@@ -1620,7 +1789,7 @@ output_json() {
 EOF
 
     local first=true
-    for protocol in reality trojan hysteria2 wireguard amneziawg dnstt slipstream trusttunnel telemt; do
+    for protocol in reality trojan anytls hysteria2 wireguard amneziawg dnstt slipstream trusttunnel telemt; do
         if [[ -n "${RESULTS[$protocol]:-}" ]]; then
             [[ "$first" != "true" ]] && echo ","
             first=false
@@ -1651,7 +1820,7 @@ output_human() {
     echo ""
     echo "───────────────────────────────────────────────────────────────"
 
-    for protocol in reality trojan hysteria2 wireguard amneziawg dnstt slipstream trusttunnel telemt; do
+    for protocol in reality trojan anytls hysteria2 wireguard amneziawg dnstt slipstream trusttunnel telemt; do
         if [[ -n "${RESULTS[$protocol]:-}" ]]; then
             local status="${RESULTS[$protocol]}"
             local detail="${DETAILS[$protocol]:-}"
@@ -1687,6 +1856,7 @@ main() {
     # Run all tests
     test_reality
     test_trojan
+    test_anytls
     test_hysteria2
     test_xhttp
     test_wireguard

--- a/scripts/generate-single-user.sh
+++ b/scripts/generate-single-user.sh
@@ -78,10 +78,10 @@ donate_needs() {
     return 1
 }
 
-# Add to sing-box config (Reality, Trojan, Hysteria2, CDN — all sing-box inbounds)
+# Add to sing-box config (Reality, Trojan, AnyTLS, Hysteria2, CDN — all sing-box inbounds)
 CONFIG_FILE="/configs/sing-box/config.json"
 
-if [[ -f "$CONFIG_FILE" ]] && donate_needs singbox reality trojan hysteria2 cdn shadowsocks ss; then
+if [[ -f "$CONFIG_FILE" ]] && donate_needs singbox reality trojan anytls hysteria2 cdn shadowsocks ss; then
     # Add to Reality inbound
     if donate_needs reality reality; then
         jq --arg name "$USER_ID" --arg uuid "$USER_UUID" \
@@ -93,6 +93,13 @@ if [[ -f "$CONFIG_FILE" ]] && donate_needs singbox reality trojan hysteria2 cdn 
     if donate_needs trojan trojan; then
         jq --arg name "$USER_ID" --arg password "$USER_PASSWORD" \
             '(.inbounds[] | select(.tag == "trojan-tls-in") | .users) += [{"name": $name, "password": $password}]' \
+            "$CONFIG_FILE" > /tmp/config.tmp && mv -f /tmp/config.tmp "$CONFIG_FILE"
+    fi
+
+    # Add to AnyTLS inbound (no-op if anytls-in inbound isn't present)
+    if donate_needs anytls anytls; then
+        jq --arg name "$USER_ID" --arg password "$USER_PASSWORD" \
+            '(.inbounds[] | select(.tag == "anytls-in") | .users) += [{"name": $name, "password": $password}]' \
             "$CONFIG_FILE" > /tmp/config.tmp && mv -f /tmp/config.tmp "$CONFIG_FILE"
     fi
 
@@ -226,6 +233,11 @@ if [[ -n "$DONATE_ONLY" ]]; then
     else
         export ENABLE_TROJAN=false
     fi
+    if echo " $DONATE_ONLY " | grep -q " anytls "; then
+        export ENABLE_ANYTLS=true
+    else
+        export ENABLE_ANYTLS=false
+    fi
     if echo " $DONATE_ONLY " | grep -q " hysteria2 "; then
         export ENABLE_HYSTERIA2=true
     else
@@ -258,11 +270,13 @@ else
     export ENABLE_MASTERDNS="${ENABLE_MASTERDNS:-true}"
     export ENABLE_GOOSERELAY="${ENABLE_GOOSERELAY:-false}"
     export ENABLE_HYSTERIA2="${ENABLE_HYSTERIA2:-true}"
+    export ENABLE_ANYTLS="${ENABLE_ANYTLS:-false}"
     export ENABLE_TRUSTTUNNEL="${ENABLE_TRUSTTUNNEL:-true}"
     export ENABLE_XHTTP="${ENABLE_XHTTP:-true}"
     export ENABLE_TELEMT="${ENABLE_TELEMT:-true}"
     export ENABLE_SS="${ENABLE_SS:-true}"
 fi
+export PORT_ANYTLS="${PORT_ANYTLS:-8445}"
 export PORT_SS="${PORT_SS:-8388}"
 export SS_METHOD="${SS_METHOD:-2022-blake3-aes-128-gcm}"
 if [[ -f "$STATE_DIR/keys/shadowsocks-server.psk" ]]; then

--- a/scripts/generate-user.sh
+++ b/scripts/generate-user.sh
@@ -179,6 +179,57 @@ EOF
 fi
 
 # -----------------------------------------------------------------------------
+# Generate AnyTLS client config (sing-box native, reuses Trojan TLS cert/domain)
+# -----------------------------------------------------------------------------
+if [[ "${ENABLE_ANYTLS:-false}" == "true" ]]; then
+  if [[ -f "$OUTPUT_DIR/anytls.txt" ]] && [[ "$FORCE_REGENERATE" != "force" ]]; then
+    log_info "  - AnyTLS config exists, skipping"
+  else
+    BUNDLE_CHANGED=true
+    cat > "$OUTPUT_DIR/anytls-singbox.json" <<EOF
+{
+  "log": {"level": "info"},
+  "inbounds": [
+    {"type": "tun", "tag": "tun-in", "address": ["172.19.0.1/30"], "auto_route": true, "strict_route": true}
+  ],
+  "outbounds": [
+    {
+      "type": "anytls",
+      "tag": "proxy",
+      "server": "${SERVER_IP}",
+      "server_port": ${PORT_ANYTLS:-8445},
+      "password": "${USER_PASSWORD}",
+      "tls": {
+        "enabled": true,
+        "server_name": "${DOMAIN}",
+        "utls": {"enabled": true, "fingerprint": "random"}
+      }
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "final": "proxy"
+  }
+}
+EOF
+
+    # Generate AnyTLS URI (IPv4)
+    ANYTLS_LINK="anytls://${USER_PASSWORD}@${SERVER_IP}:${PORT_ANYTLS:-8445}?sni=${DOMAIN}&insecure=0#MoaV-AnyTLS-${USER_ID}"
+    echo "$ANYTLS_LINK" > "$OUTPUT_DIR/anytls.txt"
+    qrencode -o "$OUTPUT_DIR/anytls-qr.png" -s 6 "$ANYTLS_LINK" 2>/dev/null || true
+
+    # Generate IPv6 link if available
+    if [[ -n "${SERVER_IPV6:-}" ]]; then
+        ANYTLS_LINK_V6="anytls://${USER_PASSWORD}@[${SERVER_IPV6}]:${PORT_ANYTLS:-8445}?sni=${DOMAIN}&insecure=0#MoaV-AnyTLS-${USER_ID}-IPv6"
+        echo "$ANYTLS_LINK_V6" > "$OUTPUT_DIR/anytls-ipv6.txt"
+        qrencode -o "$OUTPUT_DIR/anytls-ipv6-qr.png" -s 6 "$ANYTLS_LINK_V6" 2>/dev/null || true
+    fi
+
+    log_info "  - AnyTLS config generated"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # Generate Hysteria2 client config
 # -----------------------------------------------------------------------------
 if [[ "${ENABLE_HYSTERIA2:-true}" == "true" ]]; then
@@ -783,6 +834,7 @@ elif [[ -f "$TEMPLATE_FILE" ]]; then
     CONFIG_REALITY=$(cat "$OUTPUT_DIR/reality.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_HYSTERIA2=$(cat "$OUTPUT_DIR/hysteria2.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_TROJAN=$(cat "$OUTPUT_DIR/trojan.txt" 2>/dev/null | tr -d '\n' || echo "")
+    CONFIG_ANYTLS=$(cat "$OUTPUT_DIR/anytls.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_CDN=$(cat "$OUTPUT_DIR/cdn-vless.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_WIREGUARD=$(cat "$OUTPUT_DIR/wireguard.conf" 2>/dev/null || echo "")
     CONFIG_WIREGUARD_WSTUNNEL=$(cat "$OUTPUT_DIR/wireguard-wstunnel.conf" 2>/dev/null || echo "")
@@ -826,6 +878,7 @@ elif [[ -f "$TEMPLATE_FILE" ]]; then
     QR_REALITY_B64=$(qr_to_base64 "$OUTPUT_DIR/reality-qr.png")
     QR_HYSTERIA2_B64=$(qr_to_base64 "$OUTPUT_DIR/hysteria2-qr.png")
     QR_TROJAN_B64=$(qr_to_base64 "$OUTPUT_DIR/trojan-qr.png")
+    QR_ANYTLS_B64=$(qr_to_base64 "$OUTPUT_DIR/anytls-qr.png")
     QR_CDN_B64=$(qr_to_base64 "$OUTPUT_DIR/cdn-vless-qr.png")
     QR_WIREGUARD_B64=$(qr_to_base64 "$OUTPUT_DIR/wireguard-qr.png")
     QR_WIREGUARD_WSTUNNEL_B64=$(qr_to_base64 "$OUTPUT_DIR/wireguard-wstunnel-qr.png")
@@ -852,10 +905,10 @@ elif [[ -f "$TEMPLATE_FILE" ]]; then
     # configured separately and intentionally excluded. base64 has no '|', so it
     # is safe in the sed replacement below.
     _mahsanet_uris=""
-    for _f in reality cdn-vless xhttp-vless trojan shadowsocks hysteria2 \
-              reality-ipv6 trojan-ipv6 shadowsocks-ipv6 hysteria2-ipv6; do
+    for _f in reality cdn-vless xhttp-vless trojan anytls shadowsocks hysteria2 \
+              reality-ipv6 trojan-ipv6 anytls-ipv6 shadowsocks-ipv6 hysteria2-ipv6; do
         [[ -f "$OUTPUT_DIR/$_f.txt" ]] || continue
-        _u=$(tr -d '\r' < "$OUTPUT_DIR/$_f.txt" | grep -aE '^(vless|trojan|ss|hysteria2|vmess)://' | head -1 || true)
+        _u=$(tr -d '\r' < "$OUTPUT_DIR/$_f.txt" | grep -aE '^(vless|trojan|anytls|ss|hysteria2|vmess)://' | head -1 || true)
         [[ -n "$_u" ]] && _mahsanet_uris+="$_u"$'\n'
     done
     if [[ -n "$_mahsanet_uris" ]]; then
@@ -885,6 +938,7 @@ elif [[ -f "$TEMPLATE_FILE" ]]; then
         [[ "${ENABLE_WIREGUARD:-true}" != "true" ]] && DISABLED_SERVICES+="WireGuard, "
         [[ "${ENABLE_DNSTT:-true}" != "true" ]] && DISABLED_SERVICES+="DNS Tunnel, "
         [[ "${ENABLE_TROJAN:-true}" != "true" ]] && DISABLED_SERVICES+="Trojan, "
+        [[ "${ENABLE_ANYTLS:-false}" != "true" ]] && DISABLED_SERVICES+="AnyTLS, "
         [[ "${ENABLE_HYSTERIA2:-true}" != "true" ]] && DISABLED_SERVICES+="Hysteria2, "
         [[ "${ENABLE_REALITY:-true}" != "true" ]] && DISABLED_SERVICES+="Reality, "
         DISABLED_SERVICES="${DISABLED_SERVICES%, }"  # Remove trailing comma
@@ -910,6 +964,7 @@ elif [[ -f "$TEMPLATE_FILE" ]]; then
     sed -i "s|{{QR_REALITY}}|$QR_REALITY_B64|g" "$OUTPUT_HTML"
     sed -i "s|{{QR_HYSTERIA2}}|$QR_HYSTERIA2_B64|g" "$OUTPUT_HTML"
     sed -i "s|{{QR_TROJAN}}|$QR_TROJAN_B64|g" "$OUTPUT_HTML"
+    sed -i "s|{{QR_ANYTLS}}|$QR_ANYTLS_B64|g" "$OUTPUT_HTML"
     sed -i "s|{{QR_CDN}}|$QR_CDN_B64|g" "$OUTPUT_HTML"
     sed -i "s|{{QR_WIREGUARD}}|$QR_WIREGUARD_B64|g" "$OUTPUT_HTML"
     sed -i "s|{{QR_WIREGUARD_WSTUNNEL}}|$QR_WIREGUARD_WSTUNNEL_B64|g" "$OUTPUT_HTML"
@@ -949,6 +1004,12 @@ with open(filepath, 'w') as f:
         replace_placeholder "{{CONFIG_TROJAN}}" "$CONFIG_TROJAN"
     else
         replace_placeholder "{{CONFIG_TROJAN}}" "No Trojan config available"
+    fi
+
+    if [[ -n "$CONFIG_ANYTLS" ]]; then
+        replace_placeholder "{{CONFIG_ANYTLS}}" "$CONFIG_ANYTLS"
+    else
+        replace_placeholder "{{CONFIG_ANYTLS}}" "No AnyTLS config available"
     fi
 
     # CDN VLESS+WS config

--- a/scripts/singbox-user-add.sh
+++ b/scripts/singbox-user-add.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # =============================================================================
-# Add a new user to sing-box (Reality, Trojan, Hysteria2)
+# Add a new user to sing-box (Reality, Trojan, AnyTLS, Hysteria2)
 # Usage: ./scripts/singbox-user-add.sh <username> [--no-reload]
 # =============================================================================
 
@@ -144,6 +144,12 @@ jq --arg name "$USERNAME" --arg pass "$USER_PASSWORD" \
     "$TEMP_CONFIG" > "${TEMP_CONFIG}.2"
 mv -f "${TEMP_CONFIG}.2" "$TEMP_CONFIG"
 
+# Add to AnyTLS users (no-op if the anytls-in inbound isn't present)
+jq --arg name "$USERNAME" --arg pass "$USER_PASSWORD" \
+    '.inbounds |= map(if .tag == "anytls-in" then .users += [{"name": $name, "password": $pass}] else . end)' \
+    "$TEMP_CONFIG" > "${TEMP_CONFIG}.2"
+mv -f "${TEMP_CONFIG}.2" "$TEMP_CONFIG"
+
 # Add to Hysteria2 users
 jq --arg name "$USERNAME" --arg pass "$USER_PASSWORD" \
     '.inbounds |= map(if .tag == "hysteria2-in" then .users += [{"name": $name, "password": $pass}] else . end)' \
@@ -249,6 +255,12 @@ if [[ -n "${DOMAIN:-}" ]]; then
     echo "$TROJAN_LINK" > "$OUTPUT_DIR/trojan.txt"
 fi
 
+# AnyTLS link (IPv4) — only if enabled and domain is set (requires TLS cert)
+if [[ "${ENABLE_ANYTLS:-false}" == "true" ]] && [[ -n "${DOMAIN:-}" ]]; then
+    ANYTLS_LINK="anytls://${USER_PASSWORD}@${SERVER_IP}:${PORT_ANYTLS:-8445}?sni=${DOMAIN}&insecure=0#MoaV-AnyTLS-${USERNAME}"
+    echo "$ANYTLS_LINK" > "$OUTPUT_DIR/anytls.txt"
+fi
+
 # Hysteria2 link (IPv4) — only if domain is set (requires TLS cert)
 if [[ -n "${DOMAIN:-}" ]]; then
     HY2_LINK="hysteria2://${USER_PASSWORD}@${SERVER_IP}:443?sni=${DOMAIN}&obfs=salamander&obfs-password=${HYSTERIA2_OBFS_PASSWORD}#MoaV-Hysteria2-${USERNAME}"
@@ -264,6 +276,11 @@ if [[ -n "$SERVER_IPV6" ]]; then
         TROJAN_LINK_V6="trojan://${USER_PASSWORD}@[${SERVER_IPV6}]:8443?security=tls&sni=${DOMAIN}&type=tcp#MoaV-Trojan-${USERNAME}-IPv6"
         echo "$TROJAN_LINK_V6" > "$OUTPUT_DIR/trojan-ipv6.txt"
 
+        if [[ "${ENABLE_ANYTLS:-false}" == "true" ]]; then
+            ANYTLS_LINK_V6="anytls://${USER_PASSWORD}@[${SERVER_IPV6}]:${PORT_ANYTLS:-8445}?sni=${DOMAIN}&insecure=0#MoaV-AnyTLS-${USERNAME}-IPv6"
+            echo "$ANYTLS_LINK_V6" > "$OUTPUT_DIR/anytls-ipv6.txt"
+        fi
+
         HY2_LINK_V6="hysteria2://${USER_PASSWORD}@[${SERVER_IPV6}]:443?sni=${DOMAIN}&obfs=salamander&obfs-password=${HYSTERIA2_OBFS_PASSWORD}#MoaV-Hysteria2-${USERNAME}-IPv6"
         echo "$HY2_LINK_V6" > "$OUTPUT_DIR/hysteria2-ipv6.txt"
     fi
@@ -275,12 +292,14 @@ fi
 if command -v qrencode &>/dev/null; then
     qrencode -o "$OUTPUT_DIR/reality-qr.png" -s 6 "$REALITY_LINK" 2>/dev/null || true
     [[ -n "${TROJAN_LINK:-}" ]] && qrencode -o "$OUTPUT_DIR/trojan-qr.png" -s 6 "$TROJAN_LINK" 2>/dev/null || true
+    [[ -n "${ANYTLS_LINK:-}" ]] && qrencode -o "$OUTPUT_DIR/anytls-qr.png" -s 6 "$ANYTLS_LINK" 2>/dev/null || true
     [[ -n "${HY2_LINK:-}" ]] && qrencode -o "$OUTPUT_DIR/hysteria2-qr.png" -s 6 "$HY2_LINK" 2>/dev/null || true
 
     # IPv6 QR codes
     if [[ -n "$SERVER_IPV6" ]]; then
         qrencode -o "$OUTPUT_DIR/reality-ipv6-qr.png" -s 6 "$REALITY_LINK_V6" 2>/dev/null || true
         [[ -n "${TROJAN_LINK_V6:-}" ]] && qrencode -o "$OUTPUT_DIR/trojan-ipv6-qr.png" -s 6 "$TROJAN_LINK_V6" 2>/dev/null || true
+        [[ -n "${ANYTLS_LINK_V6:-}" ]] && qrencode -o "$OUTPUT_DIR/anytls-ipv6-qr.png" -s 6 "$ANYTLS_LINK_V6" 2>/dev/null || true
         [[ -n "${HY2_LINK_V6:-}" ]] && qrencode -o "$OUTPUT_DIR/hysteria2-ipv6-qr.png" -s 6 "$HY2_LINK_V6" 2>/dev/null || true
     fi
 fi
@@ -824,6 +843,11 @@ if [[ -n "${TROJAN_LINK:-}" ]]; then
     echo "Trojan Link:"
     echo "$TROJAN_LINK"
 fi
+if [[ -n "${ANYTLS_LINK:-}" ]]; then
+    echo ""
+    echo "AnyTLS Link:"
+    echo "$ANYTLS_LINK"
+fi
 if [[ -n "${HY2_LINK:-}" ]]; then
     echo ""
     echo "Hysteria2 Link:"
@@ -840,6 +864,11 @@ if [[ -n "${SERVER_IPV6:-}" ]]; then
         echo ""
         echo "Trojan (IPv6):"
         echo "$TROJAN_LINK_V6"
+    fi
+    if [[ -n "${ANYTLS_LINK_V6:-}" ]]; then
+        echo ""
+        echo "AnyTLS (IPv6):"
+        echo "$ANYTLS_LINK_V6"
     fi
     if [[ -n "${HY2_LINK_V6:-}" ]]; then
         echo ""

--- a/scripts/singbox-user-revoke.sh
+++ b/scripts/singbox-user-revoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # =============================================================================
-# Revoke a user from sing-box (Reality, Trojan, Hysteria2)
+# Revoke a user from sing-box (Reality, Trojan, AnyTLS, Hysteria2)
 # Usage: ./scripts/singbox-user-revoke.sh <username>
 # =============================================================================
 

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -153,6 +153,7 @@ if [[ -n "$DONATE_ONLY" ]]; then
     # Enable/disable based on donate list
     echo " $DONATE_ONLY " | grep -q " reality "   && ENABLE_REALITY=true   || ENABLE_REALITY=false
     echo " $DONATE_ONLY " | grep -q " trojan "    && ENABLE_TROJAN=true    || ENABLE_TROJAN=false
+    echo " $DONATE_ONLY " | grep -q " anytls "    && ENABLE_ANYTLS=true    || ENABLE_ANYTLS=false
     echo " $DONATE_ONLY " | grep -q " hysteria2 " && ENABLE_HYSTERIA2=true || ENABLE_HYSTERIA2=false
     echo " $DONATE_ONLY " | grep -q " telegram "  && ENABLE_TELEMT=true    || ENABLE_TELEMT=false
     echo " $DONATE_ONLY " | grep -q " xhttp "     && ENABLE_XHTTP=true    || ENABLE_XHTTP=false
@@ -232,10 +233,10 @@ for USERNAME in "${USERNAMES[@]}"; do
     fi
 
     # -------------------------------------------------------------------------
-    # Add to sing-box (Reality, Trojan, Hysteria2)
+    # Add to sing-box (Reality, Trojan, AnyTLS, Hysteria2)
     # -------------------------------------------------------------------------
     if [[ -f "configs/sing-box/config.json" ]]; then
-        log_info "[1/3] Adding to sing-box (Reality, Trojan, Hysteria2)..."
+        log_info "[1/3] Adding to sing-box (Reality, Trojan, AnyTLS, Hysteria2)..."
         if "$SCRIPT_DIR/singbox-user-add.sh" "$USERNAME" $RELOAD_FLAG; then
             log_info "✓ sing-box user added"
         else
@@ -716,6 +717,7 @@ if [[ -f "$TEMPLATE_FILE" ]]; then
     CONFIG_REALITY=$(cat "$OUTPUT_DIR/reality.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_HYSTERIA2=$(cat "$OUTPUT_DIR/hysteria2.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_TROJAN=$(cat "$OUTPUT_DIR/trojan.txt" 2>/dev/null | tr -d '\n' || echo "")
+    CONFIG_ANYTLS=$(cat "$OUTPUT_DIR/anytls.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_SHADOWSOCKS=$(cat "$OUTPUT_DIR/shadowsocks.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_CDN=$(cat "$OUTPUT_DIR/cdn-vless.txt" 2>/dev/null | tr -d '\n' || echo "")
     CONFIG_WIREGUARD=$(cat "$OUTPUT_DIR/wireguard.conf" 2>/dev/null || echo "")
@@ -770,6 +772,7 @@ if [[ -f "$TEMPLATE_FILE" ]]; then
     QR_REALITY_B64=$(qr_to_base64 "$OUTPUT_DIR/reality-qr.png")
     QR_HYSTERIA2_B64=$(qr_to_base64 "$OUTPUT_DIR/hysteria2-qr.png")
     QR_TROJAN_B64=$(qr_to_base64 "$OUTPUT_DIR/trojan-qr.png")
+    QR_ANYTLS_B64=$(qr_to_base64 "$OUTPUT_DIR/anytls-qr.png")
     QR_WIREGUARD_B64=$(qr_to_base64 "$OUTPUT_DIR/wireguard-qr.png")
     QR_WIREGUARD_WSTUNNEL_B64=$(qr_to_base64 "$OUTPUT_DIR/wireguard-wstunnel-qr.png")
     QR_AMNEZIAWG_B64=$(qr_to_base64 "$OUTPUT_DIR/amneziawg-qr.png")
@@ -822,6 +825,7 @@ with open(filepath, 'w') as f:
     sed -i.bak "s|{{QR_REALITY}}|$QR_REALITY_B64|g" "$OUTPUT_HTML"
     sed -i.bak "s|{{QR_HYSTERIA2}}|$QR_HYSTERIA2_B64|g" "$OUTPUT_HTML"
     sed -i.bak "s|{{QR_TROJAN}}|$QR_TROJAN_B64|g" "$OUTPUT_HTML"
+    sed -i.bak "s|{{QR_ANYTLS}}|$QR_ANYTLS_B64|g" "$OUTPUT_HTML"
     sed -i.bak "s|{{QR_WIREGUARD}}|$QR_WIREGUARD_B64|g" "$OUTPUT_HTML"
     sed -i.bak "s|{{QR_WIREGUARD_WSTUNNEL}}|$QR_WIREGUARD_WSTUNNEL_B64|g" "$OUTPUT_HTML"
     sed -i.bak "s|{{QR_AMNEZIAWG}}|$QR_AMNEZIAWG_B64|g" "$OUTPUT_HTML"
@@ -845,6 +849,12 @@ with open(filepath, 'w') as f:
         replace_placeholder "{{CONFIG_TROJAN}}" "$CONFIG_TROJAN"
     else
         replace_placeholder "{{CONFIG_TROJAN}}" "No Trojan config available"
+    fi
+
+    if [[ -n "$CONFIG_ANYTLS" ]]; then
+        replace_placeholder "{{CONFIG_ANYTLS}}" "$CONFIG_ANYTLS"
+    else
+        replace_placeholder "{{CONFIG_ANYTLS}}" "No AnyTLS config available"
     fi
 
     if [[ -n "$CONFIG_SHADOWSOCKS" ]]; then
@@ -957,10 +967,10 @@ with open(html_path, 'w') as f: f.write(html)
     # Hiddify, ...) to import all proxy protocols. DNS tunnels + GooseRelay are
     # configured separately and intentionally excluded.
     _mahsanet_uris=""
-    for _f in reality cdn-vless xhttp-vless trojan shadowsocks hysteria2 \
-              reality-ipv6 trojan-ipv6 shadowsocks-ipv6 hysteria2-ipv6; do
+    for _f in reality cdn-vless xhttp-vless trojan anytls shadowsocks hysteria2 \
+              reality-ipv6 trojan-ipv6 anytls-ipv6 shadowsocks-ipv6 hysteria2-ipv6; do
         [[ -f "$OUTPUT_DIR/$_f.txt" ]] || continue
-        _u=$(tr -d '\r' < "$OUTPUT_DIR/$_f.txt" | grep -aE '^(vless|trojan|ss|hysteria2|vmess)://' | head -1 || true)
+        _u=$(tr -d '\r' < "$OUTPUT_DIR/$_f.txt" | grep -aE '^(vless|trojan|anytls|ss|hysteria2|vmess)://' | head -1 || true)
         [[ -n "$_u" ]] && _mahsanet_uris+="$_u"$'\n'
     done
     if [[ -n "$_mahsanet_uris" ]]; then


### PR DESCRIPTION
## Summary

Adds **AnyTLS** as a new proxy protocol by mirroring the Trojan path end-to-end. AnyTLS is **native to sing-box** (we run 1.13.12), so it reuses the existing sing-box container, engine, and the **Trojan TLS certificate/domain** — no new Dockerfile or sidecar. It's **opt-in** (`ENABLE_ANYTLS=false`) on **TCP port 8445** and defeats TLS-in-TLS fingerprinting for higher stealth than Trojan.

## What's wired (per `docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md`)

- **Config**: `anytls-in` inbound (password `users`, TLS reusing `${DOMAIN}` cert/key like Trojan)
- **Env/compose**: `ENABLE_ANYTLS`, `PORT_ANYTLS=8445`, port mapping, bootstrap env passthrough
- **Bootstrap**: `domain_required`, per-user `ANYTLS_USERS_JSON` accumulator, `jq`-prune of the inbound when disabled
- **User provisioning**: `generate-user` / `generate-single-user` / `user-add` / `singbox-user-add` emit `anytls.txt` + a valid `anytls://` URI (IPv4 + bracketed IPv6), QR, sing-box client JSON, and HTML bundle vars; revoke is generic (removes the user from every inbound incl. `anytls-in`)
- **moav.sh**: proxy-profile enable logic, `status`, domainless disable list, `regenerate-users` env passthrough, no-domain cert warning
- **Client**: `client-connect.sh` (priority + outbound generation) and `client-test.sh` (`test_anytls` on SOCKS port 10805) gain AnyTLS; `Dockerfile.client` protocol comment
- **Docs**: README (EN/FA), SETUP, CLIENTS, TROUBLESHOOTING, protocols, `client-guide-template.html` (EN + FA)

### Out of scope (intentionally)
- **No new Dockerfile/entrypoint/`configs/` dir** — native sing-box inbound, lives inside `config.json` (already gitignored), so no `.gitignore` change needed.
- **No Grafana per-protocol dashboard** — sing-box is monitored by a single `singbox-users` exporter (no per-protocol pattern exists for Trojan/Hysteria2), so AnyTLS traffic surfaces there automatically.
- **No version var** — AnyTLS ships inside sing-box; no separate rebuild trigger.

## Client support (honest)
Narrower than VLESS/Trojan: **Hiddify, sing-box (SFA/SFI), NekoBox/NekoRay, mihomo (Mihomo Party), Shadowrocket 2.2.65+**. Clash-only/older clients (v2rayNG, Streisand, V2Box, Clash Verge) do **not** support AnyTLS and are documented as such.

## Verification
- ✅ `sing-box check` (v1.13.12, same as the Docker healthcheck) passes on the rendered template with the AnyTLS inbound
- ✅ Emitted `anytls://` URI (IPv4 + IPv6) parses cleanly through the moav-client subscription parser
- ✅ `bash -n` on all modified scripts
- ✅ `docker compose config` valid (port 8445 published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)