### PR TITLE
fix(wg): reliable keygen fallback via local image (fixes CLI `user add` wg/awg failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         run: bash tests/entrypoint-strict-test.sh
       - name: sing-box state read-only (no key-ownership downgrade)
         run: bash tests/singbox-state-readonly-test.sh
+      - name: wg/awg keygen fallback (local image, not lscr.io)
+        run: bash tests/wg-keygen-fallback-test.sh
       - name: grafana branding non-fatal
         run: bash tests/grafana-branding-test.sh
       - name: env resolution golden-diff

--- a/scripts/lib/keys.sh
+++ b/scripts/lib/keys.sh
@@ -37,14 +37,35 @@ _keys_resolve() {
     # compose re-parses the whole compose file on every call (~2x slower idle,
     # far worse under load), and this runs three times per peer (ps + genkey +
     # pubkey). Container names are deterministic (moav-<service>).
-    local pair svc bin cname
+    local pair svc bin cname img
     for pair in "wireguard wg" "amneziawg awg"; do
         svc=${pair% *}; bin=${pair#* }; cname="moav-$svc"
         if "${t[@]}" docker ps --filter "name=^/${cname}$" --filter status=running -q 2>/dev/null | grep -q .; then
             _keys_bin="$bin"; _keys_prefix=("${t[@]}" docker exec -i "$cname"); _keys_resolved=1; return 0
         fi
     done
-    _keys_bin=wg; _keys_prefix=("${t[@]}" docker run --rm -i lscr.io/linuxserver/wireguard); _keys_resolved=1; return 0
+    # No wg/awg container is RUNNING yet — the common case in the post-`moav
+    # start`/upgrade boot window, and exactly why `moav user add` reported "no
+    # key generator" while the web admin (hitting it seconds later, containers
+    # up) succeeded. Fall back to a one-shot `docker run` on the SAME
+    # locally-built image the container uses — resolved FROM the container so we
+    # don't guess the compose-auto-named image, works whether it is stopped or
+    # still booting, and it is always present after `moav build`. wg genkey and
+    # awg genkey are format-compatible, so either image's binary serves both.
+    # (The old fallback ran lscr.io/linuxserver/wireguard: normally not pulled —
+    # so it failed offline — and it ships wg but not awg, so AmneziaWG always
+    # died here regardless.)
+    for pair in "wireguard wg" "amneziawg awg"; do
+        svc=${pair% *}; bin=${pair#* }; cname="moav-$svc"
+        img=$("${t[@]}" docker inspect -f '{{.Config.Image}}' "$cname" 2>/dev/null)
+        if [[ -n "$img" ]]; then
+            _keys_bin="$bin"; _keys_prefix=("${t[@]}" docker run --rm -i --entrypoint "" "$img"); _keys_resolved=1; return 0
+        fi
+    done
+    # Nothing resolvable (pre-build, or wg/awg genuinely absent): leave a
+    # host-`wg` resolution that will emit nothing, so wg_keypair returns empty
+    # and the caller reports "no key generator" cleanly rather than hanging.
+    _keys_bin=wg; _keys_prefix=(); _keys_resolved=1; return 0
 }
 
 # wg_privkey — emit one CRLF-clean private key.

--- a/tests/wg-keygen-fallback-test.sh
+++ b/tests/wg-keygen-fallback-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Regression test: wg/awg key generation must survive the wg/awg container not
+# being reachable via `docker exec`.
+#
+# `moav user add` generates client keys through scripts/lib/keys.sh. When the
+# wireguard/amneziawg container is running it `docker exec`s into it; otherwise
+# it falls back. The old fallback ran `docker run lscr.io/linuxserver/wireguard`,
+# which (a) is normally NOT pulled on the server, so it failed offline, and
+# (b) ships `wg` but NOT `awg`, so AmneziaWG keygen could never work through it.
+# Live symptom: `moav user add` reported "no wg/awg key generator available" for
+# wireguard AND amneziawg (the resolver's live `docker ps` check flaked under the
+# daemon contention from the sing-box restart earlier in the same add), while the
+# web admin — hitting the same code seconds later — succeeded.
+#
+# The fix: fall back to a one-shot `docker run` on the SAME locally-built image
+# the container uses, resolved FROM the container (compose auto-names it) with the
+# entrypoint cleared so the wg/awg binary runs. Always present after `moav build`;
+# wg/awg keys are format-compatible. Functional coverage is in the e2e (real
+# containers); this pins the shape that made the fix correct.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KEYS="$ROOT/scripts/lib/keys.sh"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "wg/awg keygen fallback tests"
+
+[[ -f "$KEYS" ]] || { echo "  cannot find keys.sh"; exit 1; }
+
+# 1. The fallback resolves the image FROM the container, not a hardcoded name —
+#    compose auto-names the images, so a literal name would break per-install.
+grep -qE "docker inspect -f '\{\{\.Config\.Image\}\}'" "$KEYS" \
+    && ok "fallback resolves the image from the container (inspect .Config.Image)" \
+    || bad "fallback does not resolve the image from the container — a hardcoded image name will drift"
+
+# 2. The fallback docker run clears the entrypoint so 'wg genkey' / 'awg genkey'
+#    runs (the images' entrypoint is the service launcher, not the binary).
+grep -qE 'docker run .*--entrypoint ""' "$KEYS" \
+    && ok "fallback docker run clears the entrypoint so the wg/awg binary runs" \
+    || bad "fallback docker run does not clear the entrypoint — it would exec the service launcher, not keygen"
+
+# 3. lscr.io/linuxserver/wireguard must NOT be a keygen generator: it is usually
+#    absent (fails offline) and has no awg. It may only appear in a comment.
+if grep -nE 'lscr\.io/linuxserver/wireguard' "$KEYS" | grep -vqE '^\s*[0-9]+:\s*#'; then
+    bad "keys.sh still uses lscr.io/linuxserver/wireguard as a generator (no awg, usually not pulled)"
+    grep -nE 'lscr\.io/linuxserver/wireguard' "$KEYS" | sed 's/^/          /'
+else
+    ok "lscr.io/linuxserver/wireguard is not used as a keygen generator"
+fi
+
+# 4. The running-container fast path (docker exec) is still preferred first.
+grep -qE 'docker exec -i "\$cname"' "$KEYS" \
+    && ok "running container still preferred via docker exec (fast path intact)" \
+    || bad "the docker exec fast path is gone — every keygen would pay docker-run startup"
+
+echo
+echo "  $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## The bug (critical, reproduced live on rc.2)

`moav user add <name>` intermittently failed both WireGuard **and** AmneziaWG with **"no wg/awg key generator available"**, while creating the same user through the **web admin** worked. Reported live on the throwaway server.

## Root cause

Key generation (`scripts/lib/keys.sh`) `docker exec`s into the wireguard/amneziawg container when it's running, else falls back to `docker run lscr.io/linuxserver/wireguard`. That fallback is **doubly broken**:
1. the image is normally **not pulled** on the server → fails offline;
2. it ships `wg` but **not `awg`** → AmneziaWG keygen could *never* succeed through it.

The resolver reaches that fallback whenever its live `docker ps` check finds no running container — which flakes under the **docker-daemon contention from the sing-box restart** that happens earlier in the same `user add`. The web admin hit the same code seconds later (containers settled) and used the fast `docker exec` path, so it worked.

## Fix

Fall back to a one-shot `docker run` on the **same locally-built image the container uses** — resolved *from the container* (compose auto-names the image) with the entrypoint cleared so the `wg`/`awg` binary runs. Always present after `moav build`; wg/awg keys are format-compatible, so either binary serves both. The fast `docker exec` path for a running container is unchanged.

## Verified live (rc.2, throwaway)

- With **both containers stopped**, `moav user add` now generates a valid **AmneziaWG** peer — the case that never worked.
- Both fallback commands emit valid 44-char keys (`wg genkey`/`pubkey` via `moav-wireguard`, `awg` via `moav-amneziawg`).
- Normal path (containers up) still uses `docker exec`.

Regression test `tests/wg-keygen-fallback-test.sh` pins the shape (local-image inspect, cleared entrypoint, no lscr.io generator) and is proven to fail if the lscr.io fallback returns.