### PR TITLE
ci(telegram): post release notes into the 'github logs' forum topic

### DIFF
--- a/.github/workflows/telegram-notify.yml
+++ b/.github/workflows/telegram-notify.yml
@@ -6,6 +6,9 @@ name: Telegram notify
 #   • manual dispatch             → a test message
 # Requires repo secrets TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID; if either is
 # unset the send is skipped cleanly (no failed runs on forks).
+# Optional TELEGRAM_TOPIC_ID: when the chat is a forum supergroup, set this to
+# the target topic's thread id to post into that topic (e.g. the "github logs"
+# topic). Unset = posts to the group's General topic, as before.
 
 on:
   release:
@@ -67,6 +70,7 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TOPIC_ID: ${{ secrets.TELEGRAM_TOPIC_ID }}
         run: |
           if [ ! -s message.txt ]; then
             echo "Nothing to announce for this event — skipping."; exit 0
@@ -74,9 +78,13 @@ jobs:
           if [ -z "${BOT_TOKEN}" ] || [ -z "${CHAT_ID}" ]; then
             echo "::warning::TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID not set — skipping send."; exit 0
           fi
-          echo "Sending $(wc -c < message.txt) bytes to Telegram…"
+          # Optional: target a specific forum-supergroup topic (e.g. "github logs").
+          EXTRA=()
+          if [ -n "${TOPIC_ID}" ]; then EXTRA=(--data-urlencode "message_thread_id=${TOPIC_ID}"); fi
+          echo "Sending $(wc -c < message.txt) bytes to Telegram${TOPIC_ID:+ (topic $TOPIC_ID)}…"
           curl -fsS -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${CHAT_ID}" \
+            "${EXTRA[@]}" \
             --data-urlencode "text@message.txt" \
             -d parse_mode=HTML \
             -d disable_web_page_preview=false \


### PR DESCRIPTION
## What
Enabling topics on the MoaV Telegram group upgraded it to a **supergroup**, which changes the chat id and means broadcasts should target the **github logs** topic.

This adds an optional `TELEGRAM_TOPIC_ID` secret to the release notifier. When set, the workflow passes `message_thread_id` to `sendMessage` so posts land in that forum topic. When unset, behaviour is unchanged (posts to General) — so forks and existing installs are unaffected.

## Required secret changes (org owner, after merge)
- Update `TELEGRAM_CHAT_ID` → `@motherofallvpns` (public username; stable across the supergroup migration)
- Add `TELEGRAM_TOPIC_ID` → `31`  (the 'github logs' topic thread id, from `t.me/motherofallvpns/31/...`)

## Test
Actions → **Telegram notify** → Run workflow, leave `release_tag` blank → confirm it posts in the github logs topic. Then re-run with `release_tag: v2.0.0-rc.1` for a real-format dry run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)