### PR TITLE
fix(d4c): three strict-mode crashes in cert-wait/fallback paths (re-land of #235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Three strict-mode crashes in cert-wait/fallback paths (grafana, grafana-proxy, trusttunnel).** D4c enabled `set -e`/`-u` on these but left code written for a tolerant shell in the branches that only run *before* Let's Encrypt has issued, invisible to the happy-path e2e. grafana-proxy had the unguarded `certs=$(find_certificates)` that was fixed in grafana but missed in its twin; grafana read `GF_SERVER_CERT_KEY` unbound on the no-cert path, making its HTTP fallback unreachable; and trusttunnel's `((CERT_WAIT_COUNT++))` returned non-zero from zero, killing its cert-wait one second in. Each crashed a fresh install until certbot succeeded.
+
 ### Added
 - **Community links in the CLI and README.** The `moav` banner and `moav help` footer now show the Telegram support channel (t.me/motherofallvpns) and Twitter/X; the README gained badges and a Community & support section.
 

--- a/scripts/grafana-entrypoint.sh
+++ b/scripts/grafana-entrypoint.sh
@@ -163,6 +163,10 @@ if [ -n "$certs" ]; then
 else
     echo "[grafana] SSL: Disabled (no certificates found)"
     export GF_SERVER_PROTOCOL=http
+    # Define it empty: the readability check below reads $GF_SERVER_CERT_KEY,
+    # which is unset on this branch and aborts under `set -u`, making the whole
+    # HTTP-fallback block unreachable.
+    export GF_SERVER_CERT_KEY=""
 fi
 
 # Test certificate readability and fall back to HTTP if not readable

--- a/scripts/grafana-proxy-entrypoint.sh
+++ b/scripts/grafana-proxy-entrypoint.sh
@@ -45,7 +45,11 @@ find_certificates() {
 waited=0
 max_wait=30
 while [ $waited -lt $max_wait ]; do
-    certs=$(find_certificates)
+    # `|| true`: find_certificates returns 1 when no cert exists yet, and a plain
+    # var=$(cmd) propagates that (unlike `local x=$(cmd)`). Under -e this killed the
+    # proxy on every install before certbot issued -- the exact bug fixed in
+    # grafana-entrypoint.sh; it was missed here in D4c.
+    certs=$(find_certificates) || true
     if [ -n "$certs" ]; then
         break
     fi
@@ -54,7 +58,7 @@ while [ $waited -lt $max_wait ]; do
     waited=$((waited + 5))
 done
 
-certs=$(find_certificates)
+certs=$(find_certificates) || true
 if [ -z "$certs" ]; then
     echo "[grafana-proxy] ERROR: No certificates found, cannot start"
     exit 1

--- a/scripts/trusttunnel-entrypoint.sh
+++ b/scripts/trusttunnel-entrypoint.sh
@@ -40,7 +40,10 @@ if [[ -n "$DOMAIN" ]]; then
     echo "[TrustTunnel] Waiting for TLS certificate at $CERT_PATH..."
     while [[ ! -f "$CERT_PATH" ]] && [[ $CERT_WAIT_COUNT -lt $CERT_WAIT_TIMEOUT ]]; do
         sleep 1
-        ((CERT_WAIT_COUNT++))
+        # `$((...))` not `((...))`: the arithmetic-command form returns exit 1 when
+        # the pre-increment value is 0, which `set -e` treats as fatal -- so the
+        # container died one second into this very wait loop.
+        CERT_WAIT_COUNT=$((CERT_WAIT_COUNT + 1))
     done
 
     if [[ ! -f "$CERT_PATH" ]]; then

--- a/tests/entrypoint-strict-test.sh
+++ b/tests/entrypoint-strict-test.sh
@@ -94,6 +94,29 @@ done
 # plain `var=$(cmd)` assignment propagates that (unlike `local x=$(cmd)`). Without
 # the guard, -e killed grafana on every install before certbot had issued, which
 # is exactly the state its wait loop exists to handle.
+# grafana-proxy has the SAME cert-wait pattern as grafana and had the SAME bug
+# (unguarded certs=$(find_certificates) under -eu). It was missed in D4c and only
+# fires before certbot issues, which the happy-path e2e never hits.
+if grep -qE 'certs=\$\(find_certificates\)$' "$ROOT/scripts/grafana-proxy-entrypoint.sh"; then
+    bad "grafana-proxy: unguarded certs=\$(find_certificates) -- dies before certbot issues"
+else
+    ok "grafana-proxy: cert lookup guarded (survives a pre-certbot install)"
+fi
+
+# grafana's HTTP-fallback branch reads GF_SERVER_CERT_KEY, which is only exported
+# on the cert-found branch; under -u the no-cert path aborted before reaching it.
+grep -q 'export GF_SERVER_CERT_KEY=""' "$ROOT/scripts/grafana-entrypoint.sh" \
+    && ok "grafana: GF_SERVER_CERT_KEY defined on the no-cert path (HTTP fallback reachable)" \
+    || bad "grafana: GF_SERVER_CERT_KEY unset on no-cert path -- aborts under -u before HTTP fallback"
+
+# trusttunnel: `((x++))` returns 1 when x is 0, fatal under -e, one second into its
+# own cert-wait loop.
+if grep -qE '\(\(CERT_WAIT_COUNT\+\+\)\)' "$ROOT/scripts/trusttunnel-entrypoint.sh"; then
+    bad "trusttunnel: ((CERT_WAIT_COUNT++)) returns 1 from 0 -- kills the cert wait under -e"
+else
+    ok "trusttunnel: counter increment is set -e safe"
+fi
+
 grep -q 'certs=$(find_certificates) || true' "$ROOT/scripts/grafana-entrypoint.sh" \
     && ok "grafana: cert lookup guarded (survives a pre-certbot install)" \
     || bad "grafana: unguarded certs=\$(find_certificates) — dies before certbot issues"


### PR DESCRIPTION
Re-land of #235, which my background merge script force-closed by deleting the branch before CI finished. Same three fixes, replayed onto fresh dev.

grafana-proxy, grafana and trusttunnel each crashed a fresh install in their cert-wait/fallback paths — invisible to the happy-path e2e because it always has certs by then. Details in the previous PR; verified each in its real image with no cert present. 38 assertions, 3 new ones fail on dev / pass here.