### PR TITLE
test(e): regression tests for the CIDR whitelist and .env 0600

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         run: bash tests/exporter-socket-test.sh
       - name: admin TLS enforcement
         run: bash tests/admin-tls-test.sh
+      - name: admin IP whitelist (CIDR) unit test
+        run: python3 tests/admin-ip-whitelist-test.py
       - name: refactor verification (static)
         run: bash tests/refactor-verify.sh
       - name: protocol-roster drift gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+- **Regression tests for two security fixes that had none.** The admin CIDR-whitelist matcher is now unit-tested (13 cases incl. IPv6, family mismatch, and malformed-fails-closed) after being lifted to a module-level `ip_matches` function; and `.env` being created `0600` is now asserted at both creation sites. The whitelist bug (every CIDR entry denied everyone) had shipped untested because the repo had no Python tests.
+
 ### Fixed
 - **Three strict-mode crashes in cert-wait/fallback paths (grafana, grafana-proxy, trusttunnel).** D4c enabled `set -e`/`-u` on these but left code written for a tolerant shell in the branches that only run *before* Let's Encrypt has issued, invisible to the happy-path e2e. grafana-proxy had the unguarded `certs=$(find_certificates)` that was fixed in grafana but missed in its twin; grafana read `GF_SERVER_CERT_KEY` unbound on the no-cert path, making its HTTP fallback unreachable; and trusttunnel's `((CERT_WAIT_COUNT++))` returned non-zero from zero, killing its cert-wait one second in. Each crashed a fresh install until certbot succeeded.
 

--- a/admin/main.py
+++ b/admin/main.py
@@ -41,6 +41,26 @@ SERVER_IP = os.environ.get("SERVER_IP", "")
 DOMAIN = os.environ.get("DOMAIN", "")
 
 
+def ip_matches(ip: str, allowed: str) -> bool:
+    """True if client IP `ip` is covered by whitelist entry `allowed`.
+
+    `allowed` may be a single IP or a CIDR (IPv4 or IPv6). Module-level and pure
+    so it is unit-testable -- it was previously nested in verify_auth, where a
+    CIDR-matching bug (every CIDR entry denied everyone) shipped untested. Fails
+    CLOSED on a malformed entry or an address-family mismatch.
+    """
+    allowed = allowed.strip()
+    if not allowed:
+        return False
+    try:
+        if "/" in allowed:
+            return ipaddress.ip_address(ip) in ipaddress.ip_network(allowed, strict=False)
+        return ipaddress.ip_address(ip) == ipaddress.ip_address(allowed)
+    except ValueError:
+        # Malformed entry, or an IPv4/IPv6 family mismatch: deny.
+        return ip == allowed
+
+
 def get_system_uptime() -> int:
     """Get system uptime in seconds from /proc/uptime."""
     try:
@@ -151,19 +171,7 @@ def verify_auth(request: Request, credentials: HTTPBasicCredentials = Depends(se
         # It failed closed, so it was not a bypass, but an operator setting a
         # CIDR locked themselves out and would most likely drop the whitelist
         # entirely. Use real network containment instead.
-        def _ip_matches(ip: str, allowed: str) -> bool:
-            allowed = allowed.strip()
-            if not allowed:
-                return False
-            try:
-                if "/" in allowed:
-                    return ipaddress.ip_address(ip) in ipaddress.ip_network(allowed, strict=False)
-                return ipaddress.ip_address(ip) == ipaddress.ip_address(allowed)
-            except ValueError:
-                # Malformed entry, or an IPv4/IPv6 family mismatch: deny.
-                return ip == allowed
-
-        ip_allowed = any(_ip_matches(client_ip, a) for a in ADMIN_IP_WHITELIST)
+        ip_allowed = any(ip_matches(client_ip, a) for a in ADMIN_IP_WHITELIST)
         if not ip_allowed:
             raise HTTPException(status_code=403, detail="IP not allowed")
 

--- a/tests/admin-ip-whitelist-test.py
+++ b/tests/admin-ip-whitelist-test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Regression test for the admin IP whitelist matcher (admin/main.py ip_matches).
+
+The previous matcher stripped digits and dots off a CIDR and used startswith(),
+which could never be true for a `/`-terminated string -- so EVERY CIDR entry
+denied everyone. It failed closed (never a bypass), but an operator who set a
+CIDR locked themselves out and most likely removed the whitelist entirely,
+disabling the one mitigation there is for the missing rate limiting.
+
+The repo had zero Python tests, so nothing locked the fix. This does.
+"""
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MAIN = os.path.join(HERE, "..", "admin", "main.py")
+
+# Import ip_matches WITHOUT running the app: pull just the source of the function.
+spec = importlib.util.spec_from_file_location("admin_main", MAIN)
+src = open(MAIN).read()
+ns = {}
+import ipaddress  # noqa: F401  (ip_matches references it)
+ns["ipaddress"] = ipaddress
+# extract the function definition text and exec only that
+start = src.index("def ip_matches(")
+end = src.index("\n\n\n", start)
+exec(compile(src[start:end], MAIN, "exec"), ns)
+ip_matches = ns["ip_matches"]
+
+CASES = [
+    # (client_ip, whitelist_entry, expected)
+    ("10.1.2.3",    "10.0.0.0/8",     True),   # in CIDR  <- the case that was broken
+    ("11.1.2.3",    "10.0.0.0/8",     False),  # outside CIDR
+    ("192.168.5.9", "192.168.0.0/16", True),
+    ("192.169.5.9", "192.168.0.0/16", False),
+    ("1.2.3.4",     "1.2.3.4",        True),   # exact IP
+    ("1.2.3.5",     "1.2.3.4",        False),
+    ("::1",         "::1/128",        True),   # IPv6 CIDR
+    ("2001:db8::5", "2001:db8::/32",  True),
+    ("2001:dead::5","2001:db8::/32",  False),
+    ("10.1.2.3",    "",               False),  # empty entry -> deny
+    ("10.1.2.3",    "not-an-ip/8",    False),  # malformed -> deny (fail closed)
+    ("10.1.2.3",    "::1/128",        False),  # family mismatch -> deny
+    ("10.1.2.3",    "  10.0.0.0/8  ", True),   # surrounding whitespace tolerated
+]
+
+fails = 0
+for ip, allowed, expected in CASES:
+    got = ip_matches(ip, allowed)
+    status = "ok  " if got == expected else "FAIL"
+    if got != expected:
+        fails += 1
+    print(f"  {status} ip_matches({ip!r}, {allowed!r}) = {got}  (want {expected})")
+
+print()
+if fails:
+    print(f"  {fails} FAILED")
+    sys.exit(1)
+print(f"  all {len(CASES)} cases pass")

--- a/tests/state-perms-test.sh
+++ b/tests/state-perms-test.sh
@@ -87,6 +87,28 @@ else
     bad "bootstrap.sh never calls secure_state_keys — secrets stay 0644 in practice"
 fi
 
+# --- .env is created 0600 -------------------------------------------------------
+# .env holds ADMIN_PASSWORD, REALITY_PRIVATE_KEY, CLASH_API_SECRET and the
+# Hysteria2 obfs password. Both creation sites `chmod 600 .env || true`; the
+# `|| true` means a silent regression (e.g. chmod removed) would go unnoticed.
+# Assert the chmod is present at both sites rather than the runtime mode, since
+# these run before any .env exists.
+env_chmod_sites=0
+for f in lib/bootstrap.sh moav.sh; do
+    if grep -qE 'chmod 600 \.env' "$ROOT/$f"; then
+        env_chmod_sites=$((env_chmod_sites + 1))
+    else
+        bad "$f creates .env but does not chmod 600 it"
+    fi
+done
+[[ "$env_chmod_sites" -eq 2 ]] && ok ".env is chmod 600 at both creation sites (bootstrap + moav.sh)"
+
+# And functionally: chmod 600 on a freshly-created file yields 0600.
+tmp_env="$STATE_DIR/env-probe"
+printf 'ADMIN_PASSWORD=x\n' > "$tmp_env"; chmod 600 "$tmp_env"
+m=$(mode "$tmp_env")
+[[ "$m" == "600" ]] && ok ".env probe: chmod 600 produces 0600" || bad ".env probe is $m, not 600"
+
 echo
 echo "  $pass passed, $fail failed"
 [[ $fail -eq 0 ]]


### PR DESCRIPTION
Two security fixes shipped without a test locking them (epic audit findings).

**1. admin IP whitelist.** The CIDR matcher bug (every CIDR entry denied everyone) had no test — the repo had zero Python tests and the function was nested in `verify_auth`. Lifted it to a module-level, pure `ip_matches` (no behaviour change) and added `tests/admin-ip-whitelist-test.py`: 13 cases — IPv4/IPv6 CIDR in/out, exact IPs, empty + malformed (fail closed), family mismatch, whitespace. First Python test in the suite; wired into CI.

**2. `.env` 0600.** Both creation sites `chmod 600 .env || true`; the `|| true` means a silent regression goes unnoticed. `state-perms-test` now asserts the chmod at both sites plus a functional 0600 probe.

CI-only gate (test additions + a pure-function extraction with no behaviour change).