### PR TITLE
docs: record D4 progress + the environment-verification rule

### DIFF
--- a/docs/devdocs/REFACTOR-VERIFICATION.md
+++ b/docs/devdocs/REFACTOR-VERIFICATION.md
@@ -73,7 +73,42 @@ docker run --rm -v "$PWD":/r -w /r bash:5.2 bash tests/strict-mode-test.sh
 a bare-read crash; CI's bash 5 produced a third outcome and **CI was red for
 four merged PRs** before anyone noticed.
 
-### 8. Re-measure any plan estimate before acting on it
+### 8. Verify in the environment the code actually runs in
+
+Before editing anything that runs inside a container, establish **which image and
+therefore which shell** it uses. Before changing file permissions, establish
+**which user the process actually runs as**.
+
+```bash
+grep -m1 '^FROM' dockerfiles/Dockerfile.<svc>      # base image -> /bin/sh flavour
+grep -nE 'USER|su-exec|setpriv|gosu' dockerfiles/Dockerfile.<svc> scripts/<svc>-entrypoint.sh
+```
+
+*Incidents, all in one sprint:*
+
+- **`set -o pipefail` is fatal in dash.** `set` is a POSIX **special builtin**, so
+  a failed `set -o pipefail` exits a non-interactive shell **immediately** —
+  `|| true` never runs. dash (debian's `/bin/sh`) has no pipefail. Verified on
+  alpine, where busybox ash *does* support it, so the guard never fired and it
+  looked correct; on debian it killed the conduit container at line 3 with exit 2
+  and **no output at all**. Portable form:
+  ```sh
+  if ( set -o pipefail 2>/dev/null ); then set -o pipefail; fi   # probe in a subshell
+  ```
+- **The compose `user:` field does not tell you who the process runs as.**
+  Entrypoints drop privileges themselves — admin via `su-exec moav`, conduit via
+  `setpriv --reuid=moav`. Reading the compose field and concluding "root"
+  produced a `chmod 600` that crash-looped the admin container with
+  `PermissionError`, and it shipped to `dev`.
+- **A skip is not a repair.** State volumes persist across upgrades, so a fix that
+  only handles fresh installs leaves damaged ones broken. Repair must be
+  bidirectional: the first attempt at the above `continue`d past the file,
+  leaving it at the bad mode it already had.
+
+*The shape common to all three: verifying at the layer that is convenient rather
+than the layer where the behaviour lives.*
+
+### 9. Re-measure any plan estimate before acting on it
 Grep counts are not call-site reading.
 *Incidents:* the plan's `compose()` item claimed "100+ calls with ad-hoc
 `--profile`/`sudo`" — measured: 149 calls, **zero** sudo. The four "duplicate"

--- a/docs/devdocs/V2-REFACTOR-PLAN.md
+++ b/docs/devdocs/V2-REFACTOR-PLAN.md
@@ -341,6 +341,29 @@ reproduce — every `ENABLE_*` read in `lib/doctor.sh` goes through
 `get_env_val "<KEY>" "$env_file" "<default>"`. Logged in error or fixed earlier
 in the sprint.
 
+**D4 (PARTIALLY done) — the original D: container entrypoints.**
+
+| PR | Scope | State |
+|---|---|---|
+| D4a (#207) | `wireguard`, `amneziawg` — full `set -eu` + pipefail | ✅ |
+| D4b-1 (#210) | `conduit`, `dnstt`, `trusttunnel`, `xray` — `set -e` → `set -eu` + pipefail | ✅ |
+| D4b-2 (#211) | `admin`, `grafana`, `grafana-proxy`, `sing-box`, `snowflake`, `wstunnel` — **`-u` + pipefail only** | ⚠️ partial |
+| **D4c** | **enable `-e` on the six from D4b-2** | ⬜ **open** |
+
+**Why D4c is still open:** those six had *no* `set` line at all, so enabling `-e`
+makes every currently-tolerated non-zero exit fatal. That needs a per-command
+review of ~579 lines across six services (grafana alone is 227). Adding it blind
+to six long-running services at once risks taking the stack down. Each entrypoint
+carries an inline note saying so.
+
+Bugs found while doing D4: WireGuard/AmneziaWG could report healthy with a dead
+tunnel (empty `PrivateKey` reached the monitor loop); the WG peer count printed
+`0 0`; conduit's key extraction would have died under pipefail *before reaching
+its own empty-key check*; and `set -o pipefail 2>/dev/null || true` is fatal in
+dash — see REFACTOR-VERIFICATION.md rule 8.
+
+Original description follows.
+
 **D4 (NOT started) — the original D: container entrypoints.** Fix the landmine
 classes first (`grep KEY file | head -1 | cut` scrapers returning nonzero when a
 key is legitimately absent; `cmd | head -N` SIGPIPE under pipefail; optional


### PR DESCRIPTION
Docs only.

**`REFACTOR-VERIFICATION.md` rule 8 — "Verify in the environment the code actually runs in"**, citing the three incidents from this sprint:

- **`set -o pipefail` is fatal in dash.** `set` is a POSIX *special builtin*, so `|| true` never runs. I verified the idiom on alpine (where ash supports pipefail, so the guard never fired) and shipped it to a debian image, where it killed conduit at line 3 with exit 2 and **no output**.
- **The compose `user:` field doesn't say who the process runs as.** admin uses `su-exec`, conduit uses `setpriv`. Assuming root produced a `chmod 600` that crash-looped admin — and it shipped to `dev`.
- **A skip is not a repair.** State volumes persist, so a fresh-install-only fix leaves damaged installs broken.

All three share one shape: **verifying at the convenient layer rather than the layer where the behaviour lives.**

**`V2-REFACTOR-PLAN.md`** now shows D4's real state — D4a/D4b-1 done, D4b-2 partial (`-u` + pipefail, no `-e`), **D4c open** — plus the bugs the work surfaced.