### PR TITLE
fix(security): clash-api.env to 0600; make the key-perms repair reach existing installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **The Clash API secret file is now 0600 like every other key.** `clash-api.env` was the one deliberate world-readable exception under `state/keys` because the non-root admin app read it directly. The root admin entrypoint now reads it and hands the secret over via environment, so the exception (and the code that actively restored 0644 on every pass) is gone. Requires the admin image to be rebuilt, which `moav update` does.
+- **The key-permissions repair now actually reaches existing installs.** The rc.2 fix that tightened `state/keys` to 0600 only ran at the end of a fresh bootstrap; already-bootstrapped installs exit earlier and upgrades never run the bootstrap container at all, so the installs the repair was written for never got it. The repair now also runs inside the early-exit guard and, host-side, on every `moav up`/`moav start`.
+
 ### Changed
 - **Deduplicated the TrustTunnel... telemt user-add path.** `singbox-user-add.sh` had an inline copy of the telemt config mutation that duplicated `scripts/lib/telemt.sh` and drifted from it; the host caller now uses the shared `telemt_generate_secret` + `telemt_add_user_to_config` (the latter gained a config-path argument so host and container callers share it). Also fixes a latent bug: the inline version minted a fresh MTProxy secret on every re-run, invalidating the user's existing bundle; the lib path reuses the stored secret.
 

--- a/admin/main.py
+++ b/admin/main.py
@@ -72,14 +72,17 @@ def get_system_uptime() -> int:
 SINGBOX_API = "http://moav-sing-box:9090"
 CLASH_SECRET = ""
 
-# Try to load Clash API secret
-try:
-    with open("/state/keys/clash-api.env") as f:
-        for line in f:
-            if line.startswith("CLASH_API_SECRET="):
-                CLASH_SECRET = line.split("=", 1)[1].strip()
-except FileNotFoundError:
-    pass
+# Prefer the env var handed over by the root entrypoint (the state file is 0600
+# root-only); the file read remains as a fallback and must never be fatal.
+CLASH_SECRET = os.environ.get("CLASH_API_SECRET", "").strip()
+if not CLASH_SECRET:
+    try:
+        with open("/state/keys/clash-api.env") as f:
+            for line in f:
+                if line.startswith("CLASH_API_SECRET="):
+                    CLASH_SECRET = line.split("=", 1)[1].strip()
+    except OSError:
+        pass
 
 # Current version
 CURRENT_VERSION = "unknown"

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -730,6 +730,21 @@ ensure_conduit_lifetime_rules() {
     fi
 }
 
+# Tighten private key material in the state volume to 0600. The equivalent call
+# in bootstrap.sh is unreachable for already-bootstrapped installs (the
+# .bootstrapped guard exits first), so upgrades never got the rc.2 perms repair.
+# Runs on every start: idempotent, one alpine one-shot, mirrors
+# secure_state_keys' public-file skips.
+repair_state_key_perms() {
+    docker run --rm -v moav_moav_state:/state alpine sh -c '
+        cd /state/keys 2>/dev/null || exit 0
+        for f in *; do
+            [ -f "$f" ] || continue
+            case "$f" in *.pub|*.pub.hex|*-cert.pem|*.crt|*.csr) continue ;; esac
+            chmod 600 "$f"
+        done' 2>/dev/null || true
+}
+
 ensure_clash_api_secret() {
     local profiles="$1"
     local env_file="$SCRIPT_DIR/.env"
@@ -856,6 +871,8 @@ start_services() {
             return 1
         fi
     fi
+
+    repair_state_key_perms
 
     # Ensure CLASH_API_SECRET is configured for monitoring
     # Returns 1 if user declined monitoring when using 'all' profile
@@ -1234,6 +1251,8 @@ cmd_start() {
             exit 1
         fi
     fi
+
+    repair_state_key_perms
 
     # Ensure CLASH_API_SECRET is configured for monitoring
     # Returns 1 if user declined monitoring when using 'all' profile

--- a/scripts/admin-entrypoint.sh
+++ b/scripts/admin-entrypoint.sh
@@ -73,6 +73,11 @@ chown -R moav:moav /project/outputs /project/configs /project/state 2>/dev/null 
 chmod -R a+rwX /project/outputs /project/state 2>/dev/null || true
 chmod -R a+rwX /project/configs/sing-box /project/configs/xray /project/configs/amneziawg /project/configs/wireguard /project/configs/trusttunnel /project/configs/telemt 2>/dev/null || true
 
+# Read the Clash API secret as root and hand it to the app via env — the state
+# file is 0600 root-only and the app below runs as the non-root moav user.
+CLASH_API_SECRET=$(grep '^CLASH_API_SECRET=' /state/keys/clash-api.env 2>/dev/null | tail -1 | cut -d= -f2- || true)
+export CLASH_API_SECRET
+
 # Run the dashboard as non-root
 echo "[admin] Starting uvicorn server..."
 exec su-exec moav python main.py

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -156,6 +156,9 @@ mkdir -p "$STATE_DIR"/{users,keys}
 
 # Check if already bootstrapped
 if [[ -f "$STATE_DIR/.bootstrapped" ]]; then
+    # Repair key perms even when skipping the re-bootstrap: the call at the end
+    # of this script is unreachable for existing installs.
+    secure_state_keys "$STATE_DIR/keys"
     log_info "Already bootstrapped. To re-bootstrap, run:"
     log_info "  docker run --rm -v moav_moav_state:/state alpine rm /state/.bootstrapped"
     log_info "  docker compose --profile setup run --rm bootstrap"
@@ -238,11 +241,12 @@ if [[ "${ENABLE_REALITY:-true}" == "true" ]] || [[ "${ENABLE_TROJAN:-true}" == "
         log_info "Hysteria2 obfuscation password already exists, skipping generation"
     fi
 
-    # Save to state
-    cat > "$STATE_DIR/keys/clash-api.env" <<EOF
+    # Save to state (0600: the root admin entrypoint reads it, not the app user)
+    (umask 077 && cat > "$STATE_DIR/keys/clash-api.env" <<EOF
 CLASH_API_SECRET=$CLASH_API_SECRET
 HYSTERIA2_OBFS_PASSWORD=$HYSTERIA2_OBFS_PASSWORD
 EOF
+    )
 
     # Parse Reality target
     REALITY_TARGET_HOST=$(echo "${REALITY_TARGET:-dl.google.com:443}" | cut -d: -f1)

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -104,25 +104,10 @@ secure_state_keys() {
         base="$(basename "$f")"
         case "$base" in
             *.pub|*.pub.hex|*-cert.pem|*.crt|*.csr) continue ;;   # public by design
-            # EXCEPTION -- clash-api.env must stay group/world readable.
-            # admin/main.py reads it directly, and the admin container drops to a
-            # NON-root user (`exec su-exec moav …`, uid 100 / gid 101 on
-            # python:3.12-alpine), so 0600 root-owned locks it out and the
-            # container crash-loops with PermissionError. bootstrap's
-            # `chown -R 0:1000` never applied to it either -- /configs and
-            # /outputs only work for admin because they are world-readable.
-            # Tracked: admin should get this secret without a world-readable file.
-            #
-            # Actively RESTORE readability rather than merely skipping: an
-            # earlier build of this function already tightened the file, and the
-            # state volume persists across upgrades, so a plain `continue` would
-            # leave those installs permanently broken. Repair must be
-            # bidirectional to be a repair at all.
-            clash-api.env)
-                chmod 644 "$f" 2>/dev/null || true
-                continue
-                ;;
         esac
+        # clash-api.env is no longer an exception: the root admin entrypoint now
+        # reads it and hands the secret to the non-root app via env, so 0600 is
+        # safe. Requires an admin image built from this revision or later.
         # Only touch what is actually loose, so the log stays meaningful.
         #
         # `find -perm /077` is GNU-only: BSD/macOS find rejects it, the test

--- a/tests/state-perms-test.sh
+++ b/tests/state-perms-test.sh
@@ -39,29 +39,30 @@ echo k > "$STATE_DIR/keys/wg-server.key"; chmod 600 "$STATE_DIR/keys/wg-server.k
 
 secure_state_keys "$STATE_DIR/keys" >/dev/null 2>&1
 
-for f in reality.env cdn.env amneziawg.env shadowsocks-server.psk \
+for f in reality.env clash-api.env cdn.env amneziawg.env shadowsocks-server.psk \
          wstunnel-path.secret masterdns-encrypt.key gooserelay-tunnel.key slipstream-key.pem; do
     m=$(mode "$STATE_DIR/keys/$f")
     [[ "$m" == "600" ]] && ok "secret $f -> 0600" || bad "secret $f is $m (expected 600)"
 done
 
-# clash-api.env is a deliberate exception: admin/main.py reads it and the admin
-# container runs as a NON-root user (uid 100), so 0600 crash-loops it with
-# PermissionError. Tightening this one regressed a live e2e -- assert it stays
-# readable so the exception cannot be "helpfully" removed later.
-# REPAIR case: an earlier build of secure_state_keys already tightened this file,
-# and the state volume survives upgrades -- so the exemption must actively restore
-# readability, not merely skip. A skip-only version passed the test above while
-# leaving already-damaged installs permanently crash-looping.
-chmod 600 "$STATE_DIR/keys/clash-api.env"
+# clash-api.env used to be a deliberate 0644 exception (the non-root admin app
+# read it directly). The root admin entrypoint now hands the secret over via
+# env, so the file joins the 0600 family above -- and installs where the old
+# exception actively RESTORED 0644 must get tightened on the next pass.
+chmod 644 "$STATE_DIR/keys/clash-api.env"
 secure_state_keys "$STATE_DIR/keys" >/dev/null 2>&1
 m=$(mode "$STATE_DIR/keys/clash-api.env")
-[[ "$m" == "644" ]] && ok "clash-api.env already at 0600 is REPAIRED back to readable" \
-                    || bad "clash-api.env stayed $m — an install damaged by the earlier bug stays broken"
+[[ "$m" == "600" ]] && ok "clash-api.env restored to 644 by the old exception is re-tightened" \
+                    || bad "clash-api.env stayed $m — installs that ran the old 644-restoring exception keep a readable secret"
 
-m=$(mode "$STATE_DIR/keys/clash-api.env")
-[[ "$m" == "644" ]] && ok "clash-api.env left readable for the non-root admin ($m)" \
-                    || bad "clash-api.env is $m — the admin container cannot read it and will crash-loop"
+# The entrypoint handoff the 0600 depends on: root reads the file, exports, app
+# prefers env. Assert both halves exist so neither can be removed independently.
+grep -q 'CLASH_API_SECRET=.*clash-api.env' "$ROOT/scripts/admin-entrypoint.sh" \
+    && ok "admin entrypoint hands CLASH_API_SECRET over via env" \
+    || bad "admin entrypoint no longer exports CLASH_API_SECRET — 0600 file + non-root app = broken Clash auth"
+grep -q 'os.environ.get("CLASH_API_SECRET"' "$ROOT/admin/main.py" \
+    && ok "admin app prefers the env var" \
+    || bad "admin/main.py does not read CLASH_API_SECRET from env — 0600 file locks it out"
 
 for f in wg-server.pub awg-server.pub dnstt-server.pub.hex slipstream-cert.pem; do
     m=$(mode "$STATE_DIR/keys/$f")
@@ -85,6 +86,25 @@ if grep -q 'secure_state_keys' "$ROOT/scripts/bootstrap.sh"; then
     ok "bootstrap.sh calls secure_state_keys"
 else
     bad "bootstrap.sh never calls secure_state_keys — secrets stay 0644 in practice"
+fi
+
+# ...and it must run INSIDE the .bootstrapped early-exit guard too. The
+# end-of-script call is unreachable for existing installs (the guard exits
+# first), which is how the original repair silently never reached the live
+# servers it was written for.
+if sed -n '/\.bootstrapped" \]\]; then/,/^fi/p' "$ROOT/scripts/bootstrap.sh" | grep -q 'secure_state_keys'; then
+    ok "repair runs even when bootstrap early-exits (already bootstrapped)"
+else
+    bad "the .bootstrapped guard exits before secure_state_keys — existing installs never get repaired"
+fi
+
+# Upgrades never run the bootstrap container at all, so the host start path must
+# repair the state volume itself.
+if grep -q 'repair_state_key_perms()' "$ROOT/lib/service.sh" \
+   && [[ $(grep -cE '^\s*repair_state_key_perms$' "$ROOT/lib/service.sh") -ge 2 ]]; then
+    ok "moav start paths repair state-key perms (covers upgrades)"
+else
+    bad "lib/service.sh start paths do not call repair_state_key_perms — upgraded installs keep 0644 keys"
 fi
 
 # --- .env is created 0600 -------------------------------------------------------


### PR DESCRIPTION
## What

Two fixes from the known-bugs pass (decision B of the release plan):

**1. `clash-api.env` joins the 0600 family.** It was the one deliberate world-readable exception under `state/keys`, because `admin/main.py` reads it and the admin app runs as the non-root `moav` user. The admin entrypoint runs as root (it already chowns the project mounts), so it now reads the file and exports `CLASH_API_SECRET` before `su-exec`; the app prefers the env var with the file read kept as a non-fatal fallback. The exception in `secure_state_keys` (which actively restored 0644 on every pass) is removed, and bootstrap creates the file under `umask 077`. The other consumers (singbox-exporter, bootstrap, host scripts) all read as root and are unaffected.

**2. The rc.2 key-perms repair never reached existing installs.** `secure_state_keys` was called only at the end of a fresh bootstrap. Already-bootstrapped installs exit at the `.bootstrapped` guard ~800 lines earlier, and upgraded installs never run the bootstrap container at all — so the live servers with 0644 `reality.env` that motivated the fix never got repaired. The repair now also runs inside the early-exit guard, and host-side on every `moav up`/`moav start` via a one-shot alpine container against the state volume.

## Tests

`tests/state-perms-test.sh` extended to 24 checks: clash-api.env asserted 0600 including the re-tighten of installs the old exception had restored to 0644; both halves of the entrypoint env handoff pinned so neither can be removed independently; the in-guard repair and both host start-path calls asserted.

## Deploy note

The 0600 file requires an admin image built from this revision (entrypoint + app ship in the same image, so they update atomically on rebuild; `moav update` rebuilds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNXwkdMpF8ZaGu2fMYCBXY