### PR TITLE
fix: install-session fixes (grafana crash-loop, cadvisor logs, install links, wstunnel test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: bash tests/bundle-perms-test.sh
       - name: entrypoint strict-mode test
         run: bash tests/entrypoint-strict-test.sh
+      - name: grafana branding non-fatal
+        run: bash tests/grafana-branding-test.sh
       - name: env resolution golden-diff
         run: bash tests/env-resolution-test.sh
       - name: .env.example slim/full split

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Grafana no longer crash-loops over cosmetic branding.** The entrypoint patches a logo into the grafana image's `public/img` dir; on images/hosts where that dir is not writable even as root (seen live on a DigitalOcean droplet with `grafana/grafana:latest`), the one unguarded `cat >` write failed with "Permission denied" and, under `set -e`, killed the entrypoint and restart-looped the container. The write is now best-effort (`if cat … else skip`), so branding degrades gracefully and grafana stays up. A restart-storming grafana was also starving the box's docker daemon, which is the likely trigger for the intermittent "no wg/awg key generator" on `moav user add` right after start.
+- **`moav test` no longer warns "couldn't parse the wstunnel server".** It read the endpoint from a `wireguard-instructions.txt` that bundles do not contain; it now reads the `wstunnel client -L … wss://host:port` command from `README.html` (matching the command line, not the surrounding prose) and validates that endpoint.
+
+### Changed
+- **cAdvisor logs are quiet.** It logged a multi-line "Filesystem partitions" map (every overlayfs/tmpfs mount) on each housekeeping pass, flooding `docker logs`; added `--stderrthreshold=1 -v=0` so only warnings and up are emitted. Metrics unchanged.
+- **The installer's completion banner shows the community links** (Telegram, Twitter/X, GitHub issues) alongside Documentation and Website.
+
+
 ### Changed
 - **User bundles show only the protocols the user actually has (#73).** The README guide used to render every protocol section, with "No X config available" filler for anything disabled — a 12-protocol wall where half the entries were dead. Each section and its table-of-contents entry (English and Farsi) is now hidden when the user's bundle has no artifact for that protocol, keyed on the same per-user files the config values already read. `subscription.txt` is untouched (same unconditional format, so `moav-client` and V2Ray apps see no change). Migration for existing users: `moav regenerate-users` — and `moav update` now detects bundle-guide/renderer changes and lists that step in its post-update instructions.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1061,6 +1061,13 @@ services:
       - '--docker_only=true'
       - '--housekeeping_interval=30s'
       - '--store_container_labels=true'
+      # Quiet the logs: cAdvisor logs a multi-line "Filesystem partitions" map
+      # (every overlayfs/tmpfs mount) at glog level 0 on each housekeeping pass,
+      # which floods `docker logs`. -v=0 + only-warnings-and-up to stderr keeps
+      # the metrics unchanged while cutting the info-spam.
+      - '--logtostderr=true'
+      - '--stderrthreshold=1'
+      - '-v=0'
     environment:
       - TZ=${TZ:-UTC}
     mem_limit: 256m

--- a/install.sh
+++ b/install.sh
@@ -763,5 +763,8 @@ fi
 
 echo ""
 echo -e "${CYAN}Documentation:${NC} https://github.com/MotherofallVPNs/moav"
-echo -e "${CYAN}Website:${NC} https://moav.sh"
+echo -e "${CYAN}Website:${NC}       https://moav.sh"
+echo -e "${CYAN}Telegram:${NC}      https://t.me/motherofallvpns"
+echo -e "${CYAN}Twitter/X:${NC}     https://x.com/motherofallvpns"
+echo -e "${CYAN}Issues/bugs:${NC}   https://github.com/MotherofallVPNs/MoaV/issues"
 echo ""

--- a/scripts/grafana-entrypoint.sh
+++ b/scripts/grafana-entrypoint.sh
@@ -65,12 +65,22 @@ if [ -d "/branding" ]; then
     if [ -f "/branding/logo.png" ]; then
         # Get image dimensions (default to 100x100 if not determinable)
         LOGO_B64=$(base64 -w0 /branding/logo.png 2>/dev/null || base64 /branding/logo.png)
-        cat > "$GRAFANA_IMG/grafana_icon.svg" << SVGEOF
+        # `if cat` (not a bare `cat >`): the grafana image dir is read-only for
+        # the non-root grafana user (uid 472) in current images, so this write
+        # is Permission denied — and as the one UNGUARDED write in this block it
+        # crash-looped the whole container under `set -e` (the favicon cp's are
+        # in `&& echo` lists and the js seds are `|| true`, so only this one was
+        # fatal). Branding is cosmetic; skip it rather than take grafana down.
+        if cat > "$GRAFANA_IMG/grafana_icon.svg" 2>/dev/null << SVGEOF
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
   <image width="100" height="100" xlink:href="data:image/png;base64,$LOGO_B64"/>
 </svg>
 SVGEOF
-        echo "[grafana] Created grafana_icon.svg from logo.png"
+        then
+            echo "[grafana] Created grafana_icon.svg from logo.png"
+        else
+            echo "[grafana] logo branding skipped (image dir read-only) — dashboards unaffected"
+        fi
     fi
 
     # Replace app title in JavaScript bundles (affects browser tab and PWA name)

--- a/tests/client-test.sh
+++ b/tests/client-test.sh
@@ -2164,10 +2164,22 @@ test_wstunnel() {
     fi
 
     # The .conf points WireGuard at the local wstunnel endpoint (127.0.0.1); the
-    # real server + port live in the instructions' wstunnel client command.
-    local instr="$CONFIG_DIR/wireguard-instructions.txt"
-    local cmd=""; [[ -f "$instr" ]] && cmd=$(grep -m1 'wstunnel client' "$instr" 2>/dev/null || true)
-    local url; url=$(echo "$cmd" | grep -oE '(wss?)://[^ ]+' | head -1 || true)
+    # real server + port live in the "wstunnel client ... wss://host:port" line.
+    # That command is rendered into README.html (there is no separate
+    # wireguard-instructions.txt in the bundle), so read it from there — with a
+    # fallback to a .txt if a future bundle ships one. Extraction stops at the
+    # first space, quote or `<` so the surrounding HTML tag is trimmed.
+    # Match the command line specifically ('wstunnel client -L …'), not the
+    # surrounding prose ("run the wstunnel client to create a tunnel:"), then
+    # take the ws(s):// endpoint. Extraction stops at space/quote/`<` to trim
+    # the HTML tag around it in README.html.
+    local url=""
+    for instr in "$CONFIG_DIR/wireguard-instructions.txt" "$CONFIG_DIR/README.html"; do
+        [[ -f "$instr" ]] || continue
+        url=$(grep -oE 'wstunnel client -L[^<"]*' "$instr" 2>/dev/null \
+              | grep -oE '(wss?)://[^ <"]+' | head -1 || true)
+        [[ -n "$url" ]] && break
+    done
     local scheme="${url%%://*}"
     local hostport="${url#*://}"; hostport="${hostport%%/*}"
     local server="${hostport%:*}" port="${hostport##*:}"

--- a/tests/grafana-branding-test.sh
+++ b/tests/grafana-branding-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Regression test: grafana branding writes must never crash-loop the container.
+#
+# The grafana entrypoint patches cosmetic branding into the image's public dir.
+# On some images/hosts that dir is not writable even as root (observed live on a
+# DigitalOcean droplet with grafana/grafana:latest), so the writes fail with
+# "Permission denied". Every such write MUST be non-fatal under `set -e` — one
+# unguarded `cat >` used to kill the entrypoint and restart-loop grafana.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+f="$ROOT/scripts/grafana-entrypoint.sh"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "grafana branding non-fatal tests"
+
+# No bare `cat > "$GRAFANA_*"` — must be guarded (if cat / || true).
+if grep -nE '^\s*cat > "\$GRAFANA' "$f" >/dev/null; then
+    bad "unguarded 'cat > \$GRAFANA...' — a read-only image dir crash-loops grafana"
+else
+    ok "no unguarded cat-redirect into the grafana image dir"
+fi
+
+# The specific logo write is inside an `if cat ... then ... else` (non-fatal).
+if grep -q 'if cat > "\$GRAFANA_IMG/grafana_icon.svg"' "$f"; then
+    ok "grafana_icon.svg write is guarded (if cat)"
+else
+    bad "grafana_icon.svg write is not guarded with 'if cat'"
+fi
+
+# Functional: the exact guard pattern is non-fatal under set -e on a failed write.
+if sh -c 'set -eu
+if cat > /nonexistent-ro/x 2>/dev/null <<E
+<svg/>
+E
+then :; else :; fi
+exit 0'; then
+    ok "if-cat guard is non-fatal under set -e (reaches exec)"
+else
+    bad "guard still aborts under set -e"
+fi
+
+echo ""
+echo "  $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Fixes from the user's live 1.9.1→v2 install + `moav test` session on a throwaway server.

## Grafana crash-loop (the important one)
The grafana entrypoint patches a logo into `/usr/share/grafana/public/img`. On the current `grafana/grafana:latest` (running as root, not read-only) that dir turned out **not writable even for root** on a DigitalOcean droplet, so the SVG write failed with "Permission denied" — and it was the **one unguarded `cat >`** in the branding block (the favicon `cp`s are in `&& echo` lists and the js edits are `|| true`, both `set -e`-safe; only this write was fatal). It killed the entrypoint and restart-looped the container every ~15s. Now `if cat … else skip`: branding is best-effort, grafana stays up.

Knock-on: a grafana restart-storm on a 1-vCPU box starves the docker daemon, which is the likely trigger for the intermittent **"no wg/awg key generator"** on `moav user add` right after start (the keygen `docker exec` slows under the storm). Reproduced clean: with the box settled, `moav user add` adds wg+awg peers fine — I verified live. Fixing grafana removes the storm.

## moav test: wstunnel parse
The test read the wstunnel endpoint from `wireguard-instructions.txt`, a file bundles do not contain, so it always warned "couldn't parse the wstunnel server". It now reads the `wstunnel client -L … wss://host:port` command from `README.html` (matching the command line, not the prose around it). Verified against a real bundle: extracts `wss://<domain>:8080`.

## cAdvisor log flood
Added `--stderrthreshold=1 -v=0` — it was logging a multi-line "Filesystem partitions" map on every housekeeping pass. Metrics unchanged.

## Installer banner
Added Telegram / Twitter-X / GitHub-issues links to the "Installation complete!" banner.

## Tests
`tests/grafana-branding-test.sh` (CI): asserts no unguarded `cat > $GRAFANA…`, the logo write uses the `if cat` guard, and the guard is functionally non-fatal under `set -e`.