### PR TITLE
fix(user-add): two-line UUID corruption (bootstrap/xray/regenerate) + wg keygen under contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         run: bash tests/singbox-state-readonly-test.sh
       - name: wg/awg keygen fallback (local image, not lscr.io)
         run: bash tests/wg-keygen-fallback-test.sh
+      - name: user UUID capture (no two-line double-capture)
+        run: bash tests/uuid-capture-test.sh
       - name: grafana branding non-fatal
         run: bash tests/grafana-branding-test.sh
       - name: env resolution golden-diff

--- a/scripts/lib/keys.sh
+++ b/scripts/lib/keys.sh
@@ -80,12 +80,39 @@ wg_pubkey() {
     printf '%s' "${1:-}" | "${_keys_prefix[@]}" "$_keys_bin" pubkey 2>/dev/null | tr -d '\r\n'
 }
 
+# Force the docker-run-on-local-image generator, bypassing the running-container
+# `docker exec` path. Used as a retry when exec yields nothing — a container that
+# IS running but whose exec was killed under docker-daemon contention (e.g. the
+# sing-box restart mid `user add`) otherwise leaves no key and no fallback.
+_keys_force_run() {
+    local t=() pair svc bin cname img
+    command -v timeout >/dev/null 2>&1 && t=(timeout -k 5 60)
+    for pair in "wireguard wg" "amneziawg awg"; do
+        svc=${pair% *}; bin=${pair#* }; cname="moav-$svc"
+        img=$("${t[@]}" docker inspect -f '{{.Config.Image}}' "$cname" 2>/dev/null)
+        if [[ -n "$img" ]]; then
+            _keys_bin="$bin"; _keys_prefix=("${t[@]}" docker run --rm -i --entrypoint "" "$img"); _keys_resolved=1; return 0
+        fi
+    done
+    return 1
+}
+
 # wg_keypair — emit "<private>\n<public>" (both CRLF-clean). Returns 1 if no
 # generator produced a key. Callers: { read -r PRIV; read -r PUB; } < <(wg_keypair)
 wg_keypair() {
     local priv pub
     priv=$(wg_privkey)
     pub=$(wg_pubkey "$priv")
+    if [[ -z "$priv" || -z "$pub" ]]; then
+        # The resolved generator produced nothing. If it was a `docker exec` into
+        # a running-but-contended container that got killed, retry once on the
+        # local image via `docker run` (independent of container liveness/exec).
+        _keys_resolved=""
+        if _keys_force_run; then
+            priv=$(wg_privkey)
+            pub=$(wg_pubkey "$priv")
+        fi
+    fi
     [[ -n "$priv" && -n "$pub" ]] || return 1
     printf '%s\n%s\n' "$priv" "$pub"
 }

--- a/scripts/singbox-user-add.sh
+++ b/scripts/singbox-user-add.sh
@@ -86,8 +86,20 @@ fi
 
 log_info "Adding user '$USERNAME' to sing-box..."
 
-# Generate credentials
-USER_UUID=$(compose_timeout exec -T sing-box sing-box generate uuid 2>/dev/null || uuidgen | tr '[:upper:]' '[:lower:]')
+# Generate credentials.
+# Robust against a slow `docker compose exec` that emits a UUID *and then* gets
+# killed by the timeout wrapper (returns non-zero): the old `... || uuidgen`
+# fallback then ran too and appended a SECOND UUID, so USER_UUID became two
+# lines. That poisons everything downstream — credentials.env sources the bare
+# second UUID as a command ("command not found", failing bootstrap/regenerate),
+# and xray/sing-box reject the two-line UUID and crash-loop. Take the FIRST
+# UUID-shaped token from the output, then validate; only fall back to uuidgen if
+# nothing valid came out.
+USER_UUID=$(compose_timeout exec -T sing-box sing-box generate uuid 2>/dev/null \
+    | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
+if [[ ! "$USER_UUID" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+    USER_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+fi
 USER_PASSWORD=$(openssl rand -base64 18 | tr -d '/+=' | head -c 24)
 
 # Save credentials

--- a/tests/uuid-capture-test.sh
+++ b/tests/uuid-capture-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Regression test: user UUID capture must never yield two UUIDs.
+#
+# `moav user add` generated the UUID as:
+#   USER_UUID=$(compose_timeout exec -T sing-box sing-box generate uuid \
+#              2>/dev/null || uuidgen | tr ...)
+# When the box was contended the `docker compose exec` emitted a UUID and THEN
+# the timeout wrapper killed it (non-zero), so the `|| uuidgen` fallback ran too
+# and appended a SECOND UUID. USER_UUID became two lines, which:
+#   - corrupts credentials.env — the bare second UUID is sourced as a command
+#     ("<uuid>: command not found"), failing bootstrap and regenerate-users;
+#   - crash-loops xray/sing-box — the two-line UUID is rejected ("invalid UUID").
+# The fix takes the FIRST uuid-shaped token and validates it, falling back to
+# uuidgen only when nothing valid was produced.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+f="$ROOT/scripts/singbox-user-add.sh"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "user UUID capture tests"
+
+UUID_RE='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+# --- static: the fragile 'exec ... || uuidgen' one-liner must be gone ---------
+if grep -qE 'generate uuid[^|]*\|\| *uuidgen' "$f"; then
+    bad "still has 'exec generate uuid || uuidgen' — a timed-out exec + fallback double-captures"
+else
+    ok "no 'exec generate uuid || uuidgen' double-capture one-liner"
+fi
+# and the capture must validate the UUID shape before trusting it
+if grep -qE '\[\[ ! "\$USER_UUID" =~' "$f" || grep -qE 'USER_UUID.*=~.*36' "$f"; then
+    ok "USER_UUID is validated before use"
+else
+    bad "USER_UUID is not validated — a malformed value would propagate to configs"
+fi
+
+# --- functional: the sanitizer collapses any output to one valid UUID ---------
+# Mirror the exact fix pipeline and feed it the failure inputs.
+sanitize() {
+    local raw="$1" u
+    u=$(printf '%s' "$raw" | grep -oiE "$UUID_RE" | head -1)
+    if [[ ! "$u" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+        u=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    fi
+    printf '%s' "$u"
+}
+one_line() { [[ "$(printf '%s' "$1" | wc -l)" -eq 0 ]] && [[ -n "$1" ]]; }
+
+# two UUIDs (the bug) -> exactly one, and it's the first
+two=$'ea901364-3597-4598-8628-161a381b63cf\n7f90d9d8-83a5-4e0d-b963-a1a8d268ea48'
+r=$(sanitize "$two")
+if one_line "$r" && [[ "$r" == "ea901364-3597-4598-8628-161a381b63cf" ]]; then
+    ok "two-line output collapses to the first single UUID"
+else
+    bad "two-line output not collapsed cleanly (got: $r)"
+fi
+
+# empty output -> a freshly generated valid UUID
+r=$(sanitize "")
+if one_line "$r" && [[ "$r" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    ok "empty output falls back to a valid single UUID"
+else
+    bad "empty output did not fall back to a valid UUID (got: $r)"
+fi
+
+# already-clean single UUID -> unchanged
+r=$(sanitize "2b2a0db8-b379-4ae6-a524-c6d37f78119b")
+if [[ "$r" == "2b2a0db8-b379-4ae6-a524-c6d37f78119b" ]]; then
+    ok "a clean single UUID passes through unchanged"
+else
+    bad "a clean single UUID was altered (got: $r)"
+fi
+
+echo
+echo "  $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## The real root cause (found from your bootstrap clue)

`moav user add` generated the user UUID as:

```sh
USER_UUID=$(compose_timeout exec -T sing-box sing-box generate uuid 2>/dev/null || uuidgen | tr ...)
```

Under docker-daemon contention (the sing-box restart that runs earlier in the same add), the `docker compose exec` **emits a UUID and then gets killed by the timeout wrapper** (non-zero exit), so the `|| uuidgen` fallback **also** runs and appends a **second** UUID. `USER_UUID` becomes two lines — which explains every symptom:

- **`credentials.env: line 3: <uuid>: command not found`** — the bare second UUID is sourced as a command, so **bootstrap and `regenerate-users` fail** on that user.
- **xray crash loop** (`invalid UUID: <uuid>` then a second `<uuid>`) — the two-line UUID is rejected.

This is a *different* bug from the #267 keygen fallback (that was real too, but a separate failure mode).

## Fixes

1. **UUID capture** (`singbox-user-add.sh`): take the **first** uuid-shaped token from the output and **validate** it; fall back to `uuidgen` only when nothing valid was produced. No path can capture two. (`generate_uuid()` in `common.sh` and bootstrap's direct `sing-box generate uuid` have no timeout wrapper, so they can't emit-then-fail — unaffected.)
2. **wg/awg keygen** (`keys.sh`): the #267 local-image fallback only fired when *no* container was running. If the container **is** running but its `docker exec` is killed under the same contention, `wg_keypair` now **retries once** on the local image via `docker run`.

## Tests

`tests/uuid-capture-test.sh` — static (no `|| uuidgen` one-liner; UUID validated) + functional (two-line → one, empty → fallback, clean → passthrough).

## Note

Existing users with an already-corrupted `credentials.env` still need `moav user revoke && add`. A follow-up to make bootstrap **skip/repair** a malformed `credentials.env` instead of failing the whole run is carded separately.
