### PR TITLE
test(anytls): re-enable AnyTLS coverage — it works, #204 was a misdiagnosis

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,12 +109,13 @@ jobs:
           else
             sed -i "s|^DOMAIN=.*|DOMAIN=${MOAV_DOMAIN}|"             .env
             sed -i "s|^ACME_EMAIL=.*|ACME_EMAIL=${MOAV_ACME_EMAIL}|" .env
-            # NOTE: ENABLE_ANYTLS is deliberately NOT turned on here yet.
-            # Enabling it (PR #203) made `bootstrap` leave sing-box unconfigured
-            # — `moav user add` then reported "Skipping sing-box (not configured)"
-            # and every bundle came out empty, every protocol skipped. Tracked
-            # as a real AnyTLS-provisioning bug; re-enable once that is fixed and
-            # reproduced. AnyTLS therefore still has no live CI coverage.
+            # AnyTLS is on for the domain pass. The earlier failure (PR #203) was a
+            # STATE-REUSE artifact, not a provisioning bug: the default tier does not
+            # wipe the state volume, so a stale .bootstrapped made bootstrap skip config
+            # regeneration and the anytls inbound was never added. The template renders
+            # valid with AnyTLS on (verified), full/mega wipe state first, and the
+            # hollow-run guard now fails a run that tests nothing.
+            sed -i "s|^ENABLE_ANYTLS=.*|ENABLE_ANYTLS=true|" .env
           fi
           # INITIAL_USERS is a COUNT (not a name) — 1 creates the 'demouser'.
           # We add a named 'e2e-test' user after start (also exercises `user add`).

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -331,8 +331,8 @@ jobs:
           # HOLLOW-RUN GUARD. `skip` never counted as failure, so a broken
           # bootstrap that left every protocol unconfigured produced all-skip
           # and passed green — the run tested nothing. (This actually shipped:
-          # ENABLE_ANYTLS=true broke sing-box config generation, every protocol
-          # skipped, e2e stayed green.) Require the core sing-box protocols that
+          # skipped, e2e stayed green (this shipped once and drove this guard's
+          # creation). Require the core sing-box protocols that run in EVERY
           # run in EVERY domain pass to actually PASS. reality+ss also run in
           # the domainless pass, so gate the domain-only ones on DOMAIN.
           require_pass() {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -328,13 +328,12 @@ jobs:
             echo "::error::e2e connectivity test failed for $fails protocol(s)"
             exit 1
           fi
-          # HOLLOW-RUN GUARD. `skip` never counted as failure, so a broken
-          # bootstrap that left every protocol unconfigured produced all-skip
-          # and passed green — the run tested nothing. (This actually shipped:
-          # skipped, e2e stayed green (this shipped once and drove this guard's
-          # creation). Require the core sing-box protocols that run in EVERY
-          # run in EVERY domain pass to actually PASS. reality+ss also run in
-          # the domainless pass, so gate the domain-only ones on DOMAIN.
+          # HOLLOW-RUN GUARD. `skip` never counted as failure, so a broken bootstrap
+          # that left every protocol unconfigured produced all-skip and passed green,
+          # testing nothing. That shipped once and is why this guard exists. Require the
+          # core sing-box protocols that run in EVERY domain pass to actually PASS;
+          # reality+ss also run in the domainless pass, so gate the domain-only ones on
+          # DOMAIN.
           require_pass() {
             local p="$1"
             local st=$(jq -r --arg p "$p" '.tests[$p].status // "absent"' e2e-results.json)


### PR DESCRIPTION
**Definitive result from a clean-state full-tier e2e:**
```
[OK] AnyTLS connection successful (exit IP: 139.59.21.170)
anytls: pass
```

A real tunnel with a real exit IP. My #204 conclusion that `ENABLE_ANYTLS=true`
breaks bootstrap was **a misdiagnosis** — the sing-box template renders valid with
AnyTLS on, and the original #203 failure was a state-reuse artifact (stale
`.bootstrapped` → bootstrap skipped config regeneration) tangled with the
hollow-run bug in the same run.

This turns AnyTLS on in the e2e domain pass, so **AnyTLS has live CI coverage for
the first time**, and cleans the two stale comments that blamed it. The card is a
misdiagnosis to close, not a bug to fix.