### PR TITLE
fix(cli): warmer goodbye CTA (merge contribute links + AI-agent invite)

### DIFF
--- a/moav.sh
+++ b/moav.sh
@@ -72,8 +72,11 @@ LATEST_VERSION=""
 goodbye() {
     echo ""
     echo -e "${CYAN}Goodbye! Stay safe out there.${NC}"
-    echo -e "${DIM}Questions: https://t.me/motherofallvpns${NC}"
-    echo -e "${DIM}Issues/bugs: https://github.com/MotherofallVPNs/MoaV/issues${NC}"
+    echo ""
+    echo -e "${DIM}Come build MoaV with us:${NC}"
+    echo -e "${DIM}  Questions or ideas:  https://t.me/motherofallvpns${NC}"
+    echo -e "${DIM}  Bugs, features, PRs: https://github.com/MotherofallVPNs/MoaV${NC}"
+    echo -e "${DIM}  Run it with your AI: add moav.sh/llms.txt to your agent${NC}"
     echo ""
     exit 0
 }


### PR DESCRIPTION
The `moav` exit banner, per your ask — more inviting, merges the issue/bug/feature links, and invites AI-assisted use:

```
Goodbye! Stay safe out there.

Come build MoaV with us:
  Questions or ideas:  https://t.me/motherofallvpns
  Bugs, features, PRs: https://github.com/MotherofallVPNs/MoaV
  Run it with your AI: add moav.sh/llms.txt to your agent
```

The operator-facing 'run MoaV with an AI agent, safely' guide (SSH-key setup, security do-NOTs, what the agent can help with) is carded separately — that's the substantial piece and belongs in the moav.sh/llms.txt + a docs page.