### PR TITLE
fix(d4c): full strict mode for four entrypoints; honest admin SSL status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Full strict mode (`set -eu` + pipefail) for the admin, sing-box, snowflake and wstunnel entrypoints.** `-e` was previously held back on these because they had never run under it. Each was reviewed per command and then executed in its real base image (alpine/ash and debian/dash) to confirm it still reaches its `exec`, including the graceful-degradation branches such as snowflake continuing when it cannot detect a network interface.
+- **The admin entrypoint now reports the certificate it will actually use.** It checked only `/certs/live`, so it printed "SSL: Disabled" even when a self-signed fallback existed and TLS was about to be served.
+
 ## [2.0.0-rc.2] - 2026-07-30
 
 > ## ⚠️ EXPERIMENTAL. Do not run this on a production server.

--- a/scripts/admin-entrypoint.sh
+++ b/scripts/admin-entrypoint.sh
@@ -6,7 +6,7 @@
 
 
 # Strict mode, minus `-e` (see below).
-set -u
+set -eu
 # `set` is a POSIX SPECIAL builtin: a failed `set -o pipefail` exits a
 # non-interactive shell outright and `|| true` does NOT save it. dash (debian's
 # /bin/sh, used by sing-box and wstunnel) has no pipefail. Probe in a subshell,
@@ -50,11 +50,20 @@ fi
 # Check for SSL certificates
 # `|| true`: `… | head -1` SIGPIPEs (141) once head closes the pipe, which
 # pipefail makes fatal. An empty result is also a legitimate "no certs yet".
+# Report what main.py will ACTUALLY bind, which is /tmp/certs (Let's Encrypt if
+# present, else the self-signed fallback, else the last-resort cert generated
+# above). Checking only /certs/live printed "SSL: Disabled" even when a fallback
+# certificate existed and TLS was about to be served -- an operator reading that
+# would reasonably think the panel was plaintext when it was not. main.py refuses
+# to start without TLS, so "Disabled" is now genuinely a failure state.
 CERT_DIRS=$(find /certs/live -maxdepth 1 -type d 2>/dev/null | tail -n +2 | head -1 || true)
+FALLBACK_CERT=$(find /tmp/certs -name fullchain.pem 2>/dev/null | head -1 || true)
 if [ -n "$CERT_DIRS" ]; then
-    echo "[admin] SSL: Enabled (found certificates)"
+    echo "[admin] SSL: Enabled (Let's Encrypt certificate)"
+elif [ -n "$FALLBACK_CERT" ]; then
+    echo "[admin] SSL: Enabled (self-signed fallback; browser warning expected)"
 else
-    echo "[admin] SSL: Disabled (no certificates found)"
+    echo "[admin] SSL: no certificate found - the dashboard will refuse to start"
 fi
 
 # Ensure required directories exist and are writable by moav user

--- a/scripts/sing-box-entrypoint.sh
+++ b/scripts/sing-box-entrypoint.sh
@@ -6,7 +6,7 @@
 
 
 # Strict mode, minus `-e` (see below).
-set -u
+set -eu
 # `set` is a POSIX SPECIAL builtin: a failed `set -o pipefail` exits a
 # non-interactive shell outright and `|| true` does NOT save it. dash (debian's
 # /bin/sh, used by sing-box and wstunnel) has no pipefail. Probe in a subshell,

--- a/scripts/snowflake-entrypoint.sh
+++ b/scripts/snowflake-entrypoint.sh
@@ -5,7 +5,7 @@
 
 
 # Strict mode, minus `-e` (see below).
-set -u
+set -eu
 # `set` is a POSIX SPECIAL builtin: a failed `set -o pipefail` exits a
 # non-interactive shell outright and `|| true` does NOT save it. dash (debian's
 # /bin/sh, used by sing-box and wstunnel) has no pipefail. Probe in a subshell,

--- a/scripts/wstunnel-entrypoint.sh
+++ b/scripts/wstunnel-entrypoint.sh
@@ -11,7 +11,7 @@
 
 
 # Strict mode, minus `-e` (see below).
-set -u
+set -eu
 # `set` is a POSIX SPECIAL builtin: a failed `set -o pipefail` exits a
 # non-interactive shell outright and `|| true` does NOT save it. dash (debian's
 # /bin/sh, used by sing-box and wstunnel) has no pipefail. Probe in a subshell,

--- a/tests/entrypoint-strict-test.sh
+++ b/tests/entrypoint-strict-test.sh
@@ -84,9 +84,18 @@ done
 # `-u` + pipefail only. `-e` is deliberately deferred (see the entrypoint notes):
 # these have never run under it, so every tolerated non-zero exit would become
 # fatal, and that needs a per-command review rather than a blind sweep.
-for e in admin grafana grafana-proxy sing-box snowflake wstunnel; do
+# D4c: -e enabled per-service after a per-command review, smallest first.
+for e in admin sing-box snowflake wstunnel; do
     f="$ROOT/scripts/${e}-entrypoint.sh"
-    grep -qE '^set -u$' "$f" && ok "$e: set -u" || bad "$e: no set -u"
+    grep -qE '^set -eu$' "$f" && ok "$e: full strict mode (set -eu)" \
+                              || bad "$e: lost set -e"
+done
+# grafana and grafana-proxy are larger and still pending their review; they must
+# keep -u + pipefail in the meantime rather than silently losing them.
+for e in grafana grafana-proxy; do
+    f="$ROOT/scripts/${e}-entrypoint.sh"
+    grep -qE '^set -(u|eu)$' "$f" && ok "$e: set -u (or better) still present" \
+                                  || bad "$e: lost set -u"
     grep -q 'if ( set -o pipefail 2>/dev/null ); then' "$f" \
         && ok "$e: pipefail subshell-probed (sing-box/wstunnel are dash — no pipefail)" \
         || bad "$e: pipefail not subshell-probed"


### PR DESCRIPTION
D4c, first half. `set -u` → `set -eu` for **admin, sing-box, snowflake, wstunnel**.
`-e` was deferred in D4b-2 because these had never run under it and every
tolerated non-zero exit would become fatal.

### Reviewed per command, then actually executed
In each service's **real base image**, since which shell a script runs under has
caught me out before:

| service | image | result |
|---|---|---|
| admin | python:3.12-alpine (ash) | reaches `exec`, self-generates a cert |
| snowflake | alpine:3.21 (ash) | survives "cannot determine network interface", warns, continues |
| sing-box | debian:bookworm (dash) | validates config, reaches `exec` |
| wstunnel | debian:bookworm (dash) | takes the domainless branch, reaches `exec` |

**The snowflake case is the one that mattered** — graceful degradation is exactly
what `-e` breaks, and it still degrades gracefully.

### Deliberately not included
`grafana` (240 lines) and `grafana-proxy` (153) need the same per-command review
and are larger. Splitting keeps a red e2e pointing at four services rather than
six. The test asserts they keep `-u` + pipefail meanwhile, so they can't silently
regress while waiting.

### Also: a misleading message my own TLS work introduced
The admin entrypoint checked only `/certs/live`, so it printed
**"SSL: Disabled (no certificates found)"** even after generating a last-resort
certificate and about to serve TLS. An operator reading that would reasonably
believe the panel was plaintext. It now distinguishes Let's Encrypt, self-signed
fallback, and the genuine failure case.

**Caught while writing the test:** my guard regex `^set -eu?$` matches `set -e`
and `set -eu` but *not* `set -u`, so it reported grafana as having lost strict
mode. Fixed.

35/35 on bash 3.2 and 5.2.