### PR TITLE
security: harden reality render-guard anchor + CDN_WS_PATH (from pre-v2 security pass)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,18 +29,29 @@ are bash.
 | `docs/devdocs/` | Contributor docs: E2E-TESTING, PROTOCOL-INTEGRATION-CHECKLIST, VERSION-BUMP-CHECKLIST |
 | `.claude/skills/` | Operational Claude Code skills (e.g. running e2e) — tools, not this guide |
 
-## Build & run (local, no full install)
+## Install & run
+
+**Normal deployment** — how an operator (or an agent setting up a server) does it.
+Installs the global `moav` command, then an interactive setup + bootstrap:
 
 ```bash
-cp .env.example .env      # set DOMAIN, ACME_EMAIL, ADMIN_PASSWORD (top block)
-./moav.sh build           # build images (caps BuildKit cache when done)
-./moav.sh bootstrap       # generate keys/certs/configs + first user (idempotent)
-./moav.sh start all       # bring up the selected profiles
-./moav.sh doctor          # diagnostics
-./moav.sh user add alice  # provision a user bundle -> outputs/bundles/alice/
+curl -fsSL https://moav.sh/install.sh | bash    # or: git clone … && ./moav.sh install
+moav                                             # guided config + bootstrap + start
 ```
 
-`moav update -b dev && moav build && moav start` is the in-place upgrade path.
+Everyday operation is then `moav <cmd>`: `moav status`, `moav user add alice`,
+`moav doctor`, `moav update`. Full command reference: [moav.sh/docs/CLI](https://moav.sh/docs/CLI/).
+
+**Working on the code** (no global install) — run the dispatcher directly:
+
+```bash
+cp .env.example .env      # DOMAIN, ACME_EMAIL, ADMIN_PASSWORD (top block)
+./moav.sh build && ./moav.sh bootstrap && ./moav.sh start all
+./moav.sh doctor
+```
+
+**Upgrade in place:** `moav update -b main && moav build && moav start`
+(see [docs/V2-MIGRATION.md](docs/V2-MIGRATION.md) for the 1.9.x → v2 path).
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Hardening from the pre-v2.0.0 security review** (independent adversarial pass over the perms/secret rework since rc.2): the Reality short_id render-guard now anchors to the `short_id`/`shortIds` JSON field instead of a bare substring (an 8-hex id coincidentally appearing inside a UUID could have given a false PASS); the CDN WebSocket path is generated with a 48-bit `openssl` token instead of predictable bash `$RANDOM` (it is an active-probing barrier for a censorship tool); and its value is no longer echoed to the bootstrap log (which lands in transcripts). The review found no critical/high issues — the rc.2→now perms/secret changes are net security-positive.
+
+
 ### Removed
 - **The obsolete `scripts/wg-sync-keys.sh` workaround (E4-3).** It manually re-synced WireGuard server keys between the running container and the config files "if you have key mismatch issues after container restarts". It had zero callers, and the mismatch it patched no longer occurs: `wg-user-add.sh` reads the running container's public key and syncs `server.pub` inline on every peer add. The other half of the E4-3 card — retiring the fragile `_fix_perms` chmod dance — was already done in the world-writable-bundles fix, which replaced `chmod 777` with deterministic uid-2000 ownership; `_fix_perms` now sets owner=caller / group=admin / 2770 and is the correct handling, not a workaround, so it stays.
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -57,7 +57,10 @@ assert_reality_in_render() {
     local sid pk
     sid=$(source "$STATE_DIR/keys/reality.env"; printf '%s' "${REALITY_SHORT_ID:-}")
     pk=$(source "$STATE_DIR/keys/reality.env"; printf '%s' "${REALITY_PRIVATE_KEY:-}")
-    if [[ -n "$sid" ]] && ! grep -qF -- "$sid" "$cfg"; then
+    # Anchor to the short_id/shortIds JSON field, not a bare substring: an
+    # 8-hex short_id could otherwise coincidentally appear inside another hex
+    # field (a UUID, a key) and give a false PASS while the real field is blank.
+    if [[ -n "$sid" ]] && ! grep -qE "\"(short_id|shortIds)\"[[:space:]]*:[[:space:]]*\[[^]]*\"$sid\"" "$cfg"; then
         log_error "FATAL: Reality short_id from state is absent in $cfg."
         log_error "  The render read an empty value instead of state — every Reality client"
         log_error "  would be rejected (PR #152 class). Not writing a silently-broken config."
@@ -387,9 +390,15 @@ if [[ -z "${CDN_WS_PATH:-}" || "${CDN_WS_PATH}" == "/ws" ]]; then
     _rand_mid=${_cdn_mids[$((RANDOM % ${#_cdn_mids[@]}))]}
     _rand_file=${_cdn_files[$((RANDOM % ${#_cdn_files[@]}))]}
     _rand_ext=${_cdn_exts[$((RANDOM % ${#_cdn_exts[@]}))]}
-    _rand_num=$((RANDOM % 90 + 10))
+    # Crypto-random unique segment (48 bits) via openssl, NOT bash $RANDOM — the
+    # path is an active-probing barrier for a censorship tool, and $RANDOM is a
+    # predictable 15-bit LCG. The wordlist prefixes stay for realistic
+    # camouflage; the unguessable part is the hex token.
+    _rand_num=$(openssl rand -hex 6 2>/dev/null || printf '%04x%04x%04x' $((RANDOM)) $((RANDOM)) $((RANDOM)))
     CDN_WS_PATH="/${_rand_prefix}/${_rand_mid}/${_rand_file}-${_rand_num}.${_rand_ext}"
-    log_info "Generated CDN WS path: $CDN_WS_PATH"
+    # Do not log the value — it ships in bundles but bootstrap output lands in
+    # docker logs / install transcripts that get pasted around.
+    log_info "Generated CDN WS path"
 
     # Persist for subsequent bootstraps
     mkdir -p "$STATE_DIR/keys"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -57,10 +57,21 @@ assert_reality_in_render() {
     local sid pk
     sid=$(source "$STATE_DIR/keys/reality.env"; printf '%s' "${REALITY_SHORT_ID:-}")
     pk=$(source "$STATE_DIR/keys/reality.env"; printf '%s' "${REALITY_PRIVATE_KEY:-}")
-    # Anchor to the short_id/shortIds JSON field, not a bare substring: an
-    # 8-hex short_id could otherwise coincidentally appear inside another hex
-    # field (a UUID, a key) and give a false PASS while the real field is blank.
-    if [[ -n "$sid" ]] && ! grep -qE "\"(short_id|shortIds)\"[[:space:]]*:[[:space:]]*\[[^]]*\"$sid\"" "$cfg"; then
+    # Check the short_id is a MEMBER of a reality short_id/shortIds array, not a
+    # bare substring (an 8-hex id inside a UUID/key gives a false PASS). Use jq,
+    # not grep: the rendered config is pretty-printed, so the array spans lines
+    # ("short_id": [\n  "id"\n]) and a line-based regex can't match it. jq is
+    # available in the bootstrap container; the grep is a no-jq fallback that
+    # accepts the tiny false-pass risk over a false abort.
+    local sid_present=""
+    if [[ -n "$sid" ]]; then
+        if command -v jq >/dev/null 2>&1; then
+            jq -e --arg s "$sid" '[.inbounds[]? | (.tls.reality.short_id // .streamSettings.realitySettings.shortIds // empty)[]?] | any(. == $s)' "$cfg" >/dev/null 2>&1 && sid_present=yes
+        else
+            grep -qF -- "$sid" "$cfg" && sid_present=yes
+        fi
+    fi
+    if [[ -n "$sid" && -z "$sid_present" ]]; then
         log_error "FATAL: Reality short_id from state is absent in $cfg."
         log_error "  The render read an empty value instead of state — every Reality client"
         log_error "  would be rejected (PR #152 class). Not writing a silently-broken config."

--- a/tests/reality-desync-test.sh
+++ b/tests/reality-desync-test.sh
@@ -48,7 +48,10 @@ eval "$(awk '/^assert_reality_in_render\(\) \{/,/^\}/' "$ROOT/scripts/bootstrap.
 
 WORK=$(mktemp -d)
 good="$WORK/good.json"; bad_cfg="$WORK/bad.json"
-printf '{"inbounds":[{"tls":{"reality":{"short_id":["deadbeef"],"private_key":"PRIVKEYVALUE123"}}}]}\n' > "$good"
+# Pretty-printed (multi-line) like the REAL rendered config — the array spans
+# lines ("short_id": [\n "deadbeef"\n]). A single-line fixture hid a bug where
+# a line-based grep false-aborted bootstrap on the real (jq-formatted) config.
+printf '{"inbounds":[{"tls":{"reality":{"short_id":["deadbeef"],"private_key":"PRIVKEYVALUE123"}}}]}\n' | jq . > "$good"
 printf '{"inbounds":[{"tls":{"reality":{"short_id":[""],"private_key":""}}}]}\n' > "$bad_cfg"
 
 ( assert_reality_in_render "$good" ) && ok "good config passes the assert" \

--- a/tests/reality-desync-test.sh
+++ b/tests/reality-desync-test.sh
@@ -78,6 +78,21 @@ else
     bad "leading-dash private key wrongly rejected — grep parsed it as an option (missing --)"
 fi
 
+# The short_id check is anchored to the short_id/shortIds JSON field, not a bare
+# substring: a config whose real short_id field is blank but where the 8-hex
+# value coincidentally appears elsewhere (e.g. inside a UUID) must still ABORT.
+cat > "$STATE_DIR/keys/reality.env" <<EOF
+REALITY_SHORT_ID=deadbeef
+REALITY_PRIVATE_KEY=PRIVKEYVALUE123
+EOF
+fp="$WORK/falsepos.json"
+printf '{"inbounds":[{"users":[{"uuid":"deadbeef-1111-2222"}],"tls":{"reality":{"short_id":[""],"private_key":"PRIVKEYVALUE123"}}}]}\n' > "$fp"
+if ( assert_reality_in_render "$fp" ) 2>/dev/null; then
+    bad "short_id in a UUID gave a false PASS — the check is an unanchored substring"
+else
+    ok "short_id present only outside its field is caught (anchored check)"
+fi
+
 # When state short_id is empty (deliberate empty-short_id setup), no false abort.
 echo "REALITY_SHORT_ID=" > "$STATE_DIR/keys/reality.env"
 if ( assert_reality_in_render "$bad_cfg" ) 2>/dev/null; then


### PR DESCRIPTION
The unambiguous, zero-risk fixes from the pre-v2.0.0 adversarial security review (3 independent reviewers over the perms/secret rework since rc.2). The perms-model items are a separate decision (below).

## Fixes
- **Reality render-guard false-pass:** `assert_reality_in_render` matched the short_id with a bare `grep -F` substring. An 8-hex short_id coincidentally appearing inside a UUID/key could satisfy the check while the real `short_id` field was blank — a missed detection of the exact #152 outage the guard exists to catch. Now anchored to the `short_id`/`shortIds` JSON field. Regression case added (sid in a UUID, blank field → still aborts).
- **CDN_WS_PATH randomness:** was bash `$RANDOM` (predictable 15-bit LCG, ~185k combos). It's an active-probing barrier for a censorship tool, so it now uses a 48-bit `openssl rand` token (wordlist prefixes stay for camouflage). Also stopped logging the value (bootstrap output lands in install transcripts).

## Review verdict (context)
No critical/high findings. The rc.2→now changes are net security-positive: admin TLS fail-closed + ip_matches (no XFF trust) confirmed intact, docker-proxy isolation intact, no world-writable secrets remain, the clash-secret env-handoff is an upgrade not a downgrade, secret generation quality good.

The remaining findings (world-read of some configs/keys on a shared volume/host, perms-repair reachability on `moav start <service>`, uid-2000 host collision, grafana-still-root) are LOW severity in MoaV's single-tenant-VPS threat model and are genuine accept-vs-harden judgment calls — I'm bringing those to you as decisions rather than changing the perms model unilaterally right before the tag.