### PR TITLE
fix(ux): monitoring default >1GB, doctor RAM advisory, clearer network prompt, donate framing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -931,7 +931,13 @@ services:
       # works regardless. The tab-title patch still needs a writable image
       # (moav build --local); on the prebuilt image the tab text stays "Grafana".
       - ./branding/grafana/fav32.png:/usr/share/grafana/public/img/fav32.png:ro
+      # Grafana renders [[.FavIcon]] as public/BUILD/img/fav32.png, not img/ —
+      # so the img/ mount alone left the browser tab on the default icon. The
+      # entrypoint's copy into build/img/ fails (dir is read-only for uid 472),
+      # so bind-mount the branded icon straight over the served path.
+      - ./branding/grafana/fav32.png:/usr/share/grafana/public/build/img/fav32.png:ro
       - ./branding/grafana/apple-touch-icon.png:/usr/share/grafana/public/img/apple-touch-icon.png:ro
+      - ./branding/grafana/apple-touch-icon.png:/usr/share/grafana/public/build/img/apple-touch-icon.png:ro
       - ./branding/grafana/grafana_icon.svg:/usr/share/grafana/public/img/grafana_icon.svg:ro
       - ./scripts/grafana-entrypoint.sh:/scripts/grafana-entrypoint.sh:ro
       - moav_grafana:/var/lib/grafana

--- a/install.sh
+++ b/install.sh
@@ -534,11 +534,14 @@ maybe_offer_net_tuning() {
     current_cc=$(cat /proc/sys/net/ipv4/tcp_congestion_control 2>/dev/null || echo "?")
 
     echo ""
-    echo -e "${CYAN}Enable Linux network tuning (BBR + larger buffers)?${NC}"
+    echo -e "${CYAN}Enable Linux network tuning (BBR congestion control + larger socket buffers)?${NC}"
     echo "  Current: tcp_congestion_control=${current_cc}"
-    echo "  Real-world testing: 2–5× TCP throughput on long-RTT or lossy paths."
-    echo "  Helps UDP/QUIC too (Hysteria2, WireGuard need bigger UDP buffers)."
-    echo "  Reversible: ${WHITE}moav net revert${NC} removes the file + reloads sysctl."
+    echo "  Circumvention traffic takes long, often lossy paths out of censored"
+    echo "  networks. BBR holds throughput where the default (cubic) collapses on"
+    echo "  packet loss — 2–5x TCP throughput on high-RTT/lossy links in testing."
+    echo "  Larger UDP buffers stop the QUIC/UDP protocols (Hysteria2, WireGuard)"
+    echo "  dropping packets under load. Applied via sysctl; reversible any time."
+    echo "  Revert with: moav net revert"
     echo ""
     if ! confirm "Apply network tuning?" "y"; then
         info "Skipping network tuning. You can apply later: moav net apply"

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -126,10 +126,13 @@ doctor_check_memory() {
         echo -e "    ${RED}✗${NC} Less than 1 GB RAM — MoaV may be unstable"
         echo -e "      ${DIM}Upgrade to at least 1 GB (2 GB with monitoring)${NC}"
         return 1
-    elif [[ "$total_mb" -lt 2048 ]] && [[ "$monitoring_enabled" == "true" ]]; then
-        echo -e "    ${YELLOW}○${NC} Less than 2 GB with monitoring enabled — may cause hangs"
-        echo -e "      ${DIM}Upgrade to 2 GB+ or disable monitoring: ENABLE_MONITORING=false${NC}"
-        return 1
+    elif [[ "$total_mb" -lt 1536 ]] && [[ "$monitoring_enabled" == "true" ]]; then
+        # Advisory, not a failure: monitoring runs fine down to ~1.5 GB for light
+        # use. Only flag genuinely tight hosts, and as a warning (rc 2) — a small
+        # box with monitoring on is a tuning note, not a broken install.
+        echo -e "    ${YELLOW}○${NC} Under 1.5 GB with monitoring enabled — may be tight under load"
+        echo -e "      ${DIM}Fine for light use; add swap for headroom, or ENABLE_MONITORING=false${NC}"
+        return 2
     elif [[ "$available_mb" -lt 256 ]]; then
         echo -e "    ${RED}✗${NC} Very low available memory (${available_mb} MB)"
         echo -e "      ${DIM}Check for memory leaks: docker stats --no-stream${NC}"

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -372,7 +372,7 @@ select_profiles() {
     echo -e "  ${CYAN}│${NC}  ${BLUE}9${NC}   conduit      Donate bandwidth via Psiphon                  ${CYAN}│${NC}"
     echo -e "  ${CYAN}│${NC}  ${BLUE}10${NC}  snowflake    Donate bandwidth via Tor                      ${CYAN}│${NC}"
     echo -e "  ${CYAN}├─────────────────────────────────────────────────────────────────┤${NC}"
-    echo -e "  ${CYAN}│${NC}  ${BLUE}11${NC}  monitoring   Grafana + Prometheus (requires 2GB RAM)       ${CYAN}│${NC}"
+    echo -e "  ${CYAN}│${NC}  ${BLUE}11${NC}  monitoring   Grafana + Prometheus (2 GB+ RAM)            ${CYAN}│${NC}"
     echo -e "  ${CYAN}├─────────────────────────────────────────────────────────────────┤${NC}"
     echo -e "  ${CYAN}│${NC}  ${GREEN}a${NC}   ${GREEN}ALL${NC}          All services ${GREEN}(Recommended)${NC}                    ${CYAN}│${NC}"
     echo -e "  ${CYAN}│${NC}  ${DIM}0${NC}   ${DIM}Back${NC}         Back to main menu                             ${CYAN}│${NC}"
@@ -469,7 +469,7 @@ select_profiles() {
         elif [[ "$enable_monitoring" != "false" ]]; then
             # Not explicitly set - ask user
             echo ""
-            warn "Monitoring stack (Grafana + Prometheus) requires at least 2GB RAM."
+            warn "Monitoring (Grafana + Prometheus) runs best with 2 GB+ RAM."
             if confirm "Enable monitoring?" "$(monitoring_default_for_ram)"; then
                 update_env_var "$env_file" "ENABLE_MONITORING" "true"
                 SELECTED_PROFILES+=("monitoring")
@@ -861,10 +861,10 @@ ensure_clash_api_secret() {
     if [[ -z "$current_secret" ]] && [[ "$enable_monitoring" != "false" ]]; then
         if echo "$profiles" | grep -qE "\ball\b|--profile all"; then
             echo ""
-            warn "Monitoring requires at least 2GB RAM to run properly."
+            warn "Monitoring (Grafana + Prometheus) runs best with 2 GB+ RAM."
             echo "  The monitoring stack includes Grafana, Prometheus, and exporters."
             echo ""
-            if ! confirm "Enable monitoring? (You can start it later with 'moav start monitoring')" "n"; then
+            if ! confirm "Enable monitoring? (You can start it later with 'moav start monitoring')" "$(monitoring_default_for_ram)"; then
                 info "Skipping monitoring. Starting other services..."
                 return 1  # Signal caller to skip monitoring
             fi
@@ -1374,7 +1374,7 @@ cmd_start() {
     fi
     # Show Conduit sharing hint if conduit was started
     if echo "$profiles" | grep -qE "conduit|all"; then
-        echo -e "  ${CYAN}Psiphon Conduit:${NC} claim link, QR & sharing guide: moav conduit link"
+        echo -e "  ${CYAN}Donate bandwidth:${NC} share protocols & configs to help others bypass censorship: moav donate"
     fi
 
     if echo "$profiles" | grep -qE "admin|monitoring|proxy|all"; then

--- a/moav.sh
+++ b/moav.sh
@@ -355,9 +355,13 @@ validate_reality_targets() {
 
 # Monitoring opt-in default: N below 2 GB (hang risk), Y otherwise.
 monitoring_default_for_ram() {
+    # Default monitoring ON above ~1 GB. Grafana+Prometheus are happiest with
+    # 2 GB, but they run fine on a 1.5-2 GB box for light use, so only a genuinely
+    # tiny host (≤1 GB) defaults to off. (awk reads MemTotal, so a "2 GB" VPS
+    # reports ~1990 MB — a 2048 cutoff wrongly defaulted those to off.)
     local total_mb
     total_mb=$(awk '/MemTotal/ {printf "%.0f", $2/1024}' /proc/meminfo 2>/dev/null || echo 0)
-    if [[ "$total_mb" -gt 0 && "$total_mb" -lt 2048 ]]; then
+    if [[ "$total_mb" -gt 0 && "$total_mb" -le 1024 ]]; then
         echo "n"
     else
         echo "y"

--- a/tests/grafana-branding-test.sh
+++ b/tests/grafana-branding-test.sh
@@ -42,6 +42,17 @@ else
     bad "guard still aborts under set -e"
 fi
 
+# The browser-tab favicon is served from public/BUILD/img/fav32.png (Grafana
+# renders [[.FavIcon]] to that path). The entrypoint can't write there (read-only
+# for uid 472), so compose must bind-mount the branded icon straight over it —
+# the img/ mount alone leaves the tab on the default icon (verified live).
+compose="$ROOT/docker-compose.yml"
+if grep -qE 'branding/grafana/fav32\.png:/usr/share/grafana/public/build/img/fav32\.png' "$compose"; then
+    ok "branded favicon is bind-mounted over the SERVED path (build/img/fav32.png)"
+else
+    bad "no build/img/fav32.png mount — the served favicon stays the grafana default"
+fi
+
 echo ""
 echo "  $pass passed, $fail failed"
 [[ $fail -eq 0 ]]


### PR DESCRIPTION
Batch of install/CLI UX fixes from a live install review.

- **Monitoring default** — `monitoring_default_for_ram` now defaults **ON above ~1 GB** (was 2 GB). A "2 GB" VPS reports ~1990 MB `MemTotal`, so the old 2048 cutoff wrongly defaulted those boxes to monitoring **off**. Softened the two prompts + menu label from "requires 2GB" to "runs best with 2 GB+".
- **`moav doctor` memory check** — a sub-2 GB host with monitoring was a hard **FAIL** (counted against a healthy install). Now it's **advisory** (warning, rc 2) and only under **1.5 GB**; a 1.9 GB box reports **Memory OK**.
- **`install.sh` network-tuning prompt** — rewritten to explain *why* it matters for circumvention traffic (BBR on long/lossy paths; UDP buffers for QUIC/WireGuard), and removed the ANSI-escaped `moav net revert` line that rendered as a literal `\033[...m` escape.
- **Post-start summary** — reframed the Psiphon Conduit line as a bandwidth-donation CTA pointing at `moav donate`.

**Verified live** (rc.2, 1968 MB box): `moav doctor` now reports "Memory OK"; monitoring default resolves to `y`.