### PR TITLE
fix(d4c): full strict mode for grafana and grafana-proxy — E3 entrypoints done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Full strict mode (`set -eu` + pipefail) for the admin, sing-box, snowflake and wstunnel entrypoints.** `-e` was previously held back on these because they had never run under it. Each was reviewed per command and then executed in its real base image (alpine/ash and debian/dash) to confirm it still reaches its `exec`, including the graceful-degradation branches such as snowflake continuing when it cannot detect a network interface.
+- **Full strict mode (`set -eu` + pipefail) for every container entrypoint.** The last six (admin, sing-box, snowflake, wstunnel, grafana, grafana-proxy) had never run under `-e`, so each was reviewed per command and then executed in its real base image. Two real hazards were fixed on the way: grafana's certificate lookup returns non-zero before certbot has issued, and a plain `var=$(cmd)` assignment propagates that, so `-e` would have killed grafana on every fresh install; and its cosmetic branding edits could take the container down if the target layer were read-only.
+- **Full strict mode for the admin, sing-box, snowflake and wstunnel entrypoints.** `-e` was previously held back on these because they had never run under it. Each was reviewed per command and then executed in its real base image (alpine/ash and debian/dash) to confirm it still reaches its `exec`, including the graceful-degradation branches such as snowflake continuing when it cannot detect a network interface.
 - **The admin entrypoint now reports the certificate it will actually use.** It checked only `/certs/live`, so it printed "SSL: Disabled" even when a self-signed fallback existed and TLS was about to be served.
 
 ## [2.0.0-rc.2] - 2026-07-30

--- a/scripts/grafana-entrypoint.sh
+++ b/scripts/grafana-entrypoint.sh
@@ -5,7 +5,7 @@
 
 
 # Strict mode, minus `-e` (see below).
-set -u
+set -eu
 # `set` is a POSIX SPECIAL builtin: a failed `set -o pipefail` exits a
 # non-interactive shell outright and `|| true` does NOT save it. dash (debian's
 # /bin/sh, used by sing-box and wstunnel) has no pipefail. Probe in a subshell,
@@ -20,11 +20,14 @@ echo "[grafana] Starting MoaV Grafana Dashboard"
 
 # Determine app title (for PWA name on phone home screen)
 # Priority: GRAFANA_APP_TITLE > "MoaV - DOMAIN" > "MoaV - SERVER_IP" > "MoaV"
-if [ -n "$GRAFANA_APP_TITLE" ]; then
-    APP_TITLE="$GRAFANA_APP_TITLE"
-elif [ -n "$DOMAIN" ]; then
+# `:-` on each: compose always supplies these (as ${VAR:-}), but the entrypoint
+# should not depend on that to survive `set -u`. Running it outside compose, or
+# a compose file that drops one, would otherwise abort the container here.
+if [ -n "${GRAFANA_APP_TITLE:-}" ]; then
+    APP_TITLE="${GRAFANA_APP_TITLE:-}"
+elif [ -n "${DOMAIN:-}" ]; then
     APP_TITLE="MoaV Grafana - ${DOMAIN}"
-elif [ -n "$SERVER_IP" ]; then
+elif [ -n "${SERVER_IP:-}" ]; then
     APP_TITLE="MoaV Grafana - ${SERVER_IP}"
 else
     APP_TITLE="MoaV Grafana"
@@ -32,7 +35,7 @@ fi
 echo "[grafana] App title: $APP_TITLE"
 
 # Construct Grafana root URL from subdomain + domain
-if [ -n "$GRAFANA_SUBDOMAIN" ] && [ -n "$DOMAIN" ]; then
+if [ -n "${GRAFANA_SUBDOMAIN:-}" ] && [ -n "${DOMAIN:-}" ]; then
     export GF_SERVER_ROOT_URL="https://${GRAFANA_SUBDOMAIN}.${DOMAIN}:2083/"
     echo "[grafana] Root URL: $GF_SERVER_ROOT_URL"
 fi
@@ -78,15 +81,18 @@ SVGEOF
             [ -f "$js_file" ] || continue
             if grep -q 'AppTitle' "$js_file" 2>/dev/null; then
                 # Try multiple patterns (varies by Grafana version)
-                sed -i "s/\"AppTitle\",\"Grafana\"/\"AppTitle\",\"$APP_TITLE\"/g" "$js_file" 2>/dev/null
-                sed -i "s/AppTitle:\"Grafana\"/AppTitle:\"$APP_TITLE\"/g" "$js_file" 2>/dev/null
-                sed -i "s/AppTitle=\"Grafana\"/AppTitle=\"$APP_TITLE\"/g" "$js_file" 2>/dev/null
+                # `|| true`: branding is cosmetic. Under `set -e` a failed in-place edit
+                # (read-only layer, a Grafana upgrade renaming these bundles) would take the
+                # whole container down over a page title.
+                sed -i "s/\"AppTitle\",\"Grafana\"/\"AppTitle\",\"$APP_TITLE\"/g" "$js_file" 2>/dev/null || true
+                sed -i "s/AppTitle:\"Grafana\"/AppTitle:\"$APP_TITLE\"/g" "$js_file" 2>/dev/null || true
+                sed -i "s/AppTitle=\"Grafana\"/AppTitle=\"$APP_TITLE\"/g" "$js_file" 2>/dev/null || true
                 echo "[grafana] Patched AppTitle in $(basename "$js_file")"
                 patched=1
             fi
             # Also patch generic title references
             if grep -q 'title:"Grafana"' "$js_file" 2>/dev/null; then
-                sed -i "s/title:\"Grafana\"/title:\"$APP_TITLE\"/g" "$js_file" 2>/dev/null
+                sed -i "s/title:\"Grafana\"/title:\"$APP_TITLE\"/g" "$js_file" 2>/dev/null || true
             fi
         done
         [ "$patched" -eq 0 ] && echo "[grafana] WARNING: AppTitle pattern not found in JS bundles"
@@ -129,7 +135,11 @@ find_certificates() {
 waited=0
 max_wait=30
 while [ $waited -lt $max_wait ]; do
-    certs=$(find_certificates)
+    # `|| true`: find_certificates returns 1 when no certificate exists yet, and a
+    # plain `var=$(cmd)` assignment PROPAGATES that status (unlike `local x=$(cmd)`,
+    # which masks it). Under `set -e` that killed grafana on every install before
+    # certbot had issued -- which is exactly the state this loop exists to wait out.
+    certs=$(find_certificates) || true
     if [ -n "$certs" ]; then
         break
     fi
@@ -138,7 +148,7 @@ while [ $waited -lt $max_wait ]; do
     waited=$((waited + 5))
 done
 
-certs=$(find_certificates)
+certs=$(find_certificates) || true
 if [ -n "$certs" ]; then
     key_file=$(echo "$certs" | cut -d' ' -f1)
     cert_file=$(echo "$certs" | cut -d' ' -f2)

--- a/scripts/grafana-proxy-entrypoint.sh
+++ b/scripts/grafana-proxy-entrypoint.sh
@@ -5,7 +5,7 @@
 
 
 # Strict mode, minus `-e` (see below).
-set -u
+set -eu
 # `set` is a POSIX SPECIAL builtin: a failed `set -o pipefail` exits a
 # non-interactive shell outright and `|| true` does NOT save it. dash (debian's
 # /bin/sh, used by sing-box and wstunnel) has no pipefail. Probe in a subshell,

--- a/tests/entrypoint-strict-test.sh
+++ b/tests/entrypoint-strict-test.sh
@@ -85,21 +85,25 @@ done
 # these have never run under it, so every tolerated non-zero exit would become
 # fatal, and that needs a per-command review rather than a blind sweep.
 # D4c: -e enabled per-service after a per-command review, smallest first.
-for e in admin sing-box snowflake wstunnel; do
+for e in admin sing-box snowflake wstunnel grafana grafana-proxy; do
     f="$ROOT/scripts/${e}-entrypoint.sh"
     grep -qE '^set -eu$' "$f" && ok "$e: full strict mode (set -eu)" \
                               || bad "$e: lost set -e"
 done
-# grafana and grafana-proxy are larger and still pending their review; they must
-# keep -u + pipefail in the meantime rather than silently losing them.
-for e in grafana grafana-proxy; do
-    f="$ROOT/scripts/${e}-entrypoint.sh"
-    grep -qE '^set -(u|eu)$' "$f" && ok "$e: set -u (or better) still present" \
-                                  || bad "$e: lost set -u"
-    grep -q 'if ( set -o pipefail 2>/dev/null ); then' "$f" \
-        && ok "$e: pipefail subshell-probed (sing-box/wstunnel are dash — no pipefail)" \
-        || bad "$e: pipefail not subshell-probed"
-done
+# grafana's cert lookup returns non-zero when no certificate exists yet, and a
+# plain `var=$(cmd)` assignment propagates that (unlike `local x=$(cmd)`). Without
+# the guard, -e killed grafana on every install before certbot had issued, which
+# is exactly the state its wait loop exists to handle.
+grep -q 'certs=$(find_certificates) || true' "$ROOT/scripts/grafana-entrypoint.sh" \
+    && ok "grafana: cert lookup guarded (survives a pre-certbot install)" \
+    || bad "grafana: unguarded certs=\$(find_certificates) — dies before certbot issues"
+
+# Branding is cosmetic; a failed in-place edit must not take the container down.
+unguarded=$(grep -cE '^\s*sed -i .*2>/dev/null$' "$ROOT/scripts/grafana-entrypoint.sh" || true)
+[ "${unguarded:-0}" -eq 0 ] \
+    && ok "grafana: all in-place branding edits guarded" \
+    || bad "grafana: $unguarded unguarded 'sed -i' — a read-only layer would kill the container"
+
 
 # SIGPIPE guards that pipefail would otherwise make fatal.
 grep -q 'head -1 || true)' "$ROOT/scripts/admin-entrypoint.sh" \


### PR DESCRIPTION
Second half of D4c, and the last two entrypoints. **Reading them wasn't enough** —
running them in their real base image found a breakage my review missed.

### The one that mattered
```sh
certs=$(find_certificates)
```
`find_certificates` returns **1 when no certificate exists yet**, and a plain
`var=$(cmd)` assignment *propagates* that status — unlike `local x=$(cmd)`, which
masks it.

Under `set -e`, grafana would therefore die on any install where certbot hadn't
issued yet, **which is exactly the state the surrounding wait loop exists to
handle**. That's every fresh domain install. Guarded both call sites.

### Also fixed
- **Four bare `sed -i` branding edits.** Branding is cosmetic; a read-only layer
  or a Grafana upgrade renaming its JS bundles shouldn't take the container down
  over a page title.
- **`GRAFANA_APP_TITLE` / `DOMAIN` / `SERVER_IP` / `GRAFANA_SUBDOMAIN` reads.**
  compose always supplies these as `${VAR:-}`, but the entrypoint shouldn't depend
  on that to survive `set -u` — run outside compose it aborted at line 23.

### Verified by execution, not inspection
| scenario | result |
|---|---|
| no env at all | branding applied, continues |
| no certificates | **waits as designed** instead of dying |
| certificates present | `SSL: Enabled`, reaches `exec` |
| read-only branding tree, non-root user | still reaches `exec` |

**Every container entrypoint in the repo now runs under full strict mode.** The
test pins both grafana guards so they can't be tidied away later.

35/35 on bash 3.2 and 5.2.