### PR TITLE
fix(e4): harden state<->.env desync for generated secrets (Reality short_id class)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         run: bash tests/env-resolution-test.sh
       - name: .env.example slim/full split
         run: bash tests/env-example-test.sh
+      - name: reality short_id desync guard
+        run: bash tests/reality-desync-test.sh
       - name: docker management-plane isolation
         run: bash tests/network-isolation-test.sh
       - name: monitoring socket removal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Hardened the whole state↔.env generated-secret desync class (the Reality short_id total-outage family).** Generated secrets live in `state/keys`, but docker-compose injects them into the bootstrap container from `.env` — usually empty, since the values are not in `.env`. A render that read the empty injected value silently blanked the secret; for the Reality short_id that rejected *every* client with no error anywhere (PR #152 fixed only Reality, only in two spots). Now a single `load_state_secrets` re-sources the entire class (reality, clash-api, cdn, shadowsocks PSK) from state right before every render, and a post-render assert aborts the bootstrap if state holds a Reality short_id or private key the rendered config does not contain — refusing to ship a config that would silently reject everyone. `moav doctor` gained a matching config↔state short_id check.
+
+
 ### Changed
 - **`.env.example` slimmed from 118 vars / 475 lines to a curated 28-var first-run surface.** A new operator now sees only what they actually set (domain, ACME email, admin password, server IP, protocol toggles, and a few common options). Every advanced tunable (component versions, ports, Reality/XHTTP targets, DNS-tunnel subdomains, Telegram/telemt tuning, CDN, bandwidth donation, monitoring, client mode, registry overrides) has a working code/compose default and moved to a new complete reference, **`.env.example.full`** — copy any line into your `.env` to override it. Existing installs are unaffected (their `.env` is untouched; removed keys fall back to the same defaults). `moav update`'s version-outdated check now reads the full reference; its new-variable auto-add still reads the slim file, so an update never re-bloats your `.env` with the advanced set. A drift test keeps the slim file a strict subset of the reference and under a 40-var ceiling.
 

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -962,7 +962,7 @@ EOF
         state_sid=$(docker run --rm -v moav_moav_state:/state alpine sh -c \
             'grep "^REALITY_SHORT_ID=" /state/keys/reality.env 2>/dev/null | cut -d= -f2-' 2>/dev/null | tr -d '\r\n ')
         if [[ -n "$state_sid" && -f "$rcfg" ]]; then
-            if grep -qF "$state_sid" "$rcfg"; then
+            if grep -qF -- "$state_sid" "$rcfg"; then
                 echo -e "    ${GREEN}✓${NC} Reality short_id in config.json matches state"
             else
                 echo -e "    ${RED}✗${NC} Reality short_id from state is ABSENT in config.json"

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -953,6 +953,26 @@ EOF
     [[ "$enable_reality" == "true" ]] && _doctor_reality_one "VLESS Reality (:443)" "sing-box" "REALITY_TARGET" "www.cloudflare.com:443"
     [[ "$enable_xhttp"    == "true" ]] && _doctor_reality_one "XHTTP-Reality (:2096)" "xray" "XHTTP_REALITY_TARGET" "www.cloudflare.com:443"
 
+    # state<->config short_id desync guard (E4-4). The short_id lives in state;
+    # if a render read an empty .env-injected value instead, config.json ships
+    # an empty short_id and EVERY Reality client is rejected with no error
+    # anywhere (PR #152 class). Compare the rendered config against state.
+    if [[ "$enable_reality" == "true" ]]; then
+        local rcfg="$SCRIPT_DIR/configs/sing-box/config.json" state_sid=""
+        state_sid=$(docker run --rm -v moav_moav_state:/state alpine sh -c \
+            'grep "^REALITY_SHORT_ID=" /state/keys/reality.env 2>/dev/null | cut -d= -f2-' 2>/dev/null | tr -d '\r\n ')
+        if [[ -n "$state_sid" && -f "$rcfg" ]]; then
+            if grep -qF "$state_sid" "$rcfg"; then
+                echo -e "    ${GREEN}✓${NC} Reality short_id in config.json matches state"
+            else
+                echo -e "    ${RED}✗${NC} Reality short_id from state is ABSENT in config.json"
+                echo -e "      ${DIM}config↔state desync — every Reality client is rejected (issue class of PR #152).${NC}"
+                echo -e "      ${DIM}Fix: moav bootstrap (re-renders sing-box from state).${NC}"
+                pass=false
+            fi
+        fi
+    fi
+
     unset -f _doctor_reality_tcp_probe
     unset -f _doctor_reality_one
     $pass && return 0 || return 1

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -19,6 +19,56 @@ source /app/lib/telemt.sh
 source /app/lib/sync.sh
 source /app/lib/provision.sh   # shared "materialize every user" path (see A8)
 
+# ---------------------------------------------------------------------------
+# state <-> .env desync guards (E4-4)
+#
+# Generated secrets live in state/keys, but docker-compose injects them into
+# this container as env vars from .env (usually EMPTY, since the values are not
+# in .env). Any render that reads the empty env var instead of state silently
+# blanks the secret. PR #152 was exactly this for the Reality short_id: an
+# empty rendered short_id rejected EVERY Reality client, with no error anywhere.
+# ---------------------------------------------------------------------------
+
+# Re-load the whole generated-secret class from state, right before a render, so
+# state (the source of truth) wins over a shadowing empty .env value. Uniform
+# across reality/clash/cdn/ss — not just reality, which was the only one #152
+# covered. Safe to call repeatedly.
+load_state_secrets() {
+    [[ -f "$STATE_DIR/keys/reality.env"   ]] && source "$STATE_DIR/keys/reality.env"
+    [[ -f "$STATE_DIR/keys/clash-api.env" ]] && source "$STATE_DIR/keys/clash-api.env"
+    [[ -f "$STATE_DIR/keys/cdn.env"       ]] && source "$STATE_DIR/keys/cdn.env"
+    [[ -f "$STATE_DIR/keys/shadowsocks-server.psk" ]] && \
+        SS_SERVER_PSK=$(cat "$STATE_DIR/keys/shadowsocks-server.psk" 2>/dev/null)
+    export REALITY_SHORT_ID REALITY_PRIVATE_KEY REALITY_PUBLIC_KEY \
+           CLASH_API_SECRET HYSTERIA2_OBFS_PASSWORD CDN_WS_PATH SS_SERVER_PSK 2>/dev/null || true
+}
+
+# Fail LOUDLY if a render dropped the Reality identity that state holds. Compares
+# the state short_id / private key against the rendered file: if state has a
+# value (so this install uses Reality) but the render does not contain it, the
+# secret desynced and every client would be rejected. Aborting a bootstrap is
+# strictly better than serving a config that silently rejects everyone.
+# No false positive on a deliberate empty-short_id setup: state would be empty
+# too, and we skip.
+assert_reality_in_render() {
+    local cfg="$1"
+    [[ "${ENABLE_REALITY:-true}" == "true" ]] || return 0
+    [[ -f "$cfg" && -f "$STATE_DIR/keys/reality.env" ]] || return 0
+    local sid pk
+    sid=$(source "$STATE_DIR/keys/reality.env"; printf '%s' "${REALITY_SHORT_ID:-}")
+    pk=$(source "$STATE_DIR/keys/reality.env"; printf '%s' "${REALITY_PRIVATE_KEY:-}")
+    if [[ -n "$sid" ]] && ! grep -qF "$sid" "$cfg"; then
+        log_error "FATAL: Reality short_id from state is absent in $cfg."
+        log_error "  The render read an empty value instead of state — every Reality client"
+        log_error "  would be rejected (PR #152 class). Not writing a silently-broken config."
+        exit 1
+    fi
+    if [[ -n "$pk" ]] && ! grep -qF "$pk" "$cfg"; then
+        log_error "FATAL: Reality private key from state is absent in $cfg — Reality would not authenticate."
+        exit 1
+    fi
+}
+
 log_info "Starting MoaV bootstrap..."
 
 # -----------------------------------------------------------------------------
@@ -796,14 +846,14 @@ if [[ "${ENABLE_XHTTP:-true}" == "true" ]]; then
     XHTTP_REALITY_TARGET_HOST="${XHTTP_REALITY_TARGET%%:*}"
     export XHTTP_REALITY_TARGET_HOST
 
-    # Reuse Reality keys from sing-box. Re-load from state first so an empty
-    # REALITY_SHORT_ID injected from .env can't blank the rendered shortIds
-    # (same trap as the sing-box render below).
-    [[ -f "$STATE_DIR/keys/reality.env" ]] && source "$STATE_DIR/keys/reality.env"
+    # Re-load the whole secret class from state so an empty .env-injected value
+    # can't blank the render (see load_state_secrets / PR #152).
+    load_state_secrets
     export REALITY_PRIVATE_KEY
     export REALITY_SHORT_ID
 
     envsubst < /configs/xray/config.json.template > /configs/xray/config.json
+    assert_reality_in_render /configs/xray/config.json
 
     # Add XDNS inbound if enabled
     if [[ "${ENABLE_XDNS:-false}" == "true" ]] && [[ -n "${DOMAIN:-}" ]]; then
@@ -874,12 +924,13 @@ singbox_needed=false
 if [[ "$singbox_needed" == "true" ]]; then
     log_info "Generating sing-box configuration (using existing keys)..."
 
-    # Re-load the authoritative Reality identity from state right before the
-    # render. docker-compose injects REALITY_SHORT_ID=${REALITY_SHORT_ID:-} from
-    # .env into this container; since the short id lives in state (not .env),
-    # that value is usually empty and would shadow the real one — rendering an
-    # empty short_id that silently rejects EVERY Reality client. State wins.
-    [[ -f "$STATE_DIR/keys/reality.env" ]] && source "$STATE_DIR/keys/reality.env"
+    # Re-load the authoritative generated secrets from state right before the
+    # render. docker-compose injects these (REALITY_SHORT_ID, CLASH_API_SECRET,
+    # CDN_WS_PATH, ...) from .env into this container; since they live in state,
+    # the injected values are usually empty and would shadow the real ones —
+    # rendering e.g. an empty short_id that silently rejects EVERY Reality
+    # client. State wins. (Uniform re-source; PR #152 covered only reality.)
+    load_state_secrets
 
     export REALITY_USERS_JSON
     export TROJAN_USERS_JSON
@@ -947,6 +998,7 @@ if [[ "$singbox_needed" == "true" ]]; then
         log_info "  No server IPv6 — added prefer_ipv4 resolve rule (silences IPv6 dial failures)"
     fi
 
+    assert_reality_in_render /configs/sing-box/config.json
     log_info "sing-box configuration written to /configs/sing-box/config.json"
 else
     log_info "sing-box not needed (no TLS protocols enabled)"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -57,13 +57,13 @@ assert_reality_in_render() {
     local sid pk
     sid=$(source "$STATE_DIR/keys/reality.env"; printf '%s' "${REALITY_SHORT_ID:-}")
     pk=$(source "$STATE_DIR/keys/reality.env"; printf '%s' "${REALITY_PRIVATE_KEY:-}")
-    if [[ -n "$sid" ]] && ! grep -qF "$sid" "$cfg"; then
+    if [[ -n "$sid" ]] && ! grep -qF -- "$sid" "$cfg"; then
         log_error "FATAL: Reality short_id from state is absent in $cfg."
         log_error "  The render read an empty value instead of state — every Reality client"
         log_error "  would be rejected (PR #152 class). Not writing a silently-broken config."
         exit 1
     fi
-    if [[ -n "$pk" ]] && ! grep -qF "$pk" "$cfg"; then
+    if [[ -n "$pk" ]] && ! grep -qF -- "$pk" "$cfg"; then
         log_error "FATAL: Reality private key from state is absent in $cfg — Reality would not authenticate."
         exit 1
     fi

--- a/tests/reality-desync-test.sh
+++ b/tests/reality-desync-test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Regression test for the state<->.env Reality short_id desync guard (E4-4).
+#
+# The generated short_id lives in state/keys/reality.env, but docker-compose
+# injects REALITY_SHORT_ID from .env (usually empty) into the bootstrap
+# container. A render that reads the empty injected value writes an empty
+# short_id, and EVERY Reality client is silently rejected (PR #152). The guard:
+# assert_reality_in_render aborts the render if state has a short_id the
+# rendered config does not contain. This test exercises that function in
+# isolation against good and desynced configs.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "reality short_id desync guard tests"
+
+# The guard must be wired into bootstrap at BOTH renders.
+grep -q 'assert_reality_in_render /configs/sing-box/config.json' "$ROOT/scripts/bootstrap.sh" \
+    && ok "sing-box render asserts short_id vs state" \
+    || bad "sing-box render has no assert_reality_in_render"
+grep -q 'assert_reality_in_render /configs/xray/config.json' "$ROOT/scripts/bootstrap.sh" \
+    && ok "xray render asserts short_id vs state" \
+    || bad "xray render has no assert_reality_in_render"
+grep -q 'load_state_secrets' "$ROOT/scripts/bootstrap.sh" \
+    && ok "renders re-source the whole secret class from state" \
+    || bad "load_state_secrets not wired"
+grep -q 'Reality short_id from state is ABSENT in config.json' "$ROOT/lib/doctor.sh" \
+    && ok "doctor has the config<->state short_id check" \
+    || bad "doctor missing the short_id desync check"
+
+# Behavioural: extract assert_reality_in_render from bootstrap and run it against
+# a good and a desynced config with a fake state dir.
+STATE_DIR=$(mktemp -d); export STATE_DIR
+trap 'rm -rf "$STATE_DIR" "$WORK"' EXIT
+mkdir -p "$STATE_DIR/keys"
+cat > "$STATE_DIR/keys/reality.env" <<EOF
+REALITY_SHORT_ID=deadbeef
+REALITY_PRIVATE_KEY=PRIVKEYVALUE123
+EOF
+
+log_error() { :; }   # silence
+ENABLE_REALITY=true
+# Pull the function body out of bootstrap.sh so we test the real code.
+eval "$(awk '/^assert_reality_in_render\(\) \{/,/^\}/' "$ROOT/scripts/bootstrap.sh")"
+
+WORK=$(mktemp -d)
+good="$WORK/good.json"; bad_cfg="$WORK/bad.json"
+printf '{"inbounds":[{"tls":{"reality":{"short_id":["deadbeef"],"private_key":"PRIVKEYVALUE123"}}}]}\n' > "$good"
+printf '{"inbounds":[{"tls":{"reality":{"short_id":[""],"private_key":""}}}]}\n' > "$bad_cfg"
+
+( assert_reality_in_render "$good" ) && ok "good config passes the assert" \
+    || bad "good config wrongly rejected"
+
+# The desynced config must abort (non-zero). Run in a subshell so the exit
+# doesn't kill the test.
+if ( assert_reality_in_render "$bad_cfg" ) 2>/dev/null; then
+    bad "desynced config (empty short_id) was NOT caught — the #152 outage would ship"
+else
+    ok "desynced config (empty short_id) is caught and aborts"
+fi
+
+# When state short_id is empty (deliberate empty-short_id setup), no false abort.
+echo "REALITY_SHORT_ID=" > "$STATE_DIR/keys/reality.env"
+if ( assert_reality_in_render "$bad_cfg" ) 2>/dev/null; then
+    ok "empty state short_id → no false positive"
+else
+    bad "empty state short_id wrongly aborted (false positive)"
+fi
+
+echo ""
+echo "  $pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/tests/reality-desync-test.sh
+++ b/tests/reality-desync-test.sh
@@ -62,6 +62,22 @@ else
     ok "desynced config (empty short_id) is caught and aborts"
 fi
 
+# Base64url secret starting with '-': grep must treat it as a pattern, not an
+# option (grep -qF --). This false-positived in e2e and aborted a healthy
+# bootstrap — the short_id is hex so it never tripped, but the private key can
+# start with '-'.
+cat > "$STATE_DIR/keys/reality.env" <<EOF
+REALITY_SHORT_ID=abcd1234
+REALITY_PRIVATE_KEY=-Xleadingdashkey123
+EOF
+dash="$WORK/dash.json"
+printf '{"inbounds":[{"tls":{"reality":{"short_id":["abcd1234"],"private_key":"-Xleadingdashkey123"}}}]}\n' > "$dash"
+if ( assert_reality_in_render "$dash" ) 2>/dev/null; then
+    ok "leading-dash private key present → passes (grep -qF -- honored)"
+else
+    bad "leading-dash private key wrongly rejected — grep parsed it as an option (missing --)"
+fi
+
 # When state short_id is empty (deliberate empty-short_id setup), no false abort.
 echo "REALITY_SHORT_ID=" > "$STATE_DIR/keys/reality.env"
 if ( assert_reality_in_render "$bad_cfg" ) 2>/dev/null; then


### PR DESCRIPTION
E4-4. Generalizes the PR #152 fix from 'Reality, in two spots' to the whole generated-secret class, and adds a guardrail so it can never silently regress.

## The class
Generated secrets live in `state/keys`. docker-compose injects them into the bootstrap container from `.env` (`REALITY_SHORT_ID=${REALITY_SHORT_ID:-}`, etc.) — but the values aren't in `.env`, so the injected env vars are usually **empty**. Any render that reads the empty env var instead of state silently blanks the secret. For the Reality short_id that was a **total, silent outage**: an empty rendered short_id rejects every Reality client, no error logged anywhere. PR #152 fixed Reality specifically, in the two render spots; clash-api / cdn / ss sat in the same trap for any caller that didn't pre-load them.

## Fix
- **`load_state_secrets`** re-sources the entire class (reality, clash-api, cdn, shadowsocks PSK) from state immediately before each render (sing-box + xray), replacing the reality-only re-source. State is the source of truth; it wins over a shadowing empty `.env` value, uniformly.
- **`assert_reality_in_render`** runs after each render: if state holds a Reality short_id (or private key) that the rendered config does **not** contain, it aborts the bootstrap with a loud FATAL. Refusing to write a config is strictly better than shipping one that silently rejects everyone. No false positive on a deliberate empty-short_id setup (state is empty too → skipped).
- **`moav doctor`** gains a config↔state short_id check that flags the same desync on an already-running install and points at `moav bootstrap` to re-render.

## Tests
`tests/reality-desync-test.sh` (new, CI): extracts the real `assert_reality_in_render` and runs it against a good config (passes), a desynced/empty-short_id config (aborts — the #152 outage would be caught), and a deliberate-empty state (no false abort). Plus wiring assertions for both renders and the doctor check. 7/7.