### PR TITLE
fix(ci): strict-mode control test missed the bash>=4 guarded-probe outcome

### DIFF
--- a/tests/strict-mode-test.sh
+++ b/tests/strict-mode-test.sh
@@ -54,8 +54,9 @@ out=$(
   f
 ) 2>&1 || out="crashed:$out"
 case "$out" in
-    *"unbound variable"*)      ok "unguarded read fails loudly on this bash (>=4.x)";;
+    *"unbound variable"*)      ok "unguarded read fails loudly on this bash (>=4.x, bare read)";;
     "present=yes value=[]")    ok "unguarded read yields an empty key on this bash (3.2)";;
+    "present= value=[]")       ok "unguarded read leaves the key unset on this bash (>=4.x)";;
     *) bad "unguarded read produced something unexpected: '$out'";;
 esac
 


### PR DESCRIPTION
CI has been red since D1 (#197): the control case enumerated the bash 3.2 outcome and the bare-read crash, but the probe itself uses guarded expansions, so bash ≥ 4 prints a third outcome (`present= value=[]`) the case statement rejected. My local bash 3.2 masked it, and the D-series merge gates polled e2e only — so four PRs merged over red CI unnoticed.

All three outcomes prove the same invariant (the key never arrives); the third is now accepted. Verified 15/15 on bash 3.2 and bash 5.2 (docker). Gating this PR on **CI**, not e2e — it's a test-only change and CI is the thing that's broken.