### PR TITLE
fix(d4c): three strict-mode crashes in cert-wait/fallback paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Three strict-mode crashes in cert-wait/fallback paths (grafana, grafana-proxy, trusttunnel).** D4c enabled `set -e`/`-u` on these but left code written for a tolerant shell in the branches that only run *before* Let's Encrypt has issued — invisible to the happy-path e2e. grafana-proxy had the unguarded `certs=$(find_certificates)` that was fixed in grafana but missed in its twin; grafana read `GF_SERVER_CERT_KEY` unbound on the no-cert path, making its HTTP fallback unreachable; and trusttunnel's `((CERT_WAIT_COUNT++))` returned non-zero from zero, killing its cert-wait one second in. Each crashed a fresh install until certbot succeeded.
+
 ### Changed
 - **Full strict mode (`set -eu` + pipefail) for every container entrypoint.** The last six (admin, sing-box, snowflake, wstunnel, grafana, grafana-proxy) had never run under `-e`, so each was reviewed per command and then executed in its real base image. Two real hazards were fixed on the way: grafana's certificate lookup returns non-zero before certbot has issued, and a plain `var=$(cmd)` assignment propagates that, so `-e` would have killed grafana on every fresh install; and its cosmetic branding edits could take the container down if the target layer were read-only.
 - **Full strict mode for the admin, sing-box, snowflake and wstunnel entrypoints.** `-e` was previously held back on these because they had never run under it. Each was reviewed per command and then executed in its real base image (alpine/ash and debian/dash) to confirm it still reaches its `exec`, including the graceful-degradation branches such as snowflake continuing when it cannot detect a network interface.

--- a/scripts/grafana-entrypoint.sh
+++ b/scripts/grafana-entrypoint.sh
@@ -163,6 +163,10 @@ if [ -n "$certs" ]; then
 else
     echo "[grafana] SSL: Disabled (no certificates found)"
     export GF_SERVER_PROTOCOL=http
+    # Define it empty: the readability check below reads $GF_SERVER_CERT_KEY,
+    # which is unset on this branch and aborts under `set -u`, making the whole
+    # HTTP-fallback block unreachable.
+    export GF_SERVER_CERT_KEY=""
 fi
 
 # Test certificate readability and fall back to HTTP if not readable

--- a/scripts/grafana-proxy-entrypoint.sh
+++ b/scripts/grafana-proxy-entrypoint.sh
@@ -45,7 +45,11 @@ find_certificates() {
 waited=0
 max_wait=30
 while [ $waited -lt $max_wait ]; do
-    certs=$(find_certificates)
+    # `|| true`: find_certificates returns 1 when no cert exists yet, and a plain
+    # var=$(cmd) propagates that (unlike `local x=$(cmd)`). Under -e this killed the
+    # proxy on every install before certbot issued -- the exact bug fixed in
+    # grafana-entrypoint.sh; it was missed here in D4c.
+    certs=$(find_certificates) || true
     if [ -n "$certs" ]; then
         break
     fi
@@ -54,7 +58,7 @@ while [ $waited -lt $max_wait ]; do
     waited=$((waited + 5))
 done
 
-certs=$(find_certificates)
+certs=$(find_certificates) || true
 if [ -z "$certs" ]; then
     echo "[grafana-proxy] ERROR: No certificates found, cannot start"
     exit 1

--- a/scripts/trusttunnel-entrypoint.sh
+++ b/scripts/trusttunnel-entrypoint.sh
@@ -40,7 +40,10 @@ if [[ -n "$DOMAIN" ]]; then
     echo "[TrustTunnel] Waiting for TLS certificate at $CERT_PATH..."
     while [[ ! -f "$CERT_PATH" ]] && [[ $CERT_WAIT_COUNT -lt $CERT_WAIT_TIMEOUT ]]; do
         sleep 1
-        ((CERT_WAIT_COUNT++))
+        # `$((...))` not `((...))`: the arithmetic-command form returns exit 1 when
+        # the pre-increment value is 0, which `set -e` treats as fatal -- so the
+        # container died one second into this very wait loop.
+        CERT_WAIT_COUNT=$((CERT_WAIT_COUNT + 1))
     done
 
     if [[ ! -f "$CERT_PATH" ]]; then

--- a/tests/entrypoint-strict-test.sh
+++ b/tests/entrypoint-strict-test.sh
@@ -94,6 +94,29 @@ done
 # plain `var=$(cmd)` assignment propagates that (unlike `local x=$(cmd)`). Without
 # the guard, -e killed grafana on every install before certbot had issued, which
 # is exactly the state its wait loop exists to handle.
+# grafana-proxy has the SAME cert-wait pattern as grafana and had the SAME bug
+# (unguarded certs=$(find_certificates) under -eu). It was missed in D4c and only
+# fires before certbot issues, which the happy-path e2e never hits.
+if grep -qE 'certs=\$\(find_certificates\)$' "$ROOT/scripts/grafana-proxy-entrypoint.sh"; then
+    bad "grafana-proxy: unguarded certs=\$(find_certificates) -- dies before certbot issues"
+else
+    ok "grafana-proxy: cert lookup guarded (survives a pre-certbot install)"
+fi
+
+# grafana's HTTP-fallback branch reads GF_SERVER_CERT_KEY, which is only exported
+# on the cert-found branch; under -u the no-cert path aborted before reaching it.
+grep -q 'export GF_SERVER_CERT_KEY=""' "$ROOT/scripts/grafana-entrypoint.sh" \
+    && ok "grafana: GF_SERVER_CERT_KEY defined on the no-cert path (HTTP fallback reachable)" \
+    || bad "grafana: GF_SERVER_CERT_KEY unset on no-cert path -- aborts under -u before HTTP fallback"
+
+# trusttunnel: `((x++))` returns 1 when x is 0, fatal under -e, one second into its
+# own cert-wait loop.
+if grep -qE '\(\(CERT_WAIT_COUNT\+\+\)\)' "$ROOT/scripts/trusttunnel-entrypoint.sh"; then
+    bad "trusttunnel: ((CERT_WAIT_COUNT++)) returns 1 from 0 -- kills the cert wait under -e"
+else
+    ok "trusttunnel: counter increment is set -e safe"
+fi
+
 grep -q 'certs=$(find_certificates) || true' "$ROOT/scripts/grafana-entrypoint.sh" \
     && ok "grafana: cert lookup guarded (survives a pre-certbot install)" \
     || bad "grafana: unguarded certs=\$(find_certificates) — dies before certbot issues"


### PR DESCRIPTION
Found by an epic-completeness audit, then each **confirmed by executing the
entrypoint in its real base image with no certificate present**. D4c enabled
strict mode on these but left tolerant-shell code in exactly the branches that
run *before* Let's Encrypt issues — which the happy-path e2e never hits, so all
three passed CI while **crashing a fresh install**.

| # | file | bug |
|---|---|---|
| 1 | grafana-proxy | `certs=$(find_certificates)` (×2) unguarded under `-eu` — the exact bug I fixed in grafana and **missed in its twin** |
| 2 | grafana | HTTP-fallback branch reads `$GF_SERVER_CERT_KEY`, only set on the cert-found path — `-u` aborts before the fallback, so grafana could never fall back to HTTP |
| 3 | trusttunnel | `((CERT_WAIT_COUNT++))` returns 1 from 0 — fatal under `-e`, killed the cert-wait one second in |

### Verified in the real image/shell, no cert present
- grafana (alpine/ash): reaches HTTP fallback → `exec`
- grafana-proxy (nginx:alpine): **waits in its loop** instead of dying on iteration one
- trusttunnel (debian/bash): gets past the counter to its config check

### Honest note
I mislabelled D4c as done with these live. They're the same class D4c was meant to
close; the happy-path e2e (certs always present) structurally can't see them,
which is why the audit found them and CI didn't.

38 assertions; the 3 new ones fail on `dev`, pass here, both bash versions.