### PR TITLE
test+docs: security-review coverage gaps (G) + uid-2000 host note (F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+- **Filled the security-review test gaps.** The admin IP-whitelist test now covers the reverse family-mismatch direction (IPv6 client vs IPv4 rule, and vice-versa — must deny, never raise); the entrypoint strict-mode test pins the load-bearing `|| true` on the admin's clash-secret read (its absence crash-loops a secret-less install) and asserts the admin drops to the non-root `moav` user. Plus a migration-guide note on the uid-2000 ownership caveat for the (atypical) multi-user host.
+
+
 ### Security
 - **Hardening from the pre-v2.0.0 security review** (independent adversarial pass over the perms/secret rework since rc.2): the Reality short_id render-guard now anchors to the `short_id`/`shortIds` JSON field instead of a bare substring (an 8-hex id coincidentally appearing inside a UUID could have given a false PASS); the CDN WebSocket path is generated with a 48-bit `openssl` token instead of predictable bash `$RANDOM` (it is an active-probing barrier for a censorship tool); and its value is no longer echoed to the bootstrap log (which lands in transcripts). The review found no critical/high issues — the rc.2→now perms/secret changes are net security-positive.
 

--- a/docs/V2-MIGRATION.md
+++ b/docs/V2-MIGRATION.md
@@ -107,6 +107,13 @@ moav build && moav start
 - **Grafana browser-tab title** stays "Grafana" on the default (prebuilt) image;
   the favicon and logo are branded. The tab text only changes on a locally-built
   image (`moav build --local`).
+- **Multi-user hosts (edge case).** v2 owns user bundles and state as uid/gid
+  `2000` with no world access (they hold client private keys). On a dedicated,
+  single-tenant VPS — where only root logs in, the normal MoaV deployment — this
+  is strictly safer than before. If, unusually, you run MoaV on a box that has
+  *other human login accounts*, be aware that an account with uid 2000 or in
+  group 2000 would gain access to those bundles. Don't share a MoaV host with
+  untrusted local users, or ensure uid/gid 2000 is unused by real accounts.
 
 ## Questions
 

--- a/tests/admin-ip-whitelist-test.py
+++ b/tests/admin-ip-whitelist-test.py
@@ -41,7 +41,12 @@ CASES = [
     ("2001:dead::5","2001:db8::/32",  False),
     ("10.1.2.3",    "",               False),  # empty entry -> deny
     ("10.1.2.3",    "not-an-ip/8",    False),  # malformed -> deny (fail closed)
-    ("10.1.2.3",    "::1/128",        False),  # family mismatch -> deny
+    ("10.1.2.3",    "::1/128",        False),  # v4 client vs v6 CIDR -> deny
+    # reverse-direction family mismatch (the gap): a v6 client must not match a
+    # v4 rule and must not raise.
+    ("2001:db8::5", "10.0.0.0/8",     False),  # v6 client vs v4 CIDR -> deny
+    ("2001:db8::5", "1.2.3.4",        False),  # v6 client vs v4 exact -> deny
+    ("10.1.2.3",    "2001:db8::/32",  False),  # v4 client vs v6 CIDR (/32) -> deny
     ("10.1.2.3",    "  10.0.0.0/8  ", True),   # surrounding whitespace tolerated
 ]
 

--- a/tests/entrypoint-strict-test.sh
+++ b/tests/entrypoint-strict-test.sh
@@ -163,6 +163,24 @@ for e in wireguard amneziawg; do
     fi
 done
 
+# --- admin entrypoint: clash-secret read must not crash a secret-less install -
+# The read runs under `set -eu`; grep exits 1 when /state/keys/clash-api.env is
+# absent (a valid state: no sing-box protocols), so the `|| true` is load-bearing
+# — without it the admin container crash-loops on every such install.
+_ae="$ROOT/scripts/admin-entrypoint.sh"
+if grep -qE "CLASH_API_SECRET=\\\$\(grep .*clash-api\.env.* \|\| true\)" "$_ae"; then
+    ok "admin: clash-secret read is guarded with || true (secret-less install safe)"
+else
+    bad "admin: clash-secret read lost its || true — crash-loops when clash-api.env is absent"
+fi
+
+# --- admin must DROP privileges: the app runs as non-root `moav`, not root ----
+if grep -qE '^exec su-exec moav ' "$_ae"; then
+    ok "admin drops to non-root (exec su-exec moav …)"
+else
+    bad "admin no longer drops privileges — the dashboard would run as root"
+fi
+
 echo
 echo "  $pass passed, $fail failed"
 [[ $fail -eq 0 ]]


### PR DESCRIPTION
The safe half of the approved security follow-ups — pure test + doc additions, no behavior change.

**G — test gaps the review flagged:**
- `admin-ip-whitelist-test.py`: reverse family-mismatch (IPv6 client vs IPv4 CIDR/exact, and v4-vs-v6-/32) — must deny and not raise. 16/16.
- `entrypoint-strict-test.sh`: pins the `|| true` on the admin's clash-secret read (without it, a secret-less install crash-loops under `set -eu`) and asserts the admin `exec su-exec moav` (drops to non-root).

**F — uid-2000 doc note:** V2-MIGRATION now explains the bundle-ownership caveat for the atypical multi-user host (harmless on a normal single-tenant VPS).

The perms code changes (C daemon-key ownership, D repair reachability) and A (sing-box non-root) are separate PRs with live verification.