### PR TITLE
feat: surface community/support links in the CLI and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Community links in the CLI and README.** The `moav` banner and `moav help` footer now show the Telegram support channel (t.me/motherofallvpns) and Twitter/X; the README gained badges and a Community & support section.
+
 ### Changed
 - **Full strict mode (`set -eu` + pipefail) for every container entrypoint.** The last six (admin, sing-box, snowflake, wstunnel, grafana, grafana-proxy) had never run under `-e`, so each was reviewed per command and then executed in its real base image. Two real hazards were fixed on the way: grafana's certificate lookup returns non-zero before certbot has issued, and a plain `var=$(cmd)` assignment propagates that, so `-e` would have killed grafana on every fresh install; and its cosmetic branding edits could take the container down if the target layer were read-only.
 - **Full strict mode for the admin, sing-box, snowflake and wstunnel entrypoints.** `-e` was previously held back on these because they had never run under it. Each was reviewed per command and then executed in its real base image (alpine/ash and debian/dash) to confirm it still reaches its `exec`, including the graceful-degradation branches such as snowflake continuing when it cannot detect a network interface.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MoaV
 
-[![Website](https://img.shields.io/badge/website-moav.sh-cyan.svg)](https://moav.sh)  [![Docs](https://img.shields.io/badge/docs-moav.sh%2Fdocs-cyan.svg)](https://moav.sh/docs/)  [![Version](https://img.shields.io/badge/version-1.9.0-blue.svg)](CHANGELOG.md)  [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Website](https://img.shields.io/badge/website-moav.sh-cyan.svg)](https://moav.sh)  [![Docs](https://img.shields.io/badge/docs-moav.sh%2Fdocs-cyan.svg)](https://moav.sh/docs/)  [![Version](https://img.shields.io/badge/version-1.9.0-blue.svg)](CHANGELOG.md)  [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)  [![Telegram](https://img.shields.io/badge/Telegram-motherofallvpns-2CA5E0.svg?logo=telegram)](https://t.me/motherofallvpns)  [![Twitter](https://img.shields.io/badge/X-@motherofallvpns-000000.svg?logo=x)](https://x.com/motherofallvpns)
 
 English | **[فارسی](README-fa.md)** 
 
@@ -336,6 +336,15 @@ MIT
 See [CHANGELOG.md](CHANGELOG.md) for release notes and version history.
 
 
+
+## Community & support
+
+- **Telegram:** [t.me/motherofallvpns](https://t.me/motherofallvpns) — questions, help, and release announcements
+- **Twitter/X:** [@motherofallvpns](https://x.com/motherofallvpns)
+- **Issues:** [GitHub Issues](https://github.com/MotherofallVPNs/MoaV/issues) for bugs and feature requests
+- **Docs:** [moav.sh/docs](https://moav.sh/docs)
+
+---
 ## Disclaimer
 
 This project provides **general-purpose open-source networking software** only.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -95,6 +95,7 @@ print_header() {
     echo "║                                                    ║"
     echo "║  Multi-protocol Circumvention Stack                ║"
     printf "║  %-49s ║\n" "$version_line"
+    printf "║  %-49s ║\n" "t.me/motherofallvpns"
     if [[ -n "$update_line" ]]; then
         printf "║  ${NC}${YELLOW}%-49s${CYAN} ║\n" "$update_line"
     fi

--- a/lib/menu.sh
+++ b/lib/menu.sh
@@ -162,6 +162,11 @@ show_usage() {
     echo "  moav doctor dns                      # Check DNS configuration"
     echo "  moav export                          # Backup to moav-backup-TIMESTAMP.tar.gz"
     echo "  moav migrate-ip 1.2.3.4              # Update to new server IP"
+    echo ""
+    echo "Community & support:"
+    echo "  Telegram:  https://t.me/motherofallvpns"
+    echo "  Twitter/X: https://x.com/motherofallvpns"
+    echo "  Docs:      https://moav.sh/docs"
 }
 
 cmd_check() {

--- a/moav.sh
+++ b/moav.sh
@@ -76,6 +76,7 @@ LATEST_VERSION=""
 goodbye() {
     echo ""
     echo -e "${CYAN}Goodbye! Stay safe out there.${NC}"
+    echo -e "${DIM}Questions or issues? https://t.me/motherofallvpns${NC}"
     echo ""
     exit 0
 }


### PR DESCRIPTION
Adds **Telegram** ([t.me/motherofallvpns](https://t.me/motherofallvpns)) and **Twitter/X** ([@motherofallvpns](https://x.com/motherofallvpns)) where users look for help.

- Interactive banner (`print_header`) — one line under the version, box alignment preserved
- `moav help` footer — a *Community & support* block next to the docs link
- SIGINT goodbye message
- README — badges in the header row + a Community & support section

Docs (moav-site) and moav-client get the same via their own cards. CI-only gate (no runtime behaviour change).