### PR TITLE
test: refactor verification harness + checklist doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: bash tests/net-alloc-test.sh
       - name: strict-mode regression test
         run: bash tests/strict-mode-test.sh
+      - name: refactor verification (static)
+        run: bash tests/refactor-verify.sh
       - name: protocol-roster drift gate
         run: python3 scripts/gen-protocol-docs.py --check
 

--- a/docs/devdocs/REFACTOR-VERIFICATION.md
+++ b/docs/devdocs/REFACTOR-VERIFICATION.md
@@ -1,0 +1,99 @@
+# Refactor Verification Checklist
+
+The mechanical gate every v2-refactor PR ran through. Written down so any
+contributor — human or model, including cheaper models than the one that ran
+the sprint — can follow it verbatim. **Every rule here exists because its
+absence caused a real incident during the v2 sprint**; the incident is cited so
+the rule doesn't decay into cargo cult.
+
+Most of it is automated:
+
+```bash
+tests/refactor-verify.sh                    # static checks (also run by ci.yml)
+tests/refactor-verify.sh compare origin/dev # + conservation & behaviour diff
+```
+
+## The rules
+
+### 1. Everything parses, tests pass locally
+`bash -n` every changed file; run `tests/strict-mode-test.sh` and
+`tests/net-alloc-test.sh`. Automated by `refactor-verify.sh`.
+
+### 2. No duplicate function definitions across `moav.sh` + `lib/*.sh`
+A duplicate means an extraction left a copy behind — the sourced module
+silently shadows the dispatcher copy or vice versa.
+*Incident:* a hunk-wise merge resolution left the nettune block in **both**
+files (11 shadowed functions); only this check caught it. Automated.
+
+### 3. Behaviour diffs vs a clean worktree, byte-for-byte including exit codes
+Compare affected subcommands against a `git worktree` of the base ref — never
+against a stash or an in-place checkout.
+*Incident:* a `git stash`-based harness swapped the untracked `.env` between
+runs and manufactured a phantom regression.
+
+Two hard sub-rules:
+- **Non-mutating commands only.** Bare `moav` and `moav bootstrap --help` are
+  not read-only — both create a `.env` in the clone. (Happened twice.)
+- **Normalise the banner** (`v<ver> (<branch>)`): a detached worktree prints
+  `(HEAD)` and the box padding shifts with branch-name length.
+
+Automated for the common commands by `compare` mode.
+
+### 4. Gate merges on BOTH `ci.yml` AND `e2e.yml`; verify the merge landed
+Poll both workflows, and afterwards check `gh pr view N --json state` says
+`MERGED` — never trust the merge call's exit status or your own script's
+happy path.
+*Incidents:* (a) a gate script echoed "#195 MERGED" unconditionally over a
+merge-conflict error; (b) four D-series PRs merged over a **red CI** because
+the gate polled e2e only. Both in one sprint.
+
+### 5. On squash-merge conflicts: replay, don't resolve
+When your base branch was squash-merged into dev, your branch's parents no
+longer exist and the PR shows conflicts. **Re-apply the change onto fresh
+`dev` and force-push** (`--force-with-lease`); do not resolve hunks.
+*Incident:* hunk-wise resolution is what produced the duplicate-module bug in
+rule 2. The replay for B13 came out byte-identical to the original — that
+equality is itself a useful check.
+
+### 6. A new test must fail on unfixed dev before it counts
+Run the test against a clean worktree of pre-fix `dev` and watch it fail; then
+watch it pass on your branch. A test that passes everywhere proves nothing.
+*Incidents:* this rule caught a grep pattern being parsed as a grep option
+(assertions silently vacuous) and a wrong helper name in a guard.
+
+### 7. Bash tests run on bash 5 too, not just your shell
+macOS ships bash 3.2 and its semantics differ in ways that matter
+(`local x` unassigned reads as *set*; `declare -A` doesn't exist).
+
+```bash
+docker run --rm -v "$PWD":/r -w /r bash:5.2 bash tests/strict-mode-test.sh
+```
+
+*Incident:* the strict-mode control test enumerated only the 3.2 outcome and
+a bare-read crash; CI's bash 5 produced a third outcome and **CI was red for
+four merged PRs** before anyone noticed.
+
+### 8. Re-measure any plan estimate before acting on it
+Grep counts are not call-site reading.
+*Incidents:* the plan's `compose()` item claimed "100+ calls with ad-hoc
+`--profile`/`sudo`" — measured: 149 calls, **zero** sudo. The four "duplicate"
+sudo-detection copies turned out to have deliberately different error
+behaviour. Both items were descoped after measurement.
+
+## Also worth knowing (sprint folklore that cost time)
+
+- `lib/` modules use `error`/`warn`/`info` from `lib/common.sh`;
+  `log_error`/`log_warn`/`log_info` belong to `scripts/lib/common.sh`. Mixing
+  them turns an error message into `command not found`. (Checked by the
+  harness.)
+- Host `state/users/` ≠ the `moav_moav_state` docker volume. Container paths
+  read the **volume**. Measuring the host dir once produced a false alarm that
+  ~110 users would break.
+- `set +e` cannot catch a `set -u` violation — the shell exits outright. Tests
+  for that class must assert on process survival, not return codes.
+- A `${VAR:-}` default is not automatically the right fix for an unbound-variable
+  crash: in a bundle generator it trades a loud failure for a silently broken
+  client config. Prefer a required-value assertion with a remediation hint.
+- Merges to dev: use `gh pr merge` (local `git merge` is blocked). Docs-only
+  PRs gate on CI; anything touching runtime code gates on CI **and** e2e
+  (`gh workflow run e2e.yml --ref <branch> -f tier=default`).

--- a/tests/refactor-verify.sh
+++ b/tests/refactor-verify.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Refactor verification harness. Automates the mechanical checks every v2
+# refactor PR was gated on (see docs/devdocs/REFACTOR-VERIFICATION.md for the
+# full checklist and the incidents behind each rule).
+#
+# Usage:
+#   tests/refactor-verify.sh                 # static checks (CI-safe, no base needed)
+#   tests/refactor-verify.sh compare <ref>   # + conservation & behaviour diff vs <ref>
+#
+# Static mode is wired into ci.yml. Compare mode is for local pre-PR use:
+#   tests/refactor-verify.sh compare origin/dev
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="${1:-static}"
+BASE_REF="${2:-}"
+
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+# Function-definition census across the dispatcher + its modules.
+# Deliberately the same grep every B-series PR used.
+fn_defs() { # $1 = dir to census
+    cat <(grep -ho '^[a-z_][a-z0-9_]*() {' "$1/moav.sh") \
+        <(grep -ho '^[a-z_][a-z0-9_]*() {' "$1"/lib/*.sh) 2>/dev/null
+}
+
+echo "refactor-verify: static checks"
+
+# --- 1. everything parses -----------------------------------------------------
+syntax_bad=0
+while IFS= read -r f; do
+    bash -n "$f" 2>/dev/null || { syntax_bad=1; printf '        parse error: %s\n' "$f"; }
+done < <(find "$ROOT" -maxdepth 2 \( -path '*/lib/*.sh' -o -name 'moav.sh' -o -path '*/scripts/*.sh' -o -path '*/tests/*.sh' \) -not -path '*/.git/*')
+[[ $syntax_bad -eq 0 ]] && ok "bash -n clean across moav.sh, lib/, scripts/, tests/" \
+                        || bad "bash -n found parse errors (listed above)"
+
+# --- 2. no function defined twice across moav.sh + lib/ -----------------------
+# A duplicate means an extraction left a copy behind: the sourced module
+# silently shadows (or is shadowed by) the dispatcher copy. This happened once,
+# after a hunk-wise merge resolution, and only this check caught it.
+dups=$(fn_defs "$ROOT" | sort | uniq -d)
+if [[ -z "$dups" ]]; then
+    ok "no duplicate function definitions across moav.sh + lib/*.sh"
+else
+    bad "duplicate definitions (extraction left a copy behind):"
+    printf '%s\n' "$dups" | sed 's/^/          /'
+fi
+
+# (A "modules must not execute at source time" check was tried here and removed:
+# a line-based heuristic cannot distinguish top-level commands from multi-line
+# array assignments or heredoc bodies, and a check with false positives trains
+# readers to ignore its output. Verify that property by review instead.)
+
+# --- 3. lib/ modules call helpers that exist ----------------------------------
+# D2 regression class: a guard called log_error(), which is a scripts/lib
+# helper; lib/ defines error(). The message became "command not found".
+if grep -qn '\blog_error\b\|\blog_warn\b\|\blog_info\b' "$ROOT"/lib/*.sh; then
+    bad "lib/ modules call scripts/lib logging helpers (use error/warn/info):"
+    grep -n '\blog_error\b\|\blog_warn\b\|\blog_info\b' "$ROOT"/lib/*.sh | head -5 | sed 's/^/          /'
+else
+    ok "lib/ modules use only the logging helpers lib/common.sh defines"
+fi
+
+# --- 4. the test suites themselves --------------------------------------------
+for t in strict-mode-test.sh net-alloc-test.sh; do
+    if out=$(bash "$ROOT/tests/$t" 2>&1); then
+        ok "tests/$t: $(printf '%s\n' "$out" | grep -Eo '[0-9]+ passed[^"]*' | tail -1)"
+    else
+        bad "tests/$t failed:"
+        printf '%s\n' "$out" | tail -5 | sed 's/^/          /'
+    fi
+done
+
+# --- compare mode: conservation + behaviour diff vs a base ref -----------------
+if [[ "$MODE" == "compare" ]]; then
+    [[ -n "$BASE_REF" ]] || { echo "usage: $0 compare <base-ref>"; exit 2; }
+    echo "refactor-verify: compare vs $BASE_REF"
+    wt=$(mktemp -d)
+    git -C "$ROOT" worktree add -q --detach "$wt" "$BASE_REF" || { bad "cannot create worktree for $BASE_REF"; exit 1; }
+    trap 'git -C "$ROOT" worktree remove --force "$wt" 2>/dev/null; git -C "$ROOT" worktree prune' EXIT
+
+    # 5. function-count conservation. A pure relocation keeps the census equal;
+    # adding/removing functions is fine but must be deliberate — the check makes
+    # you look at the delta instead of discovering it later.
+    old_n=$(fn_defs "$wt" | wc -l | tr -d ' ')
+    new_n=$(fn_defs "$ROOT" | wc -l | tr -d ' ')
+    if [[ "$old_n" == "$new_n" ]]; then
+        ok "function census conserved ($new_n)"
+    else
+        printf '  NOTE  function census %s -> %s; delta:\n' "$old_n" "$new_n"
+        diff <(fn_defs "$wt" | sort) <(fn_defs "$ROOT" | sort) | grep '^[<>]' | sed 's/^</          removed:/; s/^>/          added:  /'
+        printf '        (fine if the PR intends it; a surprise here is a bug)\n'
+    fi
+
+    # 6. behaviour diff on NON-MUTATING subcommands only. Bare `moav` and
+    # `moav bootstrap --help` create a .env in the clone — never add them here.
+    # The banner's "v<ver> (<branch>)" line is normalised: a detached worktree
+    # prints (HEAD) and the box padding shifts with branch-name length.
+    # Path normalisation covers the /private prefix macOS resolves temp dirs
+    # through -- error messages cite the resolved path, not the mktemp one.
+    run_cmd() { (cd "$1" && MOAV_SKIP_BASH_CHECK=1 bash ./moav.sh $2 2>&1; echo "EXIT=$?") \
+                | sed -E 's/v[0-9][^)]*\([^)]*\).*/VERSIONLINE/' \
+                | sed -E "s#/private$wt#DIR#g; s#$wt#DIR#g; s#/private$ROOT#DIR#g; s#$ROOT#DIR#g"; }
+    dcount=0
+    for c in "version" "help" "--help" "check" "status" "profiles" "doctor help" "nosuchcmd"; do
+        a=$(run_cmd "$wt" "$c"); b=$(run_cmd "$ROOT" "$c")
+        if [[ "$a" == "$b" ]]; then
+            ok "byte-identical: moav $c"
+        else
+            dcount=$((dcount+1))
+            printf '  DIFF  moav %s\n' "$c"
+            diff <(printf '%s\n' "$a") <(printf '%s\n' "$b") | head -6 | sed 's/^/          /'
+        fi
+    done
+    rm -f "$wt/.env" "$ROOT/.env"   # belt-and-braces; these commands should not create one
+    [[ $dcount -gt 0 ]] && printf '        (a DIFF is not automatically wrong — but it must be explained in the PR)\n'
+fi
+
+echo
+echo "  $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Deliverable (a) from the sprint reality-check: the verification discipline,
codified so it survives model changes.

**`tests/refactor-verify.sh`**
- `static` (wired into CI): `bash -n` sweep, duplicate-definition census across `moav.sh`+`lib/`, the `log_error`-in-`lib/` mixup check, both unit suites
- `compare <ref>`: function-count conservation + byte-identical subcommand diffs (incl. exit codes) vs a clean worktree — non-mutating commands only, banner and `/private` temp paths normalised

Currently: static 5/5, `compare origin/dev` 14/14, census 189.

**`docs/devdocs/REFACTOR-VERIFICATION.md`** — the 8 rules, each cited to the
actual sprint incident that created it (including the two found by the
reality-check itself: merge gates polling e2e but not CI, and tests exercised
only on bash 3.2). The point of the citations is to keep the rules from
decaying into cargo cult.

One check was **removed during development**: "modules must not execute at
source time" — a line-based heuristic false-positives on array continuations
and heredocs, and a check readers learn to ignore is worse than none.

Gating on CI (test + docs only; no runtime code touched).