### PR TITLE
fix(c): migrate 5 remaining .env scrapers; close the quote-blind test hole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Five `.env` reads bypassed the config accessor, and the test that was supposed to catch them was quote-blind.** Workstream C's "no ad-hoc scrapers" gate grepped only the unquoted `cut -d= -f2`, so five sites written as `cut -d'=' -f2` passed it vacuously — including a `CLASH_API_SECRET` read that truncated any secret containing `=` (a routine base64 character), causing a perpetual "stale secret" resync. All five now use `get_env_val`; the gate matches both quoted and unquoted forms.
+
+### Fixed
 - **Three strict-mode crashes in cert-wait/fallback paths (grafana, grafana-proxy, trusttunnel).** D4c enabled `set -e`/`-u` on these but left code written for a tolerant shell in the branches that only run *before* Let's Encrypt has issued, invisible to the happy-path e2e. grafana-proxy had the unguarded `certs=$(find_certificates)` that was fixed in grafana but missed in its twin; grafana read `GF_SERVER_CERT_KEY` unbound on the no-cert path, making its HTTP fallback unreachable; and trusttunnel's `((CERT_WAIT_COUNT++))` returned non-zero from zero, killing its cert-wait one second in. Each crashed a fresh install until certbot succeeded.
 
 ### Added

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -321,7 +321,7 @@ build_local_images() {
         local version_value=""
         local build_args=""
         if [[ -n "$version_env_var" ]] && [[ -f "$env_file" ]]; then
-            version_value=$(grep "^${version_env_var}=" "$env_file" 2>/dev/null | cut -d'=' -f2 | tr -d '"' || true)
+            version_value=$(get_env_val "$version_env_var" "$env_file")
             if [[ -n "$version_value" ]] && [[ -n "$version_arg" ]]; then
                 build_args="--build-arg ${version_arg}=${version_value}"
             fi

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -574,10 +574,7 @@ save_default_profiles() {
 
 # Get default profiles from .env
 get_default_profiles() {
-    local env_file="$SCRIPT_DIR/.env"
-    if [[ -f "$env_file" ]]; then
-        grep "^DEFAULT_PROFILES=" "$env_file" 2>/dev/null | cut -d'=' -f2 | sed 's/#.*//' | tr -d '"' | tr -d "'" | xargs
-    fi
+    get_env_val "DEFAULT_PROFILES" "$SCRIPT_DIR/.env"
 }
 
 # Profile ↔ ENABLE_* mapping (issue #106) — Compose profiles don't know
@@ -762,9 +759,9 @@ ensure_clash_api_secret() {
     fi
 
     # Check if CLASH_API_SECRET is already set in .env (non-empty)
-    # Note: || true needed because set -o pipefail causes exit if grep finds nothing
+    # get_env_val keeps a secret containing '=' intact (cut -f2- vs -f2).
     local current_secret
-    current_secret=$(grep "^CLASH_API_SECRET=" "$env_file" 2>/dev/null | cut -d'=' -f2 | tr -d '"' | tr -d "'" || true)
+    current_secret=$(get_env_val "CLASH_API_SECRET" "$env_file")
 
     # Get the authoritative secret from state volume (source of truth from bootstrap)
     local state_secret

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -259,8 +259,8 @@ check_component_versions() {
 
     for var in "${version_vars[@]}"; do
         local current_val example_val
-        current_val=$(grep "^${var}=" "$env_file" 2>/dev/null | cut -d'=' -f2 | tr -d '"' | tr -d "'" || true)
-        example_val=$(grep "^${var}=" "$example_file" 2>/dev/null | cut -d'=' -f2 | tr -d '"' | tr -d "'" || true)
+        current_val=$(get_env_val "$var" "$env_file")
+        example_val=$(get_env_val "$var" "$example_file")
 
         # Skip if either is empty
         [[ -z "$current_val" || -z "$example_val" ]] && continue

--- a/moav.sh
+++ b/moav.sh
@@ -58,13 +58,9 @@ VERSION=$(cat "$SCRIPT_DIR/VERSION" 2>/dev/null || echo "dev")
 get_component_version() {
     local var_name="$1"
     local default="$2"
-    local env_file="$SCRIPT_DIR/.env"
-    if [[ -f "$env_file" ]]; then
-        local val
-        val=$(grep "^${var_name}=" "$env_file" 2>/dev/null | cut -d'=' -f2 | tr -d '"' | tr -d "'")
-        [[ -n "$val" ]] && echo "$val" && return
-    fi
-    echo "$default"
+    # get_env_val handles the read (last-wins, comment-strip, `=`-safe). Defined
+    # below in this same file; only reached at call time, never at source time.
+    get_env_val "$var_name" "$SCRIPT_DIR/.env" "$default"
 }
 
 # State file for persistent checks

--- a/tests/env-resolution-test.sh
+++ b/tests/env-resolution-test.sh
@@ -95,7 +95,16 @@ done
 # C1a: the lib/ tree must no longer carry ad-hoc .env scrapers. The one
 # permitted survivor reads state/keys/cdn.env out of the docker volume, which is
 # not a .env read at all.
-stragglers=$(grep -rn "cut -d= -f2 " --include='*.sh' "$ROOT/lib/" "$ROOT/moav.sh" 2>/dev/null | grep -v 'moav_moav_state' || true)
+# Match BOTH `cut -d= -f2` and the quoted `cut -d'=' -f2` form. The original
+# pattern only matched the unquoted one, so five quoted scrapers passed this gate
+# vacuously (found by the epic audit). Excludes: the get_env_val definitions
+# themselves (they contain `cut -d'=' -f2-`), docker-volume reads (moav_moav_state),
+# and shell-variable parses (`echo "$x" | cut`, i.e. cut immediately after a pipe
+# from echo, not from a file grep).
+stragglers=$(grep -rnE "cut -d'?=('?) -f2 " --include='*.sh' "$ROOT/lib/" "$ROOT/moav.sh" 2>/dev/null \
+             | grep -v 'moav_moav_state' \
+             | grep -vE 'cut -d.=. -f2-' \
+             | grep -vE 'echo "\$[A-Za-z_]' || true)
 if [[ -z "$stragglers" ]]; then
     ok "lib/ tree has no ad-hoc .env scrapers left (all on get_env_val)"
 else
@@ -121,8 +130,10 @@ fi
 # scripts/ must have no ad-hoc .env scrapers left. Permitted survivors read a
 # shell VARIABLE (`echo "$REALITY_ENV_CONTENT" | grep …`) or the docker volume —
 # neither is a .env read.
-leftover=$(grep -rn "cut -d= -f2" --include='*.sh' "$ROOT/scripts/" 2>/dev/null \
-           | grep -v 'moav_moav_state' | grep -v 'echo "\$' || true)
+leftover=$(grep -rnE "cut -d'?=('?) -f2 " --include='*.sh' "$ROOT/scripts/" 2>/dev/null \
+           | grep -v 'moav_moav_state' | grep -v 'echo "\$' \
+           | grep -vE 'cut -d.=. -f2-' \
+           | grep -viE 'CONFIG_FILE|wg0.conf|awg0.conf|REALITY_ENV_CONTENT' || true)
 if [[ -z "$leftover" ]]; then
     ok "scripts/ tree has no ad-hoc .env scrapers left"
 else


### PR DESCRIPTION
The epic audit found Workstream C's completion gate grepped only the **unquoted**
`cut -d= -f2`, so five sites written `cut -d'=' -f2` passed it **vacuously** —
C1a reported success falsely.

| site | what it read |
|---|---|
| `moav.sh:64` | `get_component_version` (truncating, first-match-wins) |
| `lib/service.sh:579` | `DEFAULT_PROFILES` |
| **`lib/service.sh:767`** | **`CLASH_API_SECRET`** |
| `lib/build.sh:324` | per-image version var |
| `lib/update.sh:262` | version compare |

**The CLASH_API_SECRET one had a live consequence:** it truncated any secret
containing `=` (a routine base64 char) at the first `=`, while the state-volume
secret was read whole — so the two never matched and `moav` re-synced the Clash
secret on every check for such a secret.

All five now call `get_env_val` (last-wins, comment-strip, `=`-safe).
`get_component_version` collapses to a one-liner.

**Gate tightened** to match quoted *and* unquoted forms in both trees, excluding
the accessor definitions, docker-volume reads, WireGuard config-file parsing, and
shell-variable parses. Mutation-tested: it now **fails on unfixed dev** (catches
all five), passes here.

Behaviour byte-identical for `version`/`help`/`profiles`.