### PR TITLE
test(client): add Shadowsocks-2022 + XDNS connectivity tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Testing
+- **`moav test` now covers Shadowsocks-2022 and XDNS** — two protocols that are **on by default** but previously had no connectivity test. `test_ss` decodes the bundle's `ss://` SIP002 URI (base64url `method:server_psk:user_psk`) and drives a sing-box shadowsocks outbound over a local SOCKS port, verifying a real exit IP. `test_xdns` runs the bundle's own Xray client config (`xdns-direct-config.json`, falling back to the via-DNS config) and checks connectivity through its SOCKS inbound, with a longer timeout and warn-on-failure since DNS tunnels are slow/fragile. Both appear in the human and JSON result summaries. First step of the v2 testing epic (remaining gaps: MasterDNS, wstunnel, GooseRelay, and a stronger telemt check)
+
 ### Documentation
 - **v2 docs & compatibility sweep** — reconciled the docs with the shipped 1.8.5 feature set: added a Certificates section to `docs/CLI.md` (`moav cert status/renew/install/uninstall`, `CERT_AUTORENEW`); added the missing **Shadowsocks-2022** section + overview-table row and an **`XDNS_METHOD`** (txt/aaaa) row to `docs/protocols.md`, and updated the wstunnel entry to describe `wss://` + the path secret; added **AnyTLS** to `docs/architecture.md` (plus a new Security & isolation / Service lifecycle section) and to the human-visible/structured surfaces of `site/index.html`, and fixed a stale "version 1.8.2" string there; documented the admin empty-password **fail-closed (503)** behavior in `docs/OPSEC.md`; refreshed `site/llms.txt`
 

--- a/scripts/client-test.sh
+++ b/scripts/client-test.sh
@@ -452,6 +452,171 @@ EOF
     wait $pid 2>/dev/null || true
 }
 
+# Test Shadowsocks-2022 (sing-box shadowsocks outbound via local SOCKS)
+test_ss() {
+    log_info "Testing Shadowsocks-2022..."
+
+    local config_file="" detail="" is_ipv6=false
+
+    for f in "$CONFIG_DIR"/shadowsocks.txt "$CONFIG_DIR"/shadowsocks*.txt; do
+        [[ -f "$f" ]] && config_file="$f" && break
+    done
+    if [[ -z "$config_file" ]]; then
+        detail="No Shadowsocks config found in bundle"
+        log_warn "$detail"
+        RESULTS[shadowsocks]="skip"; DETAILS[shadowsocks]="$detail"; return
+    fi
+    [[ "$config_file" == *ipv6* ]] && is_ipv6=true
+
+    local uri; uri=$(cat "$config_file" | tr -d '\n\r')
+    local server; server=$(extract_host "$uri")
+    local port; port=$(extract_port "$uri")
+    port=$(echo "$port" | tr -cd '0-9'); [[ -z "$port" ]] && port="8388"
+
+    # userinfo = base64url-nopad(method:server_psk:user_psk) — decode and split
+    local userinfo="${uri#ss://}"; userinfo="${userinfo%%@*}"
+    local b64; b64=$(echo "$userinfo" | tr '_-' '/+')
+    local pad=$(( (4 - ${#b64} % 4) % 4 ))
+    [[ $pad -gt 0 ]] && b64="${b64}$(printf '=%.0s' $(seq 1 $pad))"
+    local decoded; decoded=$(printf '%s' "$b64" | base64 -d 2>/dev/null)
+    local method="${decoded%%:*}"
+    local password="${decoded#*:}"   # server_psk:user_psk
+
+    if [[ -z "$server" || -z "$decoded" || "$method" == "$decoded" || -z "$password" ]]; then
+        detail="Failed to parse Shadowsocks URI (run with -v for details)"
+        log_error "$detail"
+        log_debug "server='$server' method='$method' decoded='${decoded:0:16}...'"
+        RESULTS[shadowsocks]="fail"; DETAILS[shadowsocks]="$detail"; return
+    fi
+
+    log_debug "Parsed: server=$server port=$port method=$method"
+
+    local client_config="$TEMP_DIR/ss-client.json"
+    cat > "$client_config" << EOF
+{
+  "log": {"level": "error"},
+  "inbounds": [
+    {"type": "socks", "listen": "127.0.0.1", "listen_port": 10807}
+  ],
+  "outbounds": [
+    {
+      "type": "shadowsocks",
+      "tag": "proxy",
+      "server": "$server",
+      "server_port": $port,
+      "method": "$method",
+      "password": "$password"
+    }
+  ],
+  "route": {"final": "proxy"}
+}
+EOF
+
+    if ! jq empty "$client_config" 2>/dev/null; then
+        detail="Generated invalid JSON config"
+        log_error "$detail"; RESULTS[shadowsocks]="fail"; DETAILS[shadowsocks]="$detail"; return
+    fi
+
+    local error_log="$TEMP_DIR/ss-error.log"
+    sing-box run -c "$client_config" 2>"$error_log" &
+    local pid=$!
+    sleep 3
+
+    if ! kill -0 $pid 2>/dev/null; then
+        detail="sing-box failed to start"
+        [[ -s "$error_log" ]] && detail="sing-box error: $(tail -5 "$error_log" 2>/dev/null | tr '\n' ' ' || true)"
+        log_error "$detail"; RESULTS[shadowsocks]="fail"; DETAILS[shadowsocks]="$detail"; return
+    fi
+
+    if curl -sf --socks5 127.0.0.1:10807 --max-time "$TEST_TIMEOUT" "$TEST_URL" >/dev/null 2>&1; then
+        local exit_ip=""
+        exit_ip=$(curl -sf --socks5 127.0.0.1:10807 --max-time "$TEST_TIMEOUT" https://api.ipify.org 2>/dev/null || \
+                  curl -sf --socks5 127.0.0.1:10807 --max-time "$TEST_TIMEOUT" https://ifconfig.me 2>/dev/null || true)
+        if [[ -n "$exit_ip" ]]; then
+            log_success "Shadowsocks-2022 connection successful (exit IP: $exit_ip)"
+            RESULTS[shadowsocks]="pass"; DETAILS[shadowsocks]="Connected via Shadowsocks-2022, exit IP: $exit_ip"
+        else
+            log_success "Shadowsocks-2022 connection successful"
+            RESULTS[shadowsocks]="pass"; DETAILS[shadowsocks]="Connected via Shadowsocks-2022"
+        fi
+    else
+        detail="Connection test failed"
+        [[ -s "$error_log" ]] && { local em; em=$(grep -i "error\|fail\|unreachable\|timeout\|refused" "$error_log" 2>/dev/null | tail -3 | tr '\n' ' ' || true); [[ -n "$em" ]] && detail="$em"; }
+        if [[ "$is_ipv6" == "true" ]] && echo "$detail" | grep -qi "unreachable\|network"; then
+            log_warn "IPv6 config - $detail"
+            RESULTS[shadowsocks]="warn"; DETAILS[shadowsocks]="IPv6 network may not be available: $detail"
+        else
+            log_error "$detail"; RESULTS[shadowsocks]="fail"; DETAILS[shadowsocks]="$detail"
+        fi
+    fi
+
+    kill $pid 2>/dev/null || true
+    wait $pid 2>/dev/null || true
+}
+
+# Test XDNS (Xray mKCP + FinalMask DNS tunnel) using the bundle's own xray
+# client config. Prefers direct mode (more stable) over via-DNS mode. XDNS is
+# slow/experimental, so a connection failure is a warn, not a hard fail.
+test_xdns() {
+    log_info "Testing XDNS (DNS tunnel via Xray mKCP)..."
+
+    local config_file="" detail=""
+    for f in "$CONFIG_DIR"/xdns-direct-config.json "$CONFIG_DIR"/xdns-config.json; do
+        [[ -f "$f" ]] && config_file="$f" && break
+    done
+    if [[ -z "$config_file" ]]; then
+        detail="No XDNS config found in bundle"
+        log_warn "$detail"
+        RESULTS[xdns]="skip"; DETAILS[xdns]="$detail"; return
+    fi
+
+    if ! command -v xray >/dev/null 2>&1; then
+        detail="xray binary not available in this environment"
+        log_warn "$detail"
+        RESULTS[xdns]="skip"; DETAILS[xdns]="$detail"; return
+    fi
+
+    if ! jq empty "$config_file" 2>/dev/null; then
+        detail="Bundle XDNS config is invalid JSON"
+        log_error "$detail"; RESULTS[xdns]="fail"; DETAILS[xdns]="$detail"; return
+    fi
+
+    log_debug "Using XDNS config: $config_file (SOCKS 127.0.0.1:7891)"
+
+    local error_log="$TEMP_DIR/xdns-error.log"
+    xray run -c "$config_file" 2>"$error_log" &
+    local pid=$!
+    sleep 4   # mKCP handshake over DNS is slower than a direct TCP dial
+
+    if ! kill -0 $pid 2>/dev/null; then
+        detail="xray failed to start"
+        [[ -s "$error_log" ]] && detail="xray error: $(tail -5 "$error_log" 2>/dev/null | tr '\n' ' ' || true)"
+        log_error "$detail"; RESULTS[xdns]="fail"; DETAILS[xdns]="$detail"; return
+    fi
+
+    # XDNS is high-latency; give it a longer ceiling than the default timeout.
+    local xdns_timeout=$(( TEST_TIMEOUT > 20 ? TEST_TIMEOUT : 20 ))
+    if curl -sf --socks5 127.0.0.1:7891 --max-time "$xdns_timeout" "$TEST_URL" >/dev/null 2>&1; then
+        local exit_ip=""
+        exit_ip=$(curl -sf --socks5 127.0.0.1:7891 --max-time "$xdns_timeout" https://api.ipify.org 2>/dev/null || true)
+        if [[ -n "$exit_ip" ]]; then
+            log_success "XDNS connection successful (exit IP: $exit_ip)"
+            RESULTS[xdns]="pass"; DETAILS[xdns]="Connected via XDNS, exit IP: $exit_ip"
+        else
+            log_success "XDNS connection successful"
+            RESULTS[xdns]="pass"; DETAILS[xdns]="Connected via XDNS"
+        fi
+    else
+        detail="XDNS connection test failed (DNS tunnels are slow/fragile — may need a reachable resolver)"
+        [[ -s "$error_log" ]] && { local em; em=$(grep -i "error\|fail\|unreachable\|timeout\|refused" "$error_log" 2>/dev/null | tail -3 | tr '\n' ' ' || true); [[ -n "$em" ]] && detail="$em"; }
+        log_warn "$detail"
+        RESULTS[xdns]="warn"; DETAILS[xdns]="$detail"
+    fi
+
+    kill $pid 2>/dev/null || true
+    wait $pid 2>/dev/null || true
+}
+
 # Test AnyTLS protocol (sing-box native, password-auth TLS, reuses Trojan cert)
 test_anytls() {
     log_info "Testing AnyTLS..."
@@ -1789,7 +1954,7 @@ output_json() {
 EOF
 
     local first=true
-    for protocol in reality trojan anytls hysteria2 wireguard amneziawg dnstt slipstream trusttunnel telemt; do
+    for protocol in reality trojan anytls hysteria2 shadowsocks wireguard amneziawg dnstt slipstream xdns trusttunnel telemt; do
         if [[ -n "${RESULTS[$protocol]:-}" ]]; then
             [[ "$first" != "true" ]] && echo ","
             first=false
@@ -1820,7 +1985,7 @@ output_human() {
     echo ""
     echo "───────────────────────────────────────────────────────────────"
 
-    for protocol in reality trojan anytls hysteria2 wireguard amneziawg dnstt slipstream trusttunnel telemt; do
+    for protocol in reality trojan anytls hysteria2 shadowsocks wireguard amneziawg dnstt slipstream xdns trusttunnel telemt; do
         if [[ -n "${RESULTS[$protocol]:-}" ]]; then
             local status="${RESULTS[$protocol]}"
             local detail="${DETAILS[$protocol]:-}"
@@ -1858,11 +2023,13 @@ main() {
     test_trojan
     test_anytls
     test_hysteria2
+    test_ss
     test_xhttp
     test_wireguard
     test_amneziawg
     test_dnstt
     test_slipstream
+    test_xdns
     test_trusttunnel
     test_telemt
 


### PR DESCRIPTION
Epic 2 (testing) of the v2 program — close the two **default-on but untested** protocol gaps first. `ENABLE_SS=true` and `ENABLE_XDNS=true` ship on by default, yet `moav test` had no coverage for either.

## What's added to `scripts/client-test.sh`

**`test_ss` (Shadowsocks-2022)** — mirrors `test_trojan`. Finds `shadowsocks.txt`, decodes the SIP002 `ss://` URI (base64url-nopad of `method:server_psk:user_psk`, converting `_-`→`/+` and re-padding), and builds a sing-box `shadowsocks` outbound on a local SOCKS port (10807), then verifies a real exit IP via `api.ipify.org`. IPv6-config network-unreachable degrades to `warn`, matching the other sing-box tests.

**`test_xdns` (Xray mKCP + FinalMask DNS tunnel)** — reuses the bundle's **own** xray client config rather than authoring one blind: runs `xray run -c xdns-direct-config.json` (falls back to the via-DNS `xdns-config.json`), which exposes SOCKS on `127.0.0.1:7891`, and checks connectivity through it. Because DNS tunnels are slow and resolver-dependent, it uses a longer timeout and treats a connection failure as **`warn`, not `fail`** (and `skip`s cleanly if xray isn't present).

Both are wired into `main()` and into the JSON + human result summaries (`shadowsocks`, `xdns` keys).

## Validation

- `bash -n` + `shellcheck -S error` clean.
- The riskiest part — the SS base64url `method:password` decode — was **round-trip validated locally** against the exact encoding `generate-user.sh` produces (`printf 'method:spsk:upsk' | base64 | tr -d '\n=' | tr '/+' '_-'`): method and `server_psk:user_psk` password come back correctly.
- **Full exit-IP verification requires a live server bundle + the client container**, which isn't available here. The upcoming **CI e2e harness** card (compose-up → generate bundle → `client-test.sh`) is what will exercise these against a real stack; until then they follow the established pattern of the 11 existing tests, which are validated the same way.

## Not in this PR (tracked as separate Epic 2 cards)

MasterDNS / wstunnel / GooseRelay coverage, a stronger telemt check (beyond `nc -z`), the `moav cert` test, the CI pipeline, the e2e harness, and the LLM testing skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)