### PR TITLE
fix: four live-upgrade regressions found on the first 1.9.1 → v2 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Four upgrade regressions found on the first live 1.9.1 → v2 upgrade.** The key-permissions repair normalized modes but not OWNERSHIP: live installs carry state keys owned by old per-container uids (uid 999 from the v1 dnstt image), and a `cap_drop: ALL` container without `DAC_OVERRIDE` cannot read a 0600 file it does not own even as in-container root. The repair now chowns to root. Second, dnstt, masterdns and slipstream run their daemons as `USER moav` and read their own key directly, so those three keys stay 644 inside the state volume (the mount boundary is the control) — 0600 silently killed all three tunnels. Third, the singbox-exporter crash-looped on the now-0600 Clash secret file: it reads the env var first now (compose already passed it) and any file-read failure is non-fatal. Fourth, the xray access-log tailer could never read the log (xray-core creates it 0600 under xray's non-root uid; the exporter has no DAC_OVERRIDE) — the xray entrypoint now keeps it 644 — and a leftover `result.stderr` reference raised NameError on every stats poll.
+
+### Added
+- **Community links in `moav start` and `moav status` output.** Telegram and X shown after "Services started!" and as a footer under the status table.
+
 ### Security
 - **The Clash API secret file is now 0600 like every other key.** `clash-api.env` was the one deliberate world-readable exception under `state/keys` because the non-root admin app read it directly. The root admin entrypoint now reads it and hands the secret over via environment, so the exception (and the code that actively restored 0644 on every pass) is gone. Requires the admin image to be rebuilt, which `moav update` does.
 - **The key-permissions repair now actually reaches existing installs.** The rc.2 fix that tightened `state/keys` to 0600 only ran at the end of a fresh bootstrap; already-bootstrapped installs exit earlier and upgrades never run the bootstrap container at all, so the installs the repair was written for never got it. The repair now also runs inside the early-exit guard and, host-side, on every `moav up`/`moav start`.

--- a/exporters/singbox/main.py
+++ b/exporters/singbox/main.py
@@ -68,10 +68,19 @@ GEOIP_POLL_INTERVAL = int(os.environ.get("SINGBOX_POLL_INTERVAL", "15"))
 
 
 def load_clash_secret():
-    """Try to load the Clash API secret from state volume or environment."""
+    """Try to load the Clash API secret from environment or state volume."""
     global CLASH_SECRET
 
-    # Try state volume (source of truth from bootstrap)
+    # Environment first: compose passes CLASH_TOKEN, and the state file is 0600
+    # root-only since the admin env-handoff change. This container is
+    # cap_drop ALL without DAC_OVERRIDE, so even as root it can only read
+    # state files it owns; a PermissionError here used to crash-loop it.
+    CLASH_SECRET = os.environ.get("CLASH_TOKEN", "").strip().strip('"').strip("'")
+    if CLASH_SECRET:
+        print(f"Loaded Clash API secret from environment ({len(CLASH_SECRET)} chars)")
+        return
+
+    # Fall back to the state volume; any read failure must be non-fatal.
     for path in ["/state/keys/clash-api.env", "/state/clash_api_secret"]:
         try:
             with open(path) as f:
@@ -86,11 +95,8 @@ def load_clash_secret():
                         CLASH_SECRET = line
                         print(f"Loaded Clash API secret from {path}")
                         return
-        except FileNotFoundError:
+        except OSError:
             continue
-
-    # Fall back to environment
-    CLASH_SECRET = os.environ.get("CLASH_TOKEN", "").strip().strip('"').strip("'")
     if CLASH_SECRET:
         print(f"Loaded Clash API secret from environment ({len(CLASH_SECRET)} chars)")
     else:

--- a/exporters/xray/main.py
+++ b/exporters/xray/main.py
@@ -135,16 +135,13 @@ def query_xray_stats():
             return
 
         if stats_query_count == 0:
-            print(f"Stats API raw: stdout={len(user_output)} bytes, stderr={len(result.stderr)} bytes")
-            if user_output:
-                print(f"Stats stdout preview: {user_output[:200]}")
-            if result.stderr and not user_output:
-                print(f"Stats stderr preview: {result.stderr[:200]}")
+            print(f"Stats snapshot: {len(user_output)} bytes")
+            print(f"Stats preview: {user_output[:200]}")
 
-        # xray may output to stdout or stderr depending on version
+        # Snapshot file contents (the docker-exec stderr fallback died with the
+        # socket removal; a leftover `result.stderr` reference here raised
+        # NameError on every poll).
         output = user_output.strip()
-        if not output:
-            output = result.stderr.strip()
         if not output:
             return
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -60,6 +60,12 @@ version_gt() {
     return 1
 }
 
+# Footer-style community links, shown after `moav start` success and at the
+# end of `moav status`.
+print_community_links() {
+    echo -e "  ${DIM}Community: https://t.me/motherofallvpns  |  https://x.com/motherofallvpns${NC}"
+}
+
 print_header() {
     # Only clear when stdout is a TTY (avoids "TERM not set" abort under setsid).
     if [[ -t 1 ]]; then

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -246,6 +246,8 @@ show_status() {
     echo -e "  ${DIM}Note: certbot is a one-time service that obtains SSL certificates.${NC}"
     echo -e "  ${DIM}      Status 'Exited (0)' means it completed successfully.${NC}"
     echo ""
+    print_community_links
+    echo ""
 }
 
 # Display service selection menu and populate SELECTED_PROFILES array
@@ -768,11 +770,22 @@ repair_bundle_perms() {
 # Runs on every start: idempotent, one alpine one-shot, mirrors
 # secure_state_keys' public-file skips.
 repair_state_key_perms() {
+    # Ownership too, not just mode: live installs carry keys owned by old
+    # per-container uids (999 from the v1 dnstt image on a real server), which
+    # a cap_drop-ALL container root cannot read once 0600. The three keys read
+    # directly by non-root daemons (dnstt/masterdns/slipstream run USER moav)
+    # stay 644 — inside the volume, the mount boundary is the control.
     docker run --rm -v moav_moav_state:/state alpine sh -c '
+        [ -d /state/keys ] || exit 0
+        chown 0:0 /state/keys 2>/dev/null || true
         cd /state/keys 2>/dev/null || exit 0
         for f in *; do
             [ -f "$f" ] || continue
-            case "$f" in *.pub|*.pub.hex|*-cert.pem|*.crt|*.csr) continue ;; esac
+            chown 0:0 "$f" 2>/dev/null || true
+            case "$f" in
+                *.pub|*.pub.hex|*-cert.pem|*.crt|*.csr) chmod 644 "$f"; continue ;;
+                dnstt-server.key.hex|masterdns-encrypt.key|slipstream-key.pem) chmod 644 "$f"; continue ;;
+            esac
             chmod 600 "$f"
         done' 2>/dev/null || true
 }
@@ -948,6 +961,8 @@ start_services() {
             echo ""
         fi
         show_log_help
+        echo ""
+        print_community_links
     fi
 }
 
@@ -1254,6 +1269,8 @@ cmd_start() {
             success "Services started!"
             auto_setup_conduit_offsets
             auto_setup_cert_renew
+            echo ""
+            print_community_links
             return 0
         elif [[ -n "$individual_services" ]]; then
             warn "Ignoring individual services ($individual_services) when mixed with profiles"
@@ -1352,6 +1369,7 @@ cmd_start() {
     if echo "$profiles" | grep -qE "admin|monitoring|proxy|all"; then
         echo ""
     fi
+    print_community_links
     auto_setup_conduit_offsets
     auto_setup_cert_renew
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -126,18 +126,34 @@ grant_admin_rw() {
 # at 0644, while the raw *.key files beside them were correctly 0600.
 #
 # Idempotent: safe to call on every bootstrap, and it repairs existing installs.
-# Public counterparts (*.pub, certs) are skipped — other parties must read those.
-# Every container that mounts the state volume runs as root, so tightening the
-# mode cannot lock a service out of its own key material.
+# Public counterparts (*.pub, certs) stay 644 — other parties must read those.
+#
+# OWNERSHIP is normalized to root, not just the mode: live installs carry keys
+# owned by whatever uid the old per-container flows wrote them as (a real
+# server had uid-999 files from the v1 dnstt image), and a cap_drop-ALL
+# container without DAC_OVERRIDE cannot read a 0600 file it does not own even
+# as in-container root. The earlier claim that "every state-volume container
+# runs as root" was wrong twice over: root there does not bypass modes, and
+# dnstt/masterdns/slipstream run their daemons as USER moav (uid ~100). Those
+# three read their own key directly, so their key files stay world-readable
+# INSIDE the volume (644) — the volume boundary is the actual control, as it
+# always was — while everything else goes 0600 root.
 secure_state_keys() {
     local keys_dir="${1:-$STATE_DIR/keys}"
     [[ -d "$keys_dir" ]] || return 0
+    chown 0:0 "$keys_dir" 2>/dev/null || true
     local f base fixed=0
     for f in "$keys_dir"/*; do
         [[ -f "$f" ]] || continue
         base="$(basename "$f")"
+        chown 0:0 "$f" 2>/dev/null || true
         case "$base" in
-            *.pub|*.pub.hex|*-cert.pem|*.crt|*.csr) continue ;;   # public by design
+            *.pub|*.pub.hex|*-cert.pem|*.crt|*.csr)
+                chmod 644 "$f" 2>/dev/null || true   # public by design
+                continue ;;
+            dnstt-server.key.hex|masterdns-encrypt.key|slipstream-key.pem)
+                chmod 644 "$f" 2>/dev/null || true   # non-root daemon reads it
+                continue ;;
         esac
         # clash-api.env is no longer an exception: the root admin entrypoint now
         # reads it and hands the secret to the non-root app via env, so 0600 is

--- a/scripts/xray-entrypoint.sh
+++ b/scripts/xray-entrypoint.sh
@@ -59,8 +59,15 @@ if [ -d "$METRICS_STATE_DIR" ]; then
     # the exporter's tail (both detect the shrink and continue).
     ACCESS_LOG="$METRICS_STATE_DIR/xray-access.log"
     ACCESS_LOG_MAX_BYTES="${ACCESS_LOG_MAX_BYTES:-33554432}"   # 32 MiB
+    # Pre-create the log readable: xray-core creates it 0600, and the exporter
+    # (root but cap_drop ALL, no DAC_OVERRIDE) reads a moav-owned file only via
+    # the world bits. We own the file, so the chmod always works; the loop
+    # below re-applies it in case xray ever recreates the file itself.
+    : >> "$ACCESS_LOG" 2>/dev/null || true
+    chmod 644 "$ACCESS_LOG" 2>/dev/null || true
     cap_access_log() {
         [ -f "$ACCESS_LOG" ] || return 0
+        chmod 644 "$ACCESS_LOG" 2>/dev/null || true
         _sz=$(stat -c %s "$ACCESS_LOG" 2>/dev/null || stat -f %z "$ACCESS_LOG" 2>/dev/null || echo 0)
         if [ "${_sz:-0}" -gt "$ACCESS_LOG_MAX_BYTES" ]; then
             : > "$ACCESS_LOG"

--- a/tests/state-perms-test.sh
+++ b/tests/state-perms-test.sh
@@ -27,7 +27,8 @@ source "$ROOT/scripts/lib/common.sh" 2>/dev/null || { echo "cannot source common
 
 # Secrets, deliberately created loose (0644) the way the heredoc writers do.
 for f in reality.env clash-api.env cdn.env amneziawg.env shadowsocks-server.psk \
-         wstunnel-path.secret masterdns-encrypt.key gooserelay-tunnel.key slipstream-key.pem; do
+         wstunnel-path.secret gooserelay-tunnel.key \
+         dnstt-server.key.hex masterdns-encrypt.key slipstream-key.pem; do
     echo "SECRET=x" > "$STATE_DIR/keys/$f"; chmod 644 "$STATE_DIR/keys/$f"
 done
 # Public counterparts must stay readable -- other parties consume them.
@@ -40,10 +41,34 @@ echo k > "$STATE_DIR/keys/wg-server.key"; chmod 600 "$STATE_DIR/keys/wg-server.k
 secure_state_keys "$STATE_DIR/keys" >/dev/null 2>&1
 
 for f in reality.env clash-api.env cdn.env amneziawg.env shadowsocks-server.psk \
-         wstunnel-path.secret masterdns-encrypt.key gooserelay-tunnel.key slipstream-key.pem; do
+         wstunnel-path.secret gooserelay-tunnel.key; do
     m=$(mode "$STATE_DIR/keys/$f")
     [[ "$m" == "600" ]] && ok "secret $f -> 0600" || bad "secret $f is $m (expected 600)"
 done
+
+# dnstt/masterdns/slipstream run their daemons as USER moav (uid ~100) and read
+# their own key directly, so those three must stay readable INSIDE the volume:
+# 0600 root there means the service silently cannot start (hit live on a v1.9.1
+# upgrade, where the keys were also owned by the old image's uid 999).
+for f in dnstt-server.key.hex masterdns-encrypt.key slipstream-key.pem; do
+    chmod 600 "$STATE_DIR/keys/$f"
+done
+secure_state_keys "$STATE_DIR/keys" >/dev/null 2>&1
+for f in dnstt-server.key.hex masterdns-encrypt.key slipstream-key.pem; do
+    m=$(mode "$STATE_DIR/keys/$f")
+    [[ "$m" == "644" ]] && ok "non-root-daemon key $f restored to 644" \
+                        || bad "$f is $m — its non-root daemon cannot read it and the service dies"
+done
+
+# Ownership must be normalized to root, not just the mode: cap_drop-ALL
+# container roots read a 0600 file only as OWNER, and live installs carry keys
+# owned by old per-container uids. (chown needs root; assert statically.)
+grep -q 'chown 0:0' "$ROOT/scripts/lib/common.sh" \
+    && ok "secure_state_keys normalizes key ownership to root" \
+    || bad "secure_state_keys no longer chowns to root — uid-999 keys stay unreadable for DAC-less containers"
+grep -q 'chown 0:0' "$ROOT/lib/service.sh" \
+    && ok "host-side repair normalizes key ownership to root" \
+    || bad "repair_state_key_perms no longer chowns — upgraded installs keep old-uid keys"
 
 # clash-api.env used to be a deliberate 0644 exception (the non-root admin app
 # read it directly). The root admin entrypoint now hands the secret over via


### PR DESCRIPTION
## What

The bitchat upgrade surfaced four regressions e2e could not see, all rooted in the same blind spot: **e2e's reused state volume is root-owned (bootstrap-created), but a real 1.9.1 install carries keys owned by old per-container uids** (uid 999 from the v1 dnstt image), and several daemons are not root at all.

1. **The key repair normalized modes but not ownership.** A `cap_drop: ALL` container without `DAC_OVERRIDE` reads a 0600 file only as its owner, so 999-owned keys became unreadable to everyone. Both repair paths (`secure_state_keys`, `repair_state_key_perms`) now chown to root.
2. **dnstt, masterdns and slipstream run their daemons as `USER moav`** and read their own key directly. 0600-root silently killed all three tunnels. Their three key files stay 644 inside the state volume; the mount boundary is (and always was) the actual control. The rc.2-era comment claiming every state-volume container runs as root is corrected.
3. **singbox-exporter crash-looped** on the now-0600 Clash secret: its file read caught only `FileNotFoundError`. It now reads `CLASH_TOKEN` from env first (compose already passes it) and treats any file-read failure as non-fatal.
4. **The xray access-log tailer could never read the log** (xray-core creates it 0600 under xray's non-root uid; the exporter has no `DAC_OVERRIDE`): the xray entrypoint now keeps it 644 (it owns the file). Plus a leftover `result.stderr` reference that raised `NameError` on every stats poll.

Also per user request: community links (Telegram/X) after `moav start` success and as a `moav status` footer.

## Tests

`tests/state-perms-test.sh` now 27 checks: the three non-root-daemon keys asserted 644 (including the repair back from 0600), everything else still 0600, and static assertions that both repair paths chown to root. All other suites green.

## Deploy note (bitchat)

After merge: `moav update -b dev && moav build && moav start` — the exporter and xray fixes are baked into images, so the build step is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNXwkdMpF8ZaGu2fMYCBXY