### PR TITLE
feat(e4): slim .env.example to a curated 28-var first-run surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,472 +1,76 @@
 # MoaV - Multi-protocol Circumvention Stack
-# Copy to .env and fill in your values
+# Copy to .env and set the values below.
+#
+# This is the CURATED minimal config. Every other tunable (ports, component
+# versions, per-protocol tuning, Reality/XHTTP targets, DNS-tunnel subdomains,
+# CDN, bandwidth donation, monitoring, client mode, registry overrides) has a
+# working default and lives in .env.example.full - copy any line you want to
+# override into your .env.
 
 # =============================================================================
-# REQUIRED CONFIGURATION
+# REQUIRED
 # =============================================================================
 
-# Your domain (must have DNS configured - see https://moav.sh/docs/DNS)
-# Leave empty to run only domainless services (Reality, XHTTP, WireGuard, etc.)
+# Your domain (DNS must point here - see https://moav.sh/docs/DNS).
+# Leave empty to run only domainless services (Reality, XHTTP, WireGuard, ...).
 DOMAIN=
 
-# Email for Let's Encrypt certificates (required if DOMAIN is set)
+# Let's Encrypt email (required if DOMAIN is set).
 ACME_EMAIL=
 
-# Auto-install a daily cert-renewal timer (systemd, or cron.d fallback) on
-# `moav start` when DOMAIN is set — Let's Encrypt certs expire after 90 days.
-# Set false to opt out and schedule renewal yourself (`moav cert install`).
-CERT_AUTORENEW=true
-
-# Admin password for stats dashboard (https://your-domain:9443)
+# Admin dashboard password (https://<your-domain>:9443).
 ADMIN_PASSWORD=change_me_to_something_secure
 
 # =============================================================================
-# SERVER IDENTITY
+# SERVER IDENTITY (auto-detected if empty)
 # =============================================================================
 
-# Server's public IP (auto-detected if empty, but set manually for reliability)
 SERVER_IP=
-
-# Server's public IPv6 (auto-detected if available)
-# Set to "disabled" to explicitly disable IPv6 even if available
+# Set to "disabled" to force IPv6 off even when available.
 SERVER_IPV6=
 
 # =============================================================================
-# PROTOCOL TOGGLES
+# PROTOCOLS (toggle what runs; each has a sensible default)
 # =============================================================================
 
-# Enable/disable individual protocols
 ENABLE_REALITY=true
 ENABLE_TROJAN=true
-ENABLE_HYSTERIA2=true
-# AnyTLS (sing-box native, defeats TLS-in-TLS fingerprinting). Opt-in: narrower
-# client support than Trojan/VLESS (Hiddify, sing-box SFA/SFI, NekoBox, mihomo,
-# Shadowrocket 2.2.65+). Reuses the Trojan TLS cert/domain. Refs: github.com/anytls/anytls-go
+# AnyTLS: narrower client support (Hiddify, sing-box, NekoBox, mihomo). Opt-in.
 ENABLE_ANYTLS=false
-# Shadowsocks-2022 (AEAD-2022, anti-active-probing). Compatible with NekoBox,
-# Hiddify, Streisand, sing-box clients via standard ss:// URI.
-# Refs: github.com/MotherofallVPNs/moav/issues/93
+ENABLE_HYSTERIA2=true
 ENABLE_SS=true
+ENABLE_XHTTP=true
 ENABLE_WIREGUARD=true
-# dnstt/Slipstream/MasterDNS all enabled by default — broader client ecosystem
-# than XDNS (standalone binaries on 25+ platforms vs FinalMask-aware Xray clients
-# like Happ). All three run in parallel: dns-router fans queries out by subdomain
-# suffix (t./s./m.) so they share port 53 with no conflict. Each needs its own
-# NS record (DNSTT_SUBDOMAIN / SLIPSTREAM_SUBDOMAIN / MASTERDNS_SUBDOMAIN below).
+ENABLE_AMNEZIAWG=true
 ENABLE_DNSTT=true
 ENABLE_SLIPSTREAM=true
-# MasterDNS - advanced DNS tunnel (ARQ + resolver LB), bundled in MahsaNG v16.
-# Adds a container. Coexists with dnstt/Slipstream via dns-router on its own
-# subdomain (MASTERDNS_SUBDOMAIN) — no port conflict. Set to false to opt out.
 ENABLE_MASTERDNS=true
+ENABLE_XDNS=true
 ENABLE_TRUSTTUNNEL=true
 ENABLE_TELEMT=true
-ENABLE_AMNEZIAWG=true
+# GooseRelay (SOCKS5 over Google Apps Script): opt-in, needs client-side setup.
+ENABLE_GOOSERELAY=false
 ENABLE_ADMIN_UI=true
 ENABLE_CONDUIT=true
 ENABLE_SNOWFLAKE=true
-# GooseRelay - SOCKS5 over Google Apps Script -> this VPS exit (MahsaNG v16).
-# Opt-in: adds a container + needs PORT_GOOSE reachable from Google's network.
-# The Apps Script forwarder + client are set up by the end user.
-ENABLE_GOOSERELAY=false
-# VLESS+XHTTP+Reality via Xray-core
-ENABLE_XHTTP=true
-# XDNS - DNS tunnel via Xray mKCP+FinalMask (modern, per-user auth)
-# Disabled by default — requires FinalMask-aware client (Happ, Xray CLI).
-# When enabled, dns-router routes x.<DOMAIN> → xray:5355 alongside dnstt/Slipstream/MasterDNS.
-# All four DNS tunnels run simultaneously on port 53 — no `moav switch-dns` needed.
-# Requires NS record: x.<DOMAIN> → dns.<DOMAIN> (see DNS Setup Step 5).
-# Requires FinalMask-aware client (Happ, Xray CLI) to actually use XDNS.
-ENABLE_XDNS=true
-# Grafana monitoring (requires 2GB+ RAM) — leave unset to be prompted during bootstrap
+# Grafana monitoring (needs 2GB+ RAM). Unset = prompt at bootstrap.
 #ENABLE_MONITORING=
 
 # =============================================================================
-# COMPONENT VERSIONS
+# COMMON OPTIONS
 # =============================================================================
 
-# sing-box - https://github.com/SagerNet/sing-box/releases
-SINGBOX_VERSION=1.13.12
-
-# wstunnel - https://github.com/erebe/wstunnel/releases
-WSTUNNEL_VERSION=10.6.1
-
-# Psiphon Conduit - https://github.com/Psiphon-Inc/conduit/releases
-CONDUIT_VERSION=2.0.0
-
-# Tor Snowflake - https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/releases
-SNOWFLAKE_VERSION=2.11.0
-
-# TrustTunnel endpoint - https://github.com/TrustTunnel/TrustTunnel/releases
-TRUSTTUNNEL_VERSION=1.0.33
-
-# TrustTunnel client - https://github.com/TrustTunnel/TrustTunnelClient/releases
-TRUSTTUNNEL_CLIENT_VERSION=1.0.49
-
-# AmneziaWG tools - https://github.com/amnezia-vpn/amneziawg-tools/releases
-AWGTOOLS_VERSION=1.0.20260223
-
-# Slipstream (QUIC-over-DNS) - https://github.com/Mygod/slipstream-rust
-# Pre-built binaries: https://github.com/net2share/slipstream-rust-build/releases
-SLIPSTREAM_VERSION=2026.02.22.1
-
-# telemt (Telegram MTProxy) - https://github.com/telemt/telemt/releases
-TELEMT_VERSION=3.4.23
-
-# dnstt (KCP+Noise DNS tunnel) - https://www.bamsoftware.com/software/dnstt/
-# Tag list: https://repo.or.cz/dnstt.git/tags
-DNSTT_VERSION=v1.20260501.0
-
-# MasterDNS (advanced DNS tunnel) - https://github.com/masterking32/MasterDnsVPN
-# This build matches the MasterDNS component bundled in MahsaNG v16.
-MASTERDNS_VERSION=v2026.05.10.180256-27c7e11
-
-# GooseRelay (SOCKS5 over Google Apps Script) - https://github.com/kianmhz/GooseRelayVPN
-# v1.7.1 — fully interoperable with the GooseRelay client bundled in MahsaNG v16
-# (v1.7.x ↔ v1.6.x wire/config compatible per upstream).
-GOOSERELAY_VERSION=v1.7.1
-
-# Xray-core (VLESS+XHTTP+Reality+XDNS) - https://github.com/XTLS/Xray-core/releases
-# Built from source for latest FinalMask/XDNS support
-XRAY_VERSION=v26.6.27
-
-# Monitoring stack versions (for moav build --local)
-# Prometheus - https://github.com/prometheus/prometheus/releases
-PROMETHEUS_VERSION=3.10.0
-
-# Grafana - https://github.com/grafana/grafana/releases
-GRAFANA_VERSION=12.4.0
-
-# Node Exporter - https://github.com/prometheus/node_exporter/releases
-NODE_EXPORTER_VERSION=1.10.2
-
-# cAdvisor - https://github.com/google/cadvisor/releases
-CADVISOR_VERSION=0.56.2
-
-# Clash Exporter - https://github.com/zxh326/clash-exporter/releases
-CLASH_EXPORTER_VERSION=0.0.4
-
-# -----------------------------------------------------------------------------
-# Go module fetch (build-time only; affects xray, amneziawg, dnstt, dns-router,
-# snowflake, and the client image — all of which compile Go from source)
-# -----------------------------------------------------------------------------
-# GOPROXY uses '|' (pipe), not ',' (comma): pipe falls through to the next entry
-# on ANY error, comma only on 404/410. Google's module CDN (proxy.golang.org)
-# can return 403 to a VPS under rate-limiting or regional restriction even when
-# the module + version exist — comma would not survive that, pipe does. Default
-# tries Google first (fast for most), then goproxy.cn (not subject to Google's
-# CDN limits), then direct VCS. Override with your own Athens mirror or set to
-# "https://proxy.golang.org,direct" to force Google-only.
-# Quoted because the value is pipe-separated — without quotes, any script that
-# `source`s this file would parse the `|` as shell pipes. Docker Compose strips
-# the surrounding quotes when passing it as a build arg.
-GOPROXY="https://proxy.golang.org|https://goproxy.cn|direct"
-# GOSUMDB=off avoids a second hard dependency on Google's checksum server
-# (sum.golang.org), which is unreachable from the same networks that get 403s
-# above. Module integrity is still verified against the go.sum committed in each
-# upstream repo. Set to "sum.golang.org" to re-enable the transparency-log check.
-GOSUMDB=off
-
-# =============================================================================
-# HYSTERIA2 CONFIGURATION (QUIC-based, fast but may be blocked)
-# =============================================================================
-
-# Obfuscation password for Hysteria2 (helps bypass QUIC blocking)
-# Auto-generated if empty. REQUIRED for censored regions
-HYSTERIA2_OBFS_PASSWORD=
-
-# =============================================================================
-# REALITY CONFIGURATION (Primary Protocol)
-# =============================================================================
-
-# Reality target site - must support TLS 1.3 + H2
-# IMPORTANT: For censored regions, avoid well-known targets like microsoft.com
-# See https://moav.sh/docs/SETUP "Choosing a Reality Target" for how to pick and verify targets
-REALITY_TARGET=dl.google.com:443
-
-# Reality short ID (8 hex chars) - auto-generated if empty
-REALITY_SHORT_ID=
-
-# Reality private key - auto-generated if empty
-REALITY_PRIVATE_KEY=
-
-# =============================================================================
-# XHTTP CONFIGURATION (Xray-core, experimental)
-# =============================================================================
-
-# Reality target for XHTTP (can differ from sing-box's REALITY_TARGET)
-# Default: same as REALITY_TARGET
-XHTTP_REALITY_TARGET=dl.google.com:443
-
-# =============================================================================
-# DNS TUNNEL CONFIGURATION (dnstunnel profile: dnstt + Slipstream + MasterDNS)
-# =============================================================================
-
-# Subdomain for dnstt DNS tunnel (NS record must point to this server)
-# Full tunnel domain: ${DNSTT_SUBDOMAIN}.${DOMAIN} (e.g., t.example.com)
-DNSTT_SUBDOMAIN=t
-
-# Subdomain for Slipstream QUIC-over-DNS tunnel (NS record must point to this server)
-# Full tunnel domain: ${SLIPSTREAM_SUBDOMAIN}.${DOMAIN} (e.g., s.example.com)
-SLIPSTREAM_SUBDOMAIN=s
-
-# Subdomain for MasterDNS tunnel (NS record must point to this server)
-# Full tunnel domain: ${MASTERDNS_SUBDOMAIN}.${DOMAIN} (e.g., m.example.com)
-# Enabled by default. Shares port 53 with dnstt/Slipstream via dns-router
-# (routed by subdomain) — no extra port needed.
-MASTERDNS_SUBDOMAIN=m
-# Optional alternate MasterDNS public subdomain used in generated client bundles.
-# Leave empty to use MASTERDNS_SUBDOMAIN.
-MASTERDNS_PUBLIC_SUBDOMAIN=
-
-# Subdomain for XDNS tunnel (NS record must point to this server)
-# Full tunnel domain: ${XDNS_SUBDOMAIN}.${DOMAIN} (e.g., x.example.com)
-XDNS_SUBDOMAIN=x
-# mKCP MTU - smaller = works with more DNS resolvers
-# 35 = safest (all resolvers), 67 = most resolvers, 130 = unrestricted resolvers
-# Values depend on domain length: shorter domain = higher MTU possible
-XDNS_MTU=35
-
-# Public DNS resolvers the client round-robins across when XDNS runs in
-# DNS-tunnel mode (xdns-config.json — NOT xdns-direct-config.json). Added
-# upstream in Xray v26.4.13 (PR #5872). CSV of IPv4 addresses. Round-robin
-# distribution within a single mKCP session = higher throughput and a
-# fallback when one resolver is throttled (e.g. during Iran shutdowns when
-# 8.8.8.8 is rate-limited). Leave empty to use single-resolver direct mode.
-XDNS_RESOLVERS=1.1.1.1,8.8.8.8
-
-# XDNS finalmask record mode in generated client bundles: txt (default, widest
-# client compatibility) or aaaa (higher throughput per query, but requires an
-# Xray client core >= v26.6.1 — Happ/Xray CLI; #6123). Server side needs nothing.
-XDNS_METHOD=txt
-
-# =============================================================================
-# TELEGRAM MTPROXY CONFIGURATION (telegram profile)
-# =============================================================================
-# Full tuning reference: https://github.com/telemt/telemt/blob/main/docs/TUNING.en.md
-# API reference:         https://github.com/telemt/telemt/blob/main/docs/API.md
-
-# Fake-TLS domain for DPI evasion (telemt mimics TLS traffic to this domain)
-# Alternatives: play.google.com, www.bing.com, www.apple.com
-TELEMT_TLS_DOMAIN=dl.google.com
-
-# Per-user limits
-TELEMT_MAX_TCP_CONNS=100    # Max simultaneous TCP connections per user
-TELEMT_MAX_UNIQUE_IPS=10    # Max unique client IPs per user
-
-# ── Anti-DPI / Traffic Randomization ──
-# Randomize keepalive packet contents (defeats pattern-matching DPI signatures)
-TELEMT_KEEPALIVE_RANDOM=true
-# Desynchronize keepalive timing across clients (secs of jitter added to interval)
-TELEMT_KEEPALIVE_JITTER=4
-# Keepalive probe interval in seconds (lower = detect dead connections faster)
-TELEMT_KEEPALIVE_INTERVAL=20
-# Randomize connection establishment timing (ms jitter on warmup steps)
-TELEMT_WARMUP_JITTER=200
-
-# ── Connection Pool Resilience ──
-# Number of concurrent ME writers (higher = more resilience when some are killed)
-# Default 8, increase for aggressive filtering. Uses ~2MB RAM per writer.
-TELEMT_POOL_SIZE=12
-# Seconds between full pool teardown/rebuild (lower = harder to fingerprint long connections)
-TELEMT_REINIT_SECS=600
-# Use generation-based pool replacement (cleaner than gradual rotation)
-TELEMT_HARDSWAP=true
-# Randomized dial spacing during hardswap (ms range, avoids burst signatures)
-TELEMT_HARDSWAP_DELAY_MIN=500
-TELEMT_HARDSWAP_DELAY_MAX=1200
-
-# ── Fast Reconnect (survive active blocking) ──
-# Immediate retries before exponential backoff kicks in
-TELEMT_FAST_RETRIES=10
-# Initial backoff delay (ms) after fast retries exhausted
-TELEMT_BACKOFF_BASE=300
-# Maximum backoff cap (ms)
-TELEMT_BACKOFF_CAP=10000
-
-# ── Config Stability (prevent flapping from transient upstream issues) ──
-# Require N identical config snapshots before applying changes
-TELEMT_STABLE_SNAPSHOTS=3
-# Cooldown between config applications (secs)
-TELEMT_APPLY_COOLDOWN=120
-
-# ── STUN / NAT Detection ──
-# Fall back to TCP STUN when UDP is blocked (critical for Iran)
-TELEMT_STUN_TCP_FALLBACK=true
-
-# ── Monitoring API ──
-# Enable telemt REST API for detailed monitoring (bound to container network only)
-# Provides: ME pool health, per-DC stats, upstream quality, connection details
-TELEMT_API_ENABLED=true
-TELEMT_API_PORT=9091
-
-# ── Advanced (opt-in) ──
-# Fail fast on an unknown/typo'd telemt config key instead of ignoring it.
-# Leave false unless debugging config generation — a version-specific unknown
-# key would otherwise crash-loop the container.
-TELEMT_CONFIG_STRICT=false
-# Anti-DPI handshake MSS clamping (telemt >= 3.4.15/3.4.19, Linux-only). Empty =
-# off. client_mss fragments the handshake (e.g. "tspu"); client_mss_bulk (e.g.
-# "1400") restores MSS for bulk data so throughput isn't tanked. Leave empty
-# unless your network fingerprints the MTPROTO handshake by MSS.
-TELEMT_CLIENT_MSS=
-TELEMT_CLIENT_MSS_BULK=
-
-# =============================================================================
-# BANDWIDTH DONATION (Help Others Bypass Censorship)
-# =============================================================================
-
-# Psiphon Conduit - donate bandwidth to help Psiphon users
-CONDUIT_BANDWIDTH=100              # Mbps limit
-CONDUIT_MAX_COMMON_CLIENTS=200     # Max concurrent common proxy clients
-# Auto-install a systemd watcher (on `moav start`, when Conduit + monitoring are
-# both running) that re-banks Conduit lifetime-bandwidth offsets on every Conduit
-# restart, so Grafana's "Lifetime Download/Upload" totals stay accurate without
-# running scripts/update-conduit-offsets.sh by hand. Set false to opt out and
-# manage it yourself (`moav conduit-offsets install`). No effect without systemd.
-CONDUIT_OFFSETS_AUTOUPDATE=true
-
-# Tor Snowflake - donate bandwidth to help Tor users
-SNOWFLAKE_BANDWIDTH=5       # Mbps limit
-SNOWFLAKE_CAPACITY=50        # Max concurrent clients
-
-# ── MAHSANET CONFIG DONATION ──────────────────────────────────────
-# Donate VPN configs to MahsaServer.com (Mahsa VPN app, 2M+ users in Iran)
-# Register at https://www.mahsaserver.com/, verify email, become verified donor,
-# then generate API key at https://www.mahsaserver.com/user/api
-MAHSANET_API_KEY=
-# Protocols to donate (space-separated): reality hysteria2 trojan cdn xhttp telegram
-MAHSANET_PROTOCOLS="reality hysteria2"
-# Pool: mahsa, warp, popup, telegram
-MAHSANET_POOL=mahsa
-
-# =============================================================================
-# PORTS
-# =============================================================================
-
-PORT_HTTPS=443       # Reality (VLESS) + Hysteria2 (UDP)
-PORT_TROJAN=8443     # Trojan fallback
-PORT_ANYTLS=8445     # AnyTLS (sing-box native, only if ENABLE_ANYTLS=true)
-PORT_WIREGUARD=51820 # WireGuard (UDP)
-PORT_WSTUNNEL=8080   # WebSocket tunnel for WireGuard
-PORT_DNS=53          # dns-router public port — all DNS tunnels share this (dnstt/Slipstream/MasterDNS/XDNS)
-PORT_XDNS=5356       # xray XDNS secondary host port — dns-router forwards internally to xray:5355
-PORT_ADMIN=9443      # Admin dashboard
-PORT_CDN=2082        # CDN WebSocket (VLESS+WS)
-PORT_AMNEZIAWG=51821 # AmneziaWG (obfuscated WireGuard, UDP)
-PORT_TRUSTTUNNEL=4443 # TrustTunnel (HTTP/2 + QUIC)
-PORT_TELEMT=993      # Telegram MTProxy (fake-TLS on IMAPS port)
-PORT_XHTTP=2096      # XHTTP (VLESS+XHTTP+Reality via Xray-core)
-PORT_SS=8388         # Shadowsocks-2022 port
-PORT_GOOSE=8444      # GooseRelay exit endpoint (only if ENABLE_GOOSERELAY=true)
-PORT_GRAFANA=9444    # Grafana monitoring dashboard
-
-# Shadowsocks-2022 cipher (AEAD-2022 family). MoaV runs SS-2022 in multi-user
-# mode (per-user PSKs), which is supported only by the AES variants:
-#   2022-blake3-aes-128-gcm   (default — fast on AES-NI, 16-byte PSK)
-#   2022-blake3-aes-256-gcm   (32-byte PSK, larger margin)
-# 2022-blake3-chacha20-poly1305 is single-user only and will fail with
-# "invalid argument" if used here. Stick to the AES variants.
-SS_METHOD=2022-blake3-aes-128-gcm
-
-# =============================================================================
-# MONITORING CONFIGURATION
-# =============================================================================
-
-# Clash API secret for sing-box metrics exporter
-# Auto-generated by bootstrap, copy from configs/sing-box/config.json if needed
-# Look for: "clash_api": { "secret": "YOUR_SECRET" }
-CLASH_API_SECRET=
-
-# Grafana subdomain for Cloudflare CDN routing (optional)
-# Access via: https://{GRAFANA_SUBDOMAIN}.{DOMAIN}:2083
-# Leave empty to only use direct access on port 9444
-GRAFANA_SUBDOMAIN=grafana
-
-# Grafana app title (optional, for PWA/phone home screen name)
-# Default: "MoaV - {DOMAIN}" or "MoaV - {SERVER_IP}" if no domain
-# Set to override with a custom name
-GRAFANA_APP_TITLE=
-
-# =============================================================================
-# CDN CONFIGURATION (Cloudflare CDN-fronted VLESS+WebSocket)
-# =============================================================================
-
-# CDN subdomain (Cloudflare-proxied). Leave empty to disable CDN links.
-# Access via: https://{CDN_SUBDOMAIN}.{DOMAIN}
-CDN_SUBDOMAIN=cdn
-
-# CDN transport type: ws (WebSocket — default, universal client support, battle-tested
-# in heavy-censorship contexts) or httpupgrade (slightly lighter overhead, but newer
-# Xray clients warn it's deprecated and some CDNs like CloudFront don't support it).
-CDN_TRANSPORT=ws
-
-# CDN transport path for inbound
-# Auto-generated with a realistic-looking path if empty (recommended for DPI evasion)
-# Set manually only if you need a specific path
-CDN_WS_PATH=
-
-# CDN TLS SNI (visible to DPI in TLS handshake). Defaults to root domain for stealth.
-# Root domain looks like a normal website visit. DPI sees "domain.com" not "cdn.domain.com".
-CDN_SNI=
-
-# CDN connect address (must resolve to Cloudflare IP, i.e. proxied/orange cloud).
-# Defaults to CDN subdomain. For extra stealth, add a 'www' proxied A record and set:
-# CDN_ADDRESS=www.yourdomain.com  (so DNS queries don't reveal "cdn" subdomain)
-CDN_ADDRESS=
-
-# =============================================================================
-# OPTIONAL CONFIGURATION
-# =============================================================================
-
-# Default profiles for 'moav start' (space-separated)
-# Options: proxy wireguard amneziawg dnstunnel trusttunnel xhttp admin conduit snowflake monitoring
-# Use 'all' for everything, or leave empty to be prompted
-DEFAULT_PROFILES=
-
-# Number of initial users to create during bootstrap
-# Set to 1 to create 'demouser', or higher for user01, user02, etc.
+# Users created at bootstrap (1 = demouser; higher = user01, user02, ...).
 INITIAL_USERS=1
 
-# Timezone for logs
-TZ=UTC
+# Profiles for 'moav start' (space-separated, or 'all'; empty = prompt).
+# Options: proxy wireguard amneziawg dnstunnel trusttunnel xhttp admin conduit snowflake monitoring
+DEFAULT_PROFILES=
 
-# Log level: debug, info, warn, error
-LOG_LEVEL=info
-
-# Admin UI IP whitelist (comma-separated CIDR, empty = password only)
-# Example: ADMIN_IP_WHITELIST=192.168.1.0/24,10.0.0.5
+# Admin UI IP allowlist (comma-separated CIDR; empty = password only).
 ADMIN_IP_WHITELIST=
 
-# =============================================================================
-# CLIENT MODE (for 'moav client' command)
-# =============================================================================
-
-# Local proxy ports when running in client mode
-# Uses non-standard ports to avoid conflicts with server services
-CLIENT_SOCKS_PORT=10800
-CLIENT_HTTP_PORT=18080
-
-# =============================================================================
-# CONTAINER IMAGES (for regions with blocked registries)
-# =============================================================================
-# Some users in restricted countries may need to use mirrors or build locally.
-# Uncomment and modify to use alternative registries or local builds.
-#
-# Build images locally (recommended for blocked regions):
-#   moav build --local              # Build commonly blocked (cadvisor, clash-exporter)
-#   moav build --local prometheus   # Build specific external image
-#   moav build --local all          # Build EVERYTHING locally (no registry pulls)
-#
-# The build command automatically updates these variables.
-#
-# IMAGE_PROMETHEUS=prom/prometheus:latest
-# IMAGE_GRAFANA=grafana/grafana:latest
-# IMAGE_NODE_EXPORTER=prom/node-exporter:latest
-# IMAGE_CADVISOR=gcr.io/cadvisor/cadvisor:latest
-# IMAGE_CLASH_EXPORTER=ghcr.io/zxh326/clash-exporter:latest
-# IMAGE_NGINX=nginx:alpine
-# IMAGE_CERTBOT=certbot/certbot:latest
+TZ=UTC
 
 # =============================================================================
 # INTERNAL (do not modify)

--- a/.env.example.full
+++ b/.env.example.full
@@ -1,0 +1,477 @@
+# MoaV - FULL configuration reference (every tunable, with defaults shown).
+# You do NOT need this to run MoaV - .env.example carries the curated minimal
+# set. Copy any line you want to override into your .env. Values shown are the
+# built-in defaults; blank generated-secret fields are filled by `moav bootstrap`.
+
+# =============================================================================
+# REQUIRED CONFIGURATION
+# =============================================================================
+
+# Your domain (must have DNS configured - see https://moav.sh/docs/DNS)
+# Leave empty to run only domainless services (Reality, XHTTP, WireGuard, etc.)
+DOMAIN=
+
+# Email for Let's Encrypt certificates (required if DOMAIN is set)
+ACME_EMAIL=
+
+# Auto-install a daily cert-renewal timer (systemd, or cron.d fallback) on
+# `moav start` when DOMAIN is set — Let's Encrypt certs expire after 90 days.
+# Set false to opt out and schedule renewal yourself (`moav cert install`).
+CERT_AUTORENEW=true
+
+# Admin password for stats dashboard (https://your-domain:9443)
+ADMIN_PASSWORD=change_me_to_something_secure
+
+# =============================================================================
+# SERVER IDENTITY
+# =============================================================================
+
+# Server's public IP (auto-detected if empty, but set manually for reliability)
+SERVER_IP=
+
+# Server's public IPv6 (auto-detected if available)
+# Set to "disabled" to explicitly disable IPv6 even if available
+SERVER_IPV6=
+
+# =============================================================================
+# PROTOCOL TOGGLES
+# =============================================================================
+
+# Enable/disable individual protocols
+ENABLE_REALITY=true
+ENABLE_TROJAN=true
+ENABLE_HYSTERIA2=true
+# AnyTLS (sing-box native, defeats TLS-in-TLS fingerprinting). Opt-in: narrower
+# client support than Trojan/VLESS (Hiddify, sing-box SFA/SFI, NekoBox, mihomo,
+# Shadowrocket 2.2.65+). Reuses the Trojan TLS cert/domain. Refs: github.com/anytls/anytls-go
+ENABLE_ANYTLS=false
+# Shadowsocks-2022 (AEAD-2022, anti-active-probing). Compatible with NekoBox,
+# Hiddify, Streisand, sing-box clients via standard ss:// URI.
+# Refs: github.com/MotherofallVPNs/moav/issues/93
+ENABLE_SS=true
+ENABLE_WIREGUARD=true
+# dnstt/Slipstream/MasterDNS all enabled by default — broader client ecosystem
+# than XDNS (standalone binaries on 25+ platforms vs FinalMask-aware Xray clients
+# like Happ). All three run in parallel: dns-router fans queries out by subdomain
+# suffix (t./s./m.) so they share port 53 with no conflict. Each needs its own
+# NS record (DNSTT_SUBDOMAIN / SLIPSTREAM_SUBDOMAIN / MASTERDNS_SUBDOMAIN below).
+ENABLE_DNSTT=true
+ENABLE_SLIPSTREAM=true
+# MasterDNS - advanced DNS tunnel (ARQ + resolver LB), bundled in MahsaNG v16.
+# Adds a container. Coexists with dnstt/Slipstream via dns-router on its own
+# subdomain (MASTERDNS_SUBDOMAIN) — no port conflict. Set to false to opt out.
+ENABLE_MASTERDNS=true
+ENABLE_TRUSTTUNNEL=true
+ENABLE_TELEMT=true
+ENABLE_AMNEZIAWG=true
+ENABLE_ADMIN_UI=true
+ENABLE_CONDUIT=true
+ENABLE_SNOWFLAKE=true
+# GooseRelay - SOCKS5 over Google Apps Script -> this VPS exit (MahsaNG v16).
+# Opt-in: adds a container + needs PORT_GOOSE reachable from Google's network.
+# The Apps Script forwarder + client are set up by the end user.
+ENABLE_GOOSERELAY=false
+# VLESS+XHTTP+Reality via Xray-core
+ENABLE_XHTTP=true
+# XDNS - DNS tunnel via Xray mKCP+FinalMask (modern, per-user auth)
+# Disabled by default — requires FinalMask-aware client (Happ, Xray CLI).
+# When enabled, dns-router routes x.<DOMAIN> → xray:5355 alongside dnstt/Slipstream/MasterDNS.
+# All four DNS tunnels run simultaneously on port 53 — no `moav switch-dns` needed.
+# Requires NS record: x.<DOMAIN> → dns.<DOMAIN> (see DNS Setup Step 5).
+# Requires FinalMask-aware client (Happ, Xray CLI) to actually use XDNS.
+ENABLE_XDNS=true
+# Grafana monitoring (requires 2GB+ RAM) — leave unset to be prompted during bootstrap
+#ENABLE_MONITORING=
+
+# =============================================================================
+# COMPONENT VERSIONS
+# =============================================================================
+
+# sing-box - https://github.com/SagerNet/sing-box/releases
+SINGBOX_VERSION=1.13.12
+
+# wstunnel - https://github.com/erebe/wstunnel/releases
+WSTUNNEL_VERSION=10.6.1
+
+# Psiphon Conduit - https://github.com/Psiphon-Inc/conduit/releases
+CONDUIT_VERSION=2.0.0
+
+# Tor Snowflake - https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/releases
+SNOWFLAKE_VERSION=2.11.0
+
+# TrustTunnel endpoint - https://github.com/TrustTunnel/TrustTunnel/releases
+TRUSTTUNNEL_VERSION=1.0.33
+
+# TrustTunnel client - https://github.com/TrustTunnel/TrustTunnelClient/releases
+TRUSTTUNNEL_CLIENT_VERSION=1.0.49
+
+# AmneziaWG tools - https://github.com/amnezia-vpn/amneziawg-tools/releases
+AWGTOOLS_VERSION=1.0.20260223
+
+# Slipstream (QUIC-over-DNS) - https://github.com/Mygod/slipstream-rust
+# Pre-built binaries: https://github.com/net2share/slipstream-rust-build/releases
+SLIPSTREAM_VERSION=2026.02.22.1
+
+# telemt (Telegram MTProxy) - https://github.com/telemt/telemt/releases
+TELEMT_VERSION=3.4.23
+
+# dnstt (KCP+Noise DNS tunnel) - https://www.bamsoftware.com/software/dnstt/
+# Tag list: https://repo.or.cz/dnstt.git/tags
+DNSTT_VERSION=v1.20260501.0
+
+# MasterDNS (advanced DNS tunnel) - https://github.com/masterking32/MasterDnsVPN
+# This build matches the MasterDNS component bundled in MahsaNG v16.
+MASTERDNS_VERSION=v2026.05.10.180256-27c7e11
+
+# GooseRelay (SOCKS5 over Google Apps Script) - https://github.com/kianmhz/GooseRelayVPN
+# v1.7.1 — fully interoperable with the GooseRelay client bundled in MahsaNG v16
+# (v1.7.x ↔ v1.6.x wire/config compatible per upstream).
+GOOSERELAY_VERSION=v1.7.1
+
+# Xray-core (VLESS+XHTTP+Reality+XDNS) - https://github.com/XTLS/Xray-core/releases
+# Built from source for latest FinalMask/XDNS support
+XRAY_VERSION=v26.6.27
+
+# Monitoring stack versions (for moav build --local)
+# Prometheus - https://github.com/prometheus/prometheus/releases
+PROMETHEUS_VERSION=3.10.0
+
+# Grafana - https://github.com/grafana/grafana/releases
+GRAFANA_VERSION=12.4.0
+
+# Node Exporter - https://github.com/prometheus/node_exporter/releases
+NODE_EXPORTER_VERSION=1.10.2
+
+# cAdvisor - https://github.com/google/cadvisor/releases
+CADVISOR_VERSION=0.56.2
+
+# Clash Exporter - https://github.com/zxh326/clash-exporter/releases
+CLASH_EXPORTER_VERSION=0.0.4
+
+# -----------------------------------------------------------------------------
+# Go module fetch (build-time only; affects xray, amneziawg, dnstt, dns-router,
+# snowflake, and the client image — all of which compile Go from source)
+# -----------------------------------------------------------------------------
+# GOPROXY uses '|' (pipe), not ',' (comma): pipe falls through to the next entry
+# on ANY error, comma only on 404/410. Google's module CDN (proxy.golang.org)
+# can return 403 to a VPS under rate-limiting or regional restriction even when
+# the module + version exist — comma would not survive that, pipe does. Default
+# tries Google first (fast for most), then goproxy.cn (not subject to Google's
+# CDN limits), then direct VCS. Override with your own Athens mirror or set to
+# "https://proxy.golang.org,direct" to force Google-only.
+# Quoted because the value is pipe-separated — without quotes, any script that
+# `source`s this file would parse the `|` as shell pipes. Docker Compose strips
+# the surrounding quotes when passing it as a build arg.
+GOPROXY="https://proxy.golang.org|https://goproxy.cn|direct"
+# GOSUMDB=off avoids a second hard dependency on Google's checksum server
+# (sum.golang.org), which is unreachable from the same networks that get 403s
+# above. Module integrity is still verified against the go.sum committed in each
+# upstream repo. Set to "sum.golang.org" to re-enable the transparency-log check.
+GOSUMDB=off
+
+# =============================================================================
+# HYSTERIA2 CONFIGURATION (QUIC-based, fast but may be blocked)
+# =============================================================================
+
+# Obfuscation password for Hysteria2 (helps bypass QUIC blocking)
+# Auto-generated if empty. REQUIRED for censored regions
+HYSTERIA2_OBFS_PASSWORD=
+
+# =============================================================================
+# REALITY CONFIGURATION (Primary Protocol)
+# =============================================================================
+
+# Reality target site - must support TLS 1.3 + H2
+# IMPORTANT: For censored regions, avoid well-known targets like microsoft.com
+# See https://moav.sh/docs/SETUP "Choosing a Reality Target" for how to pick and verify targets
+REALITY_TARGET=dl.google.com:443
+
+# Reality short ID (8 hex chars) - auto-generated if empty
+REALITY_SHORT_ID=
+
+# Reality private key - auto-generated if empty
+REALITY_PRIVATE_KEY=
+
+# =============================================================================
+# XHTTP CONFIGURATION (Xray-core, experimental)
+# =============================================================================
+
+# Reality target for XHTTP (can differ from sing-box's REALITY_TARGET)
+# Default: same as REALITY_TARGET
+XHTTP_REALITY_TARGET=dl.google.com:443
+
+# =============================================================================
+# DNS TUNNEL CONFIGURATION (dnstunnel profile: dnstt + Slipstream + MasterDNS)
+# =============================================================================
+
+# Subdomain for dnstt DNS tunnel (NS record must point to this server)
+# Full tunnel domain: ${DNSTT_SUBDOMAIN}.${DOMAIN} (e.g., t.example.com)
+DNSTT_SUBDOMAIN=t
+
+# Subdomain for Slipstream QUIC-over-DNS tunnel (NS record must point to this server)
+# Full tunnel domain: ${SLIPSTREAM_SUBDOMAIN}.${DOMAIN} (e.g., s.example.com)
+SLIPSTREAM_SUBDOMAIN=s
+
+# Subdomain for MasterDNS tunnel (NS record must point to this server)
+# Full tunnel domain: ${MASTERDNS_SUBDOMAIN}.${DOMAIN} (e.g., m.example.com)
+# Enabled by default. Shares port 53 with dnstt/Slipstream via dns-router
+# (routed by subdomain) — no extra port needed.
+MASTERDNS_SUBDOMAIN=m
+# Optional alternate MasterDNS public subdomain used in generated client bundles.
+# Leave empty to use MASTERDNS_SUBDOMAIN.
+MASTERDNS_PUBLIC_SUBDOMAIN=
+
+# Subdomain for XDNS tunnel (NS record must point to this server)
+# Full tunnel domain: ${XDNS_SUBDOMAIN}.${DOMAIN} (e.g., x.example.com)
+XDNS_SUBDOMAIN=x
+# mKCP MTU - smaller = works with more DNS resolvers
+# 35 = safest (all resolvers), 67 = most resolvers, 130 = unrestricted resolvers
+# Values depend on domain length: shorter domain = higher MTU possible
+XDNS_MTU=35
+
+# Public DNS resolvers the client round-robins across when XDNS runs in
+# DNS-tunnel mode (xdns-config.json — NOT xdns-direct-config.json). Added
+# upstream in Xray v26.4.13 (PR #5872). CSV of IPv4 addresses. Round-robin
+# distribution within a single mKCP session = higher throughput and a
+# fallback when one resolver is throttled (e.g. during Iran shutdowns when
+# 8.8.8.8 is rate-limited). Leave empty to use single-resolver direct mode.
+XDNS_RESOLVERS=1.1.1.1,8.8.8.8
+
+# XDNS finalmask record mode in generated client bundles: txt (default, widest
+# client compatibility) or aaaa (higher throughput per query, but requires an
+# Xray client core >= v26.6.1 — Happ/Xray CLI; #6123). Server side needs nothing.
+XDNS_METHOD=txt
+
+# =============================================================================
+# TELEGRAM MTPROXY CONFIGURATION (telegram profile)
+# =============================================================================
+# Full tuning reference: https://github.com/telemt/telemt/blob/main/docs/TUNING.en.md
+# API reference:         https://github.com/telemt/telemt/blob/main/docs/API.md
+
+# Fake-TLS domain for DPI evasion (telemt mimics TLS traffic to this domain)
+# Alternatives: play.google.com, www.bing.com, www.apple.com
+TELEMT_TLS_DOMAIN=dl.google.com
+
+# Per-user limits
+TELEMT_MAX_TCP_CONNS=100    # Max simultaneous TCP connections per user
+TELEMT_MAX_UNIQUE_IPS=10    # Max unique client IPs per user
+
+# ── Anti-DPI / Traffic Randomization ──
+# Randomize keepalive packet contents (defeats pattern-matching DPI signatures)
+TELEMT_KEEPALIVE_RANDOM=true
+# Desynchronize keepalive timing across clients (secs of jitter added to interval)
+TELEMT_KEEPALIVE_JITTER=4
+# Keepalive probe interval in seconds (lower = detect dead connections faster)
+TELEMT_KEEPALIVE_INTERVAL=20
+# Randomize connection establishment timing (ms jitter on warmup steps)
+TELEMT_WARMUP_JITTER=200
+
+# ── Connection Pool Resilience ──
+# Number of concurrent ME writers (higher = more resilience when some are killed)
+# Default 8, increase for aggressive filtering. Uses ~2MB RAM per writer.
+TELEMT_POOL_SIZE=12
+# Seconds between full pool teardown/rebuild (lower = harder to fingerprint long connections)
+TELEMT_REINIT_SECS=600
+# Use generation-based pool replacement (cleaner than gradual rotation)
+TELEMT_HARDSWAP=true
+# Randomized dial spacing during hardswap (ms range, avoids burst signatures)
+TELEMT_HARDSWAP_DELAY_MIN=500
+TELEMT_HARDSWAP_DELAY_MAX=1200
+
+# ── Fast Reconnect (survive active blocking) ──
+# Immediate retries before exponential backoff kicks in
+TELEMT_FAST_RETRIES=10
+# Initial backoff delay (ms) after fast retries exhausted
+TELEMT_BACKOFF_BASE=300
+# Maximum backoff cap (ms)
+TELEMT_BACKOFF_CAP=10000
+
+# ── Config Stability (prevent flapping from transient upstream issues) ──
+# Require N identical config snapshots before applying changes
+TELEMT_STABLE_SNAPSHOTS=3
+# Cooldown between config applications (secs)
+TELEMT_APPLY_COOLDOWN=120
+
+# ── STUN / NAT Detection ──
+# Fall back to TCP STUN when UDP is blocked (critical for Iran)
+TELEMT_STUN_TCP_FALLBACK=true
+
+# ── Monitoring API ──
+# Enable telemt REST API for detailed monitoring (bound to container network only)
+# Provides: ME pool health, per-DC stats, upstream quality, connection details
+TELEMT_API_ENABLED=true
+TELEMT_API_PORT=9091
+
+# ── Advanced (opt-in) ──
+# Fail fast on an unknown/typo'd telemt config key instead of ignoring it.
+# Leave false unless debugging config generation — a version-specific unknown
+# key would otherwise crash-loop the container.
+TELEMT_CONFIG_STRICT=false
+# Anti-DPI handshake MSS clamping (telemt >= 3.4.15/3.4.19, Linux-only). Empty =
+# off. client_mss fragments the handshake (e.g. "tspu"); client_mss_bulk (e.g.
+# "1400") restores MSS for bulk data so throughput isn't tanked. Leave empty
+# unless your network fingerprints the MTPROTO handshake by MSS.
+TELEMT_CLIENT_MSS=
+TELEMT_CLIENT_MSS_BULK=
+
+# =============================================================================
+# BANDWIDTH DONATION (Help Others Bypass Censorship)
+# =============================================================================
+
+# Psiphon Conduit - donate bandwidth to help Psiphon users
+CONDUIT_BANDWIDTH=100              # Mbps limit
+CONDUIT_MAX_COMMON_CLIENTS=200     # Max concurrent common proxy clients
+# Auto-install a systemd watcher (on `moav start`, when Conduit + monitoring are
+# both running) that re-banks Conduit lifetime-bandwidth offsets on every Conduit
+# restart, so Grafana's "Lifetime Download/Upload" totals stay accurate without
+# running scripts/update-conduit-offsets.sh by hand. Set false to opt out and
+# manage it yourself (`moav conduit-offsets install`). No effect without systemd.
+CONDUIT_OFFSETS_AUTOUPDATE=true
+
+# Tor Snowflake - donate bandwidth to help Tor users
+SNOWFLAKE_BANDWIDTH=5       # Mbps limit
+SNOWFLAKE_CAPACITY=50        # Max concurrent clients
+
+# ── MAHSANET CONFIG DONATION ──────────────────────────────────────
+# Donate VPN configs to MahsaServer.com (Mahsa VPN app, 2M+ users in Iran)
+# Register at https://www.mahsaserver.com/, verify email, become verified donor,
+# then generate API key at https://www.mahsaserver.com/user/api
+MAHSANET_API_KEY=
+# Protocols to donate (space-separated): reality hysteria2 trojan cdn xhttp telegram
+MAHSANET_PROTOCOLS="reality hysteria2"
+# Pool: mahsa, warp, popup, telegram
+MAHSANET_POOL=mahsa
+
+# =============================================================================
+# PORTS
+# =============================================================================
+
+PORT_HTTPS=443       # Reality (VLESS) + Hysteria2 (UDP)
+PORT_TROJAN=8443     # Trojan fallback
+PORT_ANYTLS=8445     # AnyTLS (sing-box native, only if ENABLE_ANYTLS=true)
+PORT_WIREGUARD=51820 # WireGuard (UDP)
+PORT_WSTUNNEL=8080   # WebSocket tunnel for WireGuard
+PORT_DNS=53          # dns-router public port — all DNS tunnels share this (dnstt/Slipstream/MasterDNS/XDNS)
+PORT_XDNS=5356       # xray XDNS secondary host port — dns-router forwards internally to xray:5355
+PORT_ADMIN=9443      # Admin dashboard
+PORT_CDN=2082        # CDN WebSocket (VLESS+WS)
+PORT_AMNEZIAWG=51821 # AmneziaWG (obfuscated WireGuard, UDP)
+PORT_TRUSTTUNNEL=4443 # TrustTunnel (HTTP/2 + QUIC)
+PORT_TELEMT=993      # Telegram MTProxy (fake-TLS on IMAPS port)
+PORT_XHTTP=2096      # XHTTP (VLESS+XHTTP+Reality via Xray-core)
+PORT_SS=8388         # Shadowsocks-2022 port
+PORT_GOOSE=8444      # GooseRelay exit endpoint (only if ENABLE_GOOSERELAY=true)
+PORT_GRAFANA=9444    # Grafana monitoring dashboard
+
+# Shadowsocks-2022 cipher (AEAD-2022 family). MoaV runs SS-2022 in multi-user
+# mode (per-user PSKs), which is supported only by the AES variants:
+#   2022-blake3-aes-128-gcm   (default — fast on AES-NI, 16-byte PSK)
+#   2022-blake3-aes-256-gcm   (32-byte PSK, larger margin)
+# 2022-blake3-chacha20-poly1305 is single-user only and will fail with
+# "invalid argument" if used here. Stick to the AES variants.
+SS_METHOD=2022-blake3-aes-128-gcm
+
+# =============================================================================
+# MONITORING CONFIGURATION
+# =============================================================================
+
+# Clash API secret for sing-box metrics exporter
+# Auto-generated by bootstrap, copy from configs/sing-box/config.json if needed
+# Look for: "clash_api": { "secret": "YOUR_SECRET" }
+CLASH_API_SECRET=
+
+# Grafana subdomain for Cloudflare CDN routing (optional)
+# Access via: https://{GRAFANA_SUBDOMAIN}.{DOMAIN}:2083
+# Leave empty to only use direct access on port 9444
+GRAFANA_SUBDOMAIN=grafana
+
+# Grafana app title (optional, for PWA/phone home screen name)
+# Default: "MoaV - {DOMAIN}" or "MoaV - {SERVER_IP}" if no domain
+# Set to override with a custom name
+GRAFANA_APP_TITLE=
+
+# =============================================================================
+# CDN CONFIGURATION (Cloudflare CDN-fronted VLESS+WebSocket)
+# =============================================================================
+
+# CDN subdomain (Cloudflare-proxied). Leave empty to disable CDN links.
+# Access via: https://{CDN_SUBDOMAIN}.{DOMAIN}
+CDN_SUBDOMAIN=cdn
+
+# CDN transport type: ws (WebSocket — default, universal client support, battle-tested
+# in heavy-censorship contexts) or httpupgrade (slightly lighter overhead, but newer
+# Xray clients warn it's deprecated and some CDNs like CloudFront don't support it).
+CDN_TRANSPORT=ws
+
+# CDN transport path for inbound
+# Auto-generated with a realistic-looking path if empty (recommended for DPI evasion)
+# Set manually only if you need a specific path
+CDN_WS_PATH=
+
+# CDN TLS SNI (visible to DPI in TLS handshake). Defaults to root domain for stealth.
+# Root domain looks like a normal website visit. DPI sees "domain.com" not "cdn.domain.com".
+CDN_SNI=
+
+# CDN connect address (must resolve to Cloudflare IP, i.e. proxied/orange cloud).
+# Defaults to CDN subdomain. For extra stealth, add a 'www' proxied A record and set:
+# CDN_ADDRESS=www.yourdomain.com  (so DNS queries don't reveal "cdn" subdomain)
+CDN_ADDRESS=
+
+# =============================================================================
+# OPTIONAL CONFIGURATION
+# =============================================================================
+
+# Default profiles for 'moav start' (space-separated)
+# Options: proxy wireguard amneziawg dnstunnel trusttunnel xhttp admin conduit snowflake monitoring
+# Use 'all' for everything, or leave empty to be prompted
+DEFAULT_PROFILES=
+
+# Number of initial users to create during bootstrap
+# Set to 1 to create 'demouser', or higher for user01, user02, etc.
+INITIAL_USERS=1
+
+# Timezone for logs
+TZ=UTC
+
+# Log level: debug, info, warn, error
+LOG_LEVEL=info
+
+# Admin UI IP whitelist (comma-separated CIDR, empty = password only)
+# Example: ADMIN_IP_WHITELIST=192.168.1.0/24,10.0.0.5
+ADMIN_IP_WHITELIST=
+
+# =============================================================================
+# CLIENT MODE (for 'moav client' command)
+# =============================================================================
+
+# Local proxy ports when running in client mode
+# Uses non-standard ports to avoid conflicts with server services
+CLIENT_SOCKS_PORT=10800
+CLIENT_HTTP_PORT=18080
+
+# =============================================================================
+# CONTAINER IMAGES (for regions with blocked registries)
+# =============================================================================
+# Some users in restricted countries may need to use mirrors or build locally.
+# Uncomment and modify to use alternative registries or local builds.
+#
+# Build images locally (recommended for blocked regions):
+#   moav build --local              # Build commonly blocked (cadvisor, clash-exporter)
+#   moav build --local prometheus   # Build specific external image
+#   moav build --local all          # Build EVERYTHING locally (no registry pulls)
+#
+# The build command automatically updates these variables.
+#
+# IMAGE_PROMETHEUS=prom/prometheus:latest
+# IMAGE_GRAFANA=grafana/grafana:latest
+# IMAGE_NODE_EXPORTER=prom/node-exporter:latest
+# IMAGE_CADVISOR=gcr.io/cadvisor/cadvisor:latest
+# IMAGE_CLASH_EXPORTER=ghcr.io/zxh326/clash-exporter:latest
+# IMAGE_NGINX=nginx:alpine
+# IMAGE_CERTBOT=certbot/certbot:latest
+
+# =============================================================================
+# INTERNAL (do not modify)
+# =============================================================================
+
+COMPOSE_PROJECT_NAME=moav

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         run: bash tests/entrypoint-strict-test.sh
       - name: env resolution golden-diff
         run: bash tests/env-resolution-test.sh
+      - name: .env.example slim/full split
+        run: bash tests/env-example-test.sh
       - name: docker management-plane isolation
         run: bash tests/network-isolation-test.sh
       - name: monitoring socket removal

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,7 +102,6 @@ jobs:
             # Disable protocols that need a domain cert or DNS delegation so
             # their services don't crash-loop without one.
             sed -i "s|^DOMAIN=.*|DOMAIN=|" .env
-            sed -i "s|^CDN_SUBDOMAIN=.*|CDN_SUBDOMAIN=|" .env
             for p in TROJAN ANYTLS HYSTERIA2 DNSTT SLIPSTREAM MASTERDNS TRUSTTUNNEL XDNS; do
               sed -i "s|^ENABLE_${p}=.*|ENABLE_${p}=false|" .env
             done
@@ -394,7 +393,6 @@ jobs:
           sed -i "s|^DOMAIN=.*|DOMAIN=|" .env
           sed -i "s|^ADMIN_PASSWORD=.*|ADMIN_PASSWORD=${MOAV_ADMIN_PASSWORD}|" .env
           [ -n "${MOAV_SERVER_IP:-}" ] && sed -i "s|^SERVER_IP=.*|SERVER_IP=${MOAV_SERVER_IP}|" .env
-          sed -i "s|^CDN_SUBDOMAIN=.*|CDN_SUBDOMAIN=|" .env
           for p in TROJAN ANYTLS HYSTERIA2 DNSTT SLIPSTREAM MASTERDNS TRUSTTUNNEL XDNS; do
             sed -i "s|^ENABLE_${p}=.*|ENABLE_${p}=false|" .env
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`.env.example` slimmed from 118 vars / 475 lines to a curated 28-var first-run surface.** A new operator now sees only what they actually set (domain, ACME email, admin password, server IP, protocol toggles, and a few common options). Every advanced tunable (component versions, ports, Reality/XHTTP targets, DNS-tunnel subdomains, Telegram/telemt tuning, CDN, bandwidth donation, monitoring, client mode, registry overrides) has a working code/compose default and moved to a new complete reference, **`.env.example.full`** — copy any line into your `.env` to override it. Existing installs are unaffected (their `.env` is untouched; removed keys fall back to the same defaults). `moav update`'s version-outdated check now reads the full reference; its new-variable auto-add still reads the slim file, so an update never re-bloats your `.env` with the advanced set. A drift test keeps the slim file a strict subset of the reference and under a 40-var ceiling.
+
+
 ### Fixed
 - **`moav user add` from the CLI could fail WireGuard/AmneziaWG right after `moav start`.** The key generator fell back to `docker compose exec` (which re-parses the whole compose file every call, three times per peer) under a 20s timeout; on a 1-vCPU/1-GB box still settling from a full start, that blew the budget and reported "no wg/awg key generator available" for a perfectly healthy container. It now uses `docker exec` by container name (no compose parse, ~2x faster idle and far more under load) with a 60s ceiling. The web admin was unaffected because it never hit the slow path. Found on the first live 1.9.1 upgrade.
 - **`moav doctor` printed network buffers as "0 MiB".** The kernel default (~208 KiB) integer-divided to 0 MiB, reading like a broken probe instead of "buffer is small". Sub-MiB values now print in KiB. (The BBR/qdisc/buffer lines remain advisory until `moav net apply` is run.)

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -229,10 +229,14 @@ cmd_update() {
     fi
 }
 
-# Check if component versions in .env are outdated compared to .env.example
+# Check if component versions in .env are outdated compared to the reference.
+# Reads .env.example.full: the curated .env.example no longer carries pinned
+# *_VERSION lines (they live in the full reference and default in compose), so
+# the slim file would make this a silent no-op.
 check_component_versions() {
     local env_file="$SCRIPT_DIR/.env"
-    local example_file="$SCRIPT_DIR/.env.example"
+    local example_file="$SCRIPT_DIR/.env.example.full"
+    [[ -f "$example_file" ]] || example_file="$SCRIPT_DIR/.env.example"
 
     # Skip if .env doesn't exist
     [[ ! -f "$env_file" ]] && return 0
@@ -537,6 +541,10 @@ migrate_dns_tunnel_state() {
 
 check_env_additions() {
     local env_file="$SCRIPT_DIR/.env"
+    # Deliberately the SLIM .env.example, not .env.example.full: on update we
+    # only auto-add newly-introduced ESSENTIAL vars. Advanced tunables have
+    # code defaults and stay opt-in via the full reference, so we never
+    # re-bloat a user's .env with the whole advanced set.
     local example_file="$SCRIPT_DIR/.env.example"
 
     [[ ! -f "$env_file" ]] && return 0

--- a/tests/env-example-test.sh
+++ b/tests/env-example-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Guards the slim .env.example / full-reference split (E4-1).
+#
+# .env.example is a CURATED minimal first-run surface; .env.example.full is the
+# complete reference (every tunable, with defaults). The invariants below keep
+# the two from drifting: slim must be a strict subset of full, slim must stay
+# slim (no re-bloat), and the essentials a fresh `cp .env.example .env` install
+# needs must be present.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+SLIM="$ROOT/.env.example"
+FULL="$ROOT/.env.example.full"
+
+echo ".env.example split tests"
+
+[[ -f "$SLIM" ]] && ok ".env.example exists" || { bad ".env.example missing"; echo "  $pass/$fail"; exit 1; }
+[[ -f "$FULL" ]] && ok ".env.example.full (reference) exists" || bad ".env.example.full missing — the full reference was lost"
+
+# var keys (LHS of KEY=), ignoring commented lines
+keys() { grep -oE '^[A-Za-z_][A-Za-z0-9_]*=' "$1" 2>/dev/null | sed 's/=$//' | sort -u; }
+
+# 1. slim ⊆ full: every key in the minimal file must also be in the reference,
+#    or an operator copying a line "from the full reference" could find it absent.
+missing_from_full=$(comm -23 <(keys "$SLIM") <(keys "$FULL") 2>/dev/null | tr '\n' ' ')
+[[ -z "$missing_from_full" ]] && ok "every slim key is present in the full reference" \
+    || bad "slim keys missing from full reference (drift): $missing_from_full"
+
+# 2. slim stays slim: guard against a future edit re-bloating it back toward the
+#    old 118-var / 475-line surface this split exists to remove.
+n=$(keys "$SLIM" | wc -l | tr -d ' ')
+[[ "$n" -le 40 ]] && ok "slim .env.example is curated ($n vars, ceiling 40)" \
+                  || bad "slim .env.example has $n vars (> 40) — re-bloating; move advanced tunables to .env.example.full"
+
+# 3. full is genuinely the superset (has the advanced classes slim dropped).
+for k in SINGBOX_VERSION PORT_HTTPS TELEMT_POOL_SIZE CDN_TRANSPORT REALITY_TARGET; do
+    grep -qE "^${k}=" "$FULL" && ok "full reference carries $k" \
+        || bad "full reference missing $k — advanced tunable lost, not just moved"
+done
+
+# 4. the version-outdated check reads .env.example.full — it must hold versions.
+grep -qE '^[A-Z_]+_VERSION=' "$FULL" \
+    && ok "full reference carries *_VERSION lines (moav update version check)" \
+    || bad "no *_VERSION in full reference — check_component_versions goes silent"
+
+# 5. essentials a bare `cp .env.example .env` install needs.
+for k in DOMAIN ACME_EMAIL ADMIN_PASSWORD COMPOSE_PROJECT_NAME INITIAL_USERS; do
+    grep -qE "^#?${k}=" "$SLIM" && ok "slim has essential $k" \
+        || bad "slim .env.example dropped essential $k"
+done
+
+echo ""
+echo "  $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
First E4 breaking-set item. **Not breaking for existing installs** — their `.env` is untouched and every removed key falls back to the same code/compose default.

## What
`.env.example` went from **118 vars / 475 lines / 21 KB** to a curated **28 vars**: domain, ACME email, admin password, server identity, protocol toggles, and a handful of common options. Everything advanced moved to a new complete reference **`.env.example.full`** (versions, ports, Reality/XHTTP targets, DNS-tunnel subdomains, telemt tuning, CDN, donation, monitoring, client mode, registry overrides). Copy any line from the full reference into your `.env` to override it.

## Safety (audited before cutting)
- `.env.example` → `.env` is a plain `cp`; a fresh install with the slim file behaves identically because:
  - all `PORT_*` and `*_VERSION` default via `${VAR:-...}` in compose (zero bare refs),
  - tuning vars read through `get_env_val` (always with a default) or inline `${VAR:-x}`,
  - enabled-protocol vars (REALITY_TARGET, SS_METHOD, the DNS subdomains, XDNS_MTU, TELEMT_TLS_DOMAIN, CERT_AUTORENEW) all have code defaults — verified,
  - generated secrets live in **state**; compose defaults them to empty whether the `.env` line exists or not.
- `moav update`: version-outdated check repointed to `.env.example.full` (where `*_VERSION` now lives); the new-variable auto-add still reads the **slim** file, so updates never re-bloat a user's `.env`.
- Removed two now-dead `CDN_SUBDOMAIN` seds from the e2e domainless prep (var no longer in the slim file; CDN is inert without a domain).

## Tests
`tests/env-example-test.sh` (new, in CI): slim is a strict subset of the full reference, stays under a 40-var ceiling (anti-re-bloat), the full reference still carries every advanced class, and the copy-install essentials are present. 15/15.