### PR TITLE
docs+test: root llms.txt + AGENTS.md; CI test for nested env fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         run: bash tests/grafana-branding-test.sh
       - name: env resolution golden-diff
         run: bash tests/env-resolution-test.sh
+      - name: env nested-fallback resolution
+        run: bash tests/env-fallback-test.sh
       - name: .env.example slim/full split
         run: bash tests/env-example-test.sh
       - name: reality short_id desync guard

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md — MoaV server repo guide for AI agents
+
+This is the deep guide for coding agents (Claude Code, Cursor, etc.) working in
+the **MoaV server** repository. Humans: start with [README.md](README.md); the
+public docs live at [moav.sh/docs](https://moav.sh/docs). A one-fetch index for
+agents is [llms.txt](llms.txt).
+
+## What MoaV is
+
+A single-host, Docker-Compose, multi-protocol Internet-censorship-circumvention
+stack. `moav.sh` is a bash dispatcher over `lib/*.sh` modules; it bootstraps
+keys/certs, generates per-user bundles (configs, QR codes, a V2Ray
+subscription), and runs 16+ transports plus an optional Prometheus/Grafana
+monitoring stack. Protocol servers run as containers; provisioning and the CLI
+are bash.
+
+## Repository layout
+
+| Path | What |
+|---|---|
+| `moav.sh` | CLI dispatcher (~1k lines). Subcommands: bootstrap, build, start, stop, restart, status, update, user(s), test, doctor, donate, conduit, admin, cert, install, uninstall, logs, export, import, profiles |
+| `lib/*.sh` | Host-side CLI modules sourced by `moav.sh`: `service` (up/down), `users`, `bootstrap`, `build`, `update`, `doctor`, `donate`, `cert`, `nettune`, `peers`, `migrate`, `install`, `menu`, `dns`, `common` |
+| `scripts/*-entrypoint.sh` | Container entrypoints (sing-box, xray, grafana, admin, wstunnel, trusttunnel, snowflake, …) |
+| `scripts/user-add.sh`, `wg-user-add.sh`, `singbox-user-add.sh` | Per-user provisioning (host + container) |
+| `scripts/lib/*.sh` | Provisioning libs, mounted into containers as `/app/lib`: `sing-box`, `xray`, `wireguard`, `amneziawg`, `telemt`, `dnstt`, `slipstream`, `masterdns`, `gooserelay`, `trusttunnel`, `keys`, `provision`, `sync`, `bundle-readme`, `common` |
+| `configs/` | `*.template` files (tracked) → rendered `*.json`/`*.conf` (gitignored). Grafana dashboards in `configs/monitoring/grafana/provisioning/dashboards/*.json` |
+| `dockerfiles/`, `exporters/`, `admin/` | Image builds; the Prometheus exporters; the FastAPI admin dashboard |
+| `tests/*.sh` | The regression suite (see Testing) |
+| `docs/devdocs/` | Contributor docs: E2E-TESTING, PROTOCOL-INTEGRATION-CHECKLIST, VERSION-BUMP-CHECKLIST |
+| `.claude/skills/` | Operational Claude Code skills (e.g. running e2e) — tools, not this guide |
+
+## Build & run (local, no full install)
+
+```bash
+cp .env.example .env      # set DOMAIN, ACME_EMAIL, ADMIN_PASSWORD (top block)
+./moav.sh build           # build images (caps BuildKit cache when done)
+./moav.sh bootstrap       # generate keys/certs/configs + first user (idempotent)
+./moav.sh start all       # bring up the selected profiles
+./moav.sh doctor          # diagnostics
+./moav.sh user add alice  # provision a user bundle -> outputs/bundles/alice/
+```
+
+`moav update -b dev && moav build && moav start` is the in-place upgrade path.
+
+## Testing
+
+```bash
+bash tests/<name>.sh            # any single suite
+```
+CI (`.github/workflows/ci.yml`) runs the bash suites: strict-mode, entrypoint-strict,
+state-perms, bundle-perms, env-resolution, env-fallback, env-example, reality-desync,
+grafana-branding, singbox-links, net-alloc, user-add-timeout, and more. **e2e**
+(`.github/workflows/e2e.yml`, `workflow_dispatch`, self-hosted) builds the stack on
+a real VPS + domain and probes every protocol end-to-end; the merge bar for
+anything touching provisioning.
+
+**Every bug found in dev gets a regression test in the same PR** — see the many
+`tests/*-test.sh` named after the class they pin.
+
+## Conventions that bite if you miss them
+
+- **Strict mode.** Entrypoints run `set -eu` (+ pipefail probed in a subshell — `set -o pipefail` is fatal in dash regardless of `|| true`). `cmd1 && cmd2` does not trip `-e` on `cmd1`; a bare `cmd >file` does. `((x++))` returns 1 from 0 under `-e`.
+- **`get_env_val`** is the single `.env` accessor (`lib/common.sh` + `scripts/lib/common.sh`, held byte-identical by a test). Uses `cut -d= -f2-` so base64 `=` isn't truncated. Don't hand-roll `grep|cut` scrapers.
+- **bash 3.2.** macOS ships it; scripts and tests must run under it. No `mapfile`, no `declare -A` in hot paths, no `${var^^}`.
+- **Host vs container paths.** `scripts/*-entrypoint.sh` use relative `configs/`; container lib functions may hardcode absolute `/configs`, `/state`. `state/users/` (host) ≠ the `moav_moav_state` volume (container reads the volume).
+- **Generated configs are gitignored**; only `*.template` is tracked. `git pull` on update can't clobber a user's rendered config.
+- **Admin container runs as uid/gid 2000**; bundles/state are chowned to it, never world-writable. State-key files are 0600 (root-owned) except the three read by non-root daemons (dnstt/masterdns/slipstream keys stay 0644 inside the volume).
+- **Secrets live in state, not `.env`.** Renders re-source state right before writing (see `load_state_secrets`) so an empty `.env`-injected value can't blank a rendered secret.
+
+## Common tasks
+
+- **New CLI subcommand:** add a `case` in `moav.sh` dispatch + a `cmd_*` in the right `lib/*.sh`.
+- **New protocol:** follow `docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md`; add a `scripts/lib/<proto>.sh`, wire provisioning, add a live e2e probe + a bundle section.
+- **Version bump:** `docs/devdocs/VERSION-BUMP-CHECKLIST.md`; pinned `*_VERSION` vars default in compose build args.
+- **Merge flow:** PRs via `gh pr merge` only; gate on `ci.yml` **and** `e2e.yml`; verify PR state `MERGED` before deleting the branch. Do not add AI-attribution trailers to commits/PRs.
+
+## Where to look next
+
+- [docs/devdocs/E2E-TESTING.md](docs/devdocs/E2E-TESTING.md) — the e2e harness, tiers, and how a green run is defined
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contributor workflow
+- [CHANGELOG.md](CHANGELOG.md) — behavior changes per version
+- [moav.sh/docs](https://moav.sh/docs) — the full public documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Agent entry points: root `llms.txt` and `AGENTS.md`.** `llms.txt` (llmstxt.org format, mirroring the moav-site one) is a concise project summary + curated index for AI agents landing on the repo; `AGENTS.md` is the deep agent guide (repo layout, build/run, testing, and the conventions that bite — strict mode, `get_env_val`, bash 3.2, host-vs-container paths, uid 2000, secrets-in-state). The `.claude/skills/` stay as operational tools.
+- **CI test for nested env-var fallbacks.** `tests/env-fallback-test.sh` verifies every `${PRIMARY:-${SECONDARY:-DEFAULT}}` chain resolves correctly for primary-set / primary-empty+secondary-set / both-unset (XHTTP_REALITY_TARGET→REALITY_TARGET, CDN_ADDRESS→CDN_DOMAIN, CDN_SNI→DOMAIN, CONDUIT_MAX_COMMON_CLIENTS→CONDUIT_MAX_CLIENTS), pins the XHTTP→REALITY chain at all three call sites, and a coverage guard fails CI if a new nested fallback ships untested. Runs under bash 3.2.
+
+
 ### Fixed
 - **`XHTTP_REALITY_TARGET` now actually defaults to `REALITY_TARGET`.** The comment claimed "default: same as REALITY_TARGET" but the value was hardcoded to `dl.google.com:443` in `.env.example` and every code path, so changing REALITY_TARGET silently did not change XHTTP's camouflage target. It is now empty in `.env.example` and falls back `XHTTP_REALITY_TARGET -> REALITY_TARGET -> dl.google.com:443` at all sites (bootstrap, xray config-gen, compose).
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,31 @@
+# MoaV
+
+> Multi-protocol Internet censorship circumvention stack optimized for hostile network environments. Bundles 16+ transports — Reality (VLESS), Trojan, AnyTLS (defeats TLS-in-TLS fingerprinting), Hysteria2, XHTTP, Shadowsocks-2022, CDN VLESS+WS, WireGuard (direct + over wss:// WebSocket via wstunnel), AmneziaWG, TrustTunnel (HTTP/2+QUIC), Telegram MTProxy, plus four DNS tunnels (dnstt, Slipstream, MasterDNS, XDNS) sharing port 53 through a subdomain-routing daemon. Optional bandwidth donation paths via Psiphon Conduit, Tor Snowflake, and GooseRelay. Single-host Docker Compose deployment with per-user bundle generation (configs, QR codes, V2Ray subscription), automatic Let's Encrypt certificate renewal, and an optional Prometheus + Grafana monitoring stack.
+
+This is the **source repository**. `moav.sh` is a bash dispatcher over `lib/*.sh` modules; protocol servers run as containers.
+
+## For agents working in this repo
+
+- [AGENTS.md](AGENTS.md): the deep guide — repo layout, build/run, testing, the conventions that bite (strict mode, get_env_val, bash 3.2, host-vs-container paths, uid 2000, secrets in state)
+- [CONTRIBUTING.md](CONTRIBUTING.md): contributor workflow
+- [CHANGELOG.md](CHANGELOG.md): behavior changes per version
+- [docs/devdocs/E2E-TESTING.md](docs/devdocs/E2E-TESTING.md): the end-to-end harness and what a passing run must prove
+- [docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md](docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md): adding a new protocol
+- [docs/devdocs/VERSION-BUMP-CHECKLIST.md](docs/devdocs/VERSION-BUMP-CHECKLIST.md): bumping a component version
+
+## Documentation (moav.sh)
+
+- [Quick Start](https://moav.sh/docs/quick-start/): one-command install and minimal first run
+- [Setup Guide](https://moav.sh/docs/SETUP/): full deployment — domain, DNS, certbot, ports, firewall, bootstrap
+- [DNS Configuration](https://moav.sh/docs/DNS/): NS delegations for the DNS tunnels, dns-router fan-out, freeing port 53
+- [Supported Protocols](https://moav.sh/docs/protocols/): per-protocol cipher, port, transport, client compatibility
+- [CLI Reference](https://moav.sh/docs/CLI/): every `moav` command, profile filtering, environment variables
+- [Architecture](https://moav.sh/docs/architecture/): container topology, bundle generation flow, monitoring stack
+- [Monitoring](https://moav.sh/docs/MONITORING/): Grafana dashboards, Conduit lifetime bandwidth, GeoIP
+- [Troubleshooting](https://moav.sh/docs/TROUBLESHOOTING/): common failure modes with diagnostic recipes
+- [OPSEC Guide](https://moav.sh/docs/OPSEC/): operator-side hardening and threat-model notes
+
+## Optional
+
+- [Full documentation in one file](https://moav.sh/llms-full.txt): every docs page concatenated
+- [Website / project home](https://moav.sh): landing page and hosted docs

--- a/tests/env-fallback-test.sh
+++ b/tests/env-fallback-test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# CI test for nested env-var fallbacks: ${PRIMARY:-${SECONDARY:-DEFAULT}}.
+#
+# These chains are easy to get subtly wrong — XHTTP_REALITY_TARGET shipped as
+# ${XHTTP_REALITY_TARGET:-dl.google.com:443}, silently ignoring REALITY_TARGET
+# despite a comment claiming it followed it. This pins, for every such chain:
+#   primary set            -> primary
+#   primary empty/unset    -> secondary (if set)
+#   both empty/unset       -> hardcoded default
+# plus a coverage guard so a NEW nested fallback added without a test fails CI,
+# and a site-check that the XHTTP->REALITY chain stays wired at all its callers.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "env nested-fallback resolution tests"
+
+# resolve <primary_name> <secondary_name> <default> — evaluate the real
+# ${primary:-${secondary:-default}} chain with whatever env is currently set.
+resolve() {
+    local p="$1" s="$2" d="$3"
+    eval "printf '%s' \"\${$p:-\${$s:-$d}}\""
+}
+
+# assert_chain <primary> <secondary> <default>
+assert_chain() {
+    local p="$1" s="$2" d="$3" got
+    # 1. primary set -> primary wins (even if secondary also set)
+    got=$(env -i bash -c "$p='PRIMARY' $s='SECONDARY'; $(declare -f resolve); resolve $p $s '$d'")
+    [[ "$got" == "PRIMARY" ]] && ok "$p set -> primary ($got)" || bad "$p set -> got '$got', want PRIMARY"
+    # 2. primary empty, secondary set -> secondary
+    got=$(env -i bash -c "$p='' $s='SECONDARY'; $(declare -f resolve); resolve $p $s '$d'")
+    [[ "$got" == "SECONDARY" ]] && ok "$p empty, $s set -> secondary ($got)" || bad "$p empty -> got '$got', want SECONDARY"
+    # 3. both unset -> default
+    got=$(env -i bash -c "$(declare -f resolve); resolve $p $s '$d'")
+    [[ "$got" == "$d" ]] && ok "$p & $s unset -> default ($got)" || bad "both unset -> got '$got', want '$d'"
+}
+
+# --- the known nested fallbacks (keep in sync with the coverage guard below) --
+assert_chain XHTTP_REALITY_TARGET      REALITY_TARGET   "dl.google.com:443"
+assert_chain CDN_ADDRESS               CDN_DOMAIN       ""
+assert_chain CDN_SNI                   DOMAIN           ""
+assert_chain CONDUIT_MAX_COMMON_CLIENTS CONDUIT_MAX_CLIENTS "100"
+
+# --- regression: the XHTTP->REALITY chain must stay wired at every site --------
+for f in scripts/bootstrap.sh scripts/lib/xray.sh docker-compose.yml; do
+    if grep -qF 'XHTTP_REALITY_TARGET:-${REALITY_TARGET' "$ROOT/$f"; then
+        ok "$f: XHTTP_REALITY_TARGET falls back to REALITY_TARGET"
+    else
+        bad "$f: XHTTP_REALITY_TARGET no longer falls back to REALITY_TARGET (the fixed bug)"
+    fi
+done
+
+# --- coverage guard: every nested ${A:-${B:-...}} in the source must be a known
+# --- chain above, so a new one can't ship untested. -------------------------
+# bash 3.2 compatible (no mapfile): read via a while loop.
+known='XHTTP_REALITY_TARGET|CDN_ADDRESS|CDN_SNI|CONDUIT_MAX_COMMON_CLIENTS'
+uncovered=""
+while IFS= read -r v; do
+    [[ -n "$v" ]] || continue
+    [[ "$v" =~ ^($known)$ ]] || uncovered+=" $v"
+done < <(grep -rhoE '\$\{[A-Z_]+:-\$\{[A-Z_]+:-' "$ROOT/scripts" "$ROOT/lib" "$ROOT/docker-compose.yml" 2>/dev/null \
+    | sed -E 's/\$\{([A-Z_]+):-.*/\1/' | sort -u)
+[[ -z "$uncovered" ]] && ok "all nested fallbacks in the source are covered by a test" \
+                      || bad "untested nested fallback(s):$uncovered — add an assert_chain above"
+
+echo ""
+echo "  $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Two things from your review.

## CI test for env-var fallback resolution
`tests/env-fallback-test.sh` (in CI): for every `${PRIMARY:-${SECONDARY:-DEFAULT}}` chain in the codebase, asserts it resolves correctly for **primary set** → primary, **primary empty + secondary set** → secondary, **both unset** → default. Covers the four that exist today (XHTTP_REALITY_TARGET→REALITY_TARGET, CDN_ADDRESS→CDN_DOMAIN, CDN_SNI→DOMAIN, CONDUIT_MAX_COMMON_CLIENTS→CONDUIT_MAX_CLIENTS), pins the XHTTP→REALITY chain at all three call sites (the exact bug just fixed), and a **coverage guard** greps the source for any `${A:-${B:-` and fails if it isn't covered — so a new nested fallback can't ship untested. Runs under bash 3.2 (no mapfile). 16 checks.

Checked first: `env-resolution-test.sh` covers `get_env_val` scrapers, `env-example-test.sh` covers file structure — neither tested shell-param nested fallbacks, so this fills a real gap.

## Agent entry points
- **Root `llms.txt`** — llmstxt.org format, adapted from moav-site's: project summary + a curated index (AGENTS.md, devdocs, the moav.sh docs).
- **`AGENTS.md`** — the deep agent guide for the server repo: layout, build/run, testing, and the conventions that bite (strict mode, get_env_val, bash 3.2, host-vs-container paths, uid 2000, secrets-in-state, merge flow).
- The server repo had no CLAUDE.md/AGENTS.md, so no duplication. `.claude/skills/` stay as operational tools.

The post-v2 docs refresh (moav-site + llms.txt sweep, stale-troubleshooting cleanup) and the "llms.txt as a release resource the site mirrors, like install.sh" idea are carded as a separate epic.