### PR TITLE
fix(telegram): full release body + cleaner markdown + shield emoji

### DIFF
--- a/.github/scripts/telegram_format.py
+++ b/.github/scripts/telegram_format.py
@@ -11,7 +11,11 @@ import html
 import os
 import re
 
-MAX_BODY = 900  # keep the whole message well under Telegram's 4096-char cap
+# Release-notes bodies are typically 1–3 KB; Telegram's hard cap is 4096 chars
+# (raw text incl. HTML tags). 3500 leaves ample room for the header + footer
+# links while fitting a full release section without truncation.
+MAX_BODY = 3500
+HEADER_EMOJI = "🛡️"  # release header icon — change here (or set to "" for none)
 
 
 def esc(s: str) -> str:
@@ -19,9 +23,13 @@ def esc(s: str) -> str:
 
 
 def demarkdown(s: str) -> str:
-    """Light-touch: strip markdown that renders as noise in HTML mode."""
-    s = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", s)  # [text](url) -> text
-    s = s.replace("**", "").replace("`", "")
+    """Light-touch: strip markdown that renders as literal noise in HTML mode."""
+    s = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", s)         # [text](url) -> text
+    s = re.sub(r"^```[a-zA-Z0-9]*[ \t]*$", "", s, flags=re.M)  # code-fence lines
+    s = re.sub(r"^#{1,6}[ \t]*", "", s, flags=re.M)        # # headers -> plain
+    s = re.sub(r"^[ \t]*[-*_]{3,}[ \t]*$", "", s, flags=re.M)  # --- hr rules
+    s = s.replace("**", "").replace("`", "")               # bold / code spans
+    s = re.sub(r"\n{3,}", "\n\n", s)                       # collapse blank runs
     return s
 
 
@@ -29,7 +37,13 @@ def trim(s: str, limit: int = MAX_BODY) -> str:
     s = s.strip()
     if len(s) <= limit:
         return s
-    return s[:limit].rsplit("\n", 1)[0].rstrip() + "\n…"
+    cut = s[:limit]
+    # Prefer to end on a newline, but only if one is near the end — otherwise a
+    # long single-line bullet would collapse the whole body back to its header.
+    nl = cut.rfind("\n")
+    if nl >= limit - 300:
+        cut = cut[:nl]
+    return cut.rstrip() + "\n…"
 
 
 def link(url: str, text: str) -> str:
@@ -40,7 +54,8 @@ def release() -> str:
     name = os.environ.get("REL_NAME") or os.environ.get("REL_TAG") or "New release"
     url = os.environ.get("REL_URL", "")
     body = trim(demarkdown(os.environ.get("REL_BODY", "")))
-    out = [f"🧅 <b>{esc(name)}</b> is out"]
+    head = f"{HEADER_EMOJI} " if HEADER_EMOJI else ""
+    out = [f"{head}<b>{esc(name)}</b> is out"]
     if body:
         out += ["", esc(body)]
     out += ["", f"📦 {link(url, 'Release notes & downloads')}",


### PR DESCRIPTION
Follow-up to #161. The first live release post came through truncated to just `🧅 <b>v1.9.1</b> is out` + `### Fixed` + `…`.

## Cause
Two bugs in `telegram_format.py`:
1. Body cap was **900 chars** — real release notes are ~2–3 KB (v1.9.1 is 2360), so it cut almost immediately.
2. The truncation trimmed back to the last newline — and v1.9.1's first bullet is one ~900-char line, so that collapsed the body all the way back to the `### Fixed` header.

## Fix
- Cap **900 → 3500** (full release section fits; total message stays under Telegram's 4096).
- Truncation only trims to a newline if one is near the cut; otherwise hard-cuts — a long single-line bullet can't collapse the body to its header anymore.
- Strip markdown that renders as literal noise now the full body shows: `#` headers, ``` ``` ``` code fences, `---` rules; collapse blank runs.
- **Header emoji 🧅 → 🛡️** (per request) — a `HEADER_EMOJI` constant, set `""` for none.

## Verified
Rendered the **real v1.9.1** release body (2360 chars): full notes + the install one-liner come through, clean formatting, 2200-char message, no truncation.

Note: #161 was merged before these landed, so this is a separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)