### PR TITLE
fix(user-add): generate UUID locally; survive root-0600 .env in the admin container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -834,6 +834,15 @@ services:
       - ./state:/project/state                     # Credential sync (read-write for user-add.sh)
       - moav_state:/state:ro                       # Dashboard reads keys from Docker volume
       - moav_certs:/certs:ro                       # SSL certificates
+    # .env is root:root 0600 (holds ADMIN_PASSWORD), so the non-root admin
+    # process cannot read the mounted copy that provisioning scripts source.
+    # env_file injects the full .env as process environment instead — read
+    # host-side (as root) at `up` time, so the file perms don't matter and the
+    # ENABLE_*/PORT_* toggles keep working in the web-admin user-add path.
+    # Explicit `environment:` entries below still take precedence.
+    env_file:
+      - path: .env
+        required: false
     environment:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - ADMIN_IP_WHITELIST=${ADMIN_IP_WHITELIST:-}

--- a/scripts/singbox-user-add.sh
+++ b/scripts/singbox-user-add.sh
@@ -49,7 +49,10 @@ if [[ ! "$USERNAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
 fi
 
 # Load environment
-if [[ -f .env ]]; then
+# -r too: .env is root 0600; in the admin container (uid 2000) it exists but
+# is unreadable -- source would die with "Permission denied" under set -e. The
+# container gets the full .env via the compose env_file instead.
+if [[ -f .env && -r .env ]]; then
     set -a
     source .env
     set +a
@@ -87,18 +90,17 @@ fi
 log_info "Adding user '$USERNAME' to sing-box..."
 
 # Generate credentials.
-# Robust against a slow `docker compose exec` that emits a UUID *and then* gets
-# killed by the timeout wrapper (returns non-zero): the old `... || uuidgen`
-# fallback then ran too and appended a SECOND UUID, so USER_UUID became two
-# lines. That poisons everything downstream — credentials.env sources the bare
-# second UUID as a command ("command not found", failing bootstrap/regenerate),
-# and xray/sing-box reject the two-line UUID and crash-loop. Take the FIRST
-# UUID-shaped token from the output, then validate; only fall back to uuidgen if
-# nothing valid came out.
-USER_UUID=$(compose_timeout exec -T sing-box sing-box generate uuid 2>/dev/null \
-    | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
-if [[ ! "$USER_UUID" =~ ^[0-9a-fA-F-]{36}$ ]]; then
-    USER_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+# LOCALLY — never via `docker compose exec sing-box generate uuid`. Any RFC-4122
+# v4 UUID is valid for VLESS/VMess; the exec bought nothing and was the root of
+# two real failures: (a) emitting a UUID and THEN getting killed by the timeout
+# wrapper, whose old `|| uuidgen` fallback then appended a SECOND UUID (two-line
+# USER_UUID -> corrupt credentials.env, failed bootstrap/regenerate, xray crash
+# loop); (b) under set -e/pipefail, a restarting sing-box (hot-reload fallback
+# from the PREVIOUS add) made the exec fail and killed this script silently.
+USER_UUID=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)
+if [[ ! "$USER_UUID" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    log_error "Could not generate a UUID (no /proc/sys/kernel/random/uuid or uuidgen)"
+    exit 1
 fi
 USER_PASSWORD=$(openssl rand -base64 18 | tr -d '/+=' | head -c 24)
 

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -145,13 +145,18 @@ for _f in configs/sing-box/config.json configs/xray/config.json \
     fi
 done
 
-# Load environment
-if [[ -f .env ]]; then
+# Load environment.
+# -r, not just -f: .env is root-owned 0600 (it holds ADMIN_PASSWORD), so inside
+# the admin container (uid 2000, /project mounted ro) it exists but is NOT
+# readable — the unguarded sed printed "sed: .env: Permission denied" and, under
+# set -e, could kill the add. In the container the full .env is injected as
+# process environment via the compose env_file instead, so skipping the file
+# read there loses nothing.
+if [[ -f .env && -r .env ]]; then
     # Auto-heal: GOPROXY's value is pipe-separated (proxy|proxy|direct). If the
     # line is unquoted (older .env files), `source` below parses the `|` as a
     # shell pipe and tries to run the URLs as commands. Heal in a tempfile —
-    # works even when .env is on a RO mount (admin container), and we only
-    # persist the heal back to .env when it's writable (CLI on the host).
+    # we only persist the heal back to .env when it's writable (CLI on the host).
     _ENV_TMP=$(mktemp)
     sed -E '/^GOPROXY=[^"]*\|/ s/^GOPROXY=(.*)$/GOPROXY="\1"/' .env > "$_ENV_TMP"
     if [[ -w .env ]] && ! cmp -s "$_ENV_TMP" .env; then

--- a/scripts/user-package.sh
+++ b/scripts/user-package.sh
@@ -50,7 +50,10 @@ if [[ ! -d "$BUNDLE_DIR" ]]; then
 fi
 
 # Load environment for server info
-if [[ -f .env ]]; then
+# -r too: .env is root 0600; in the admin container (uid 2000) it exists but
+# is unreadable -- source would die with "Permission denied" under set -e. The
+# container gets the full .env via the compose env_file instead.
+if [[ -f .env && -r .env ]]; then
     set -a
     source .env
     set +a

--- a/scripts/user-revoke.sh
+++ b/scripts/user-revoke.sh
@@ -59,7 +59,10 @@ for _f in configs/sing-box/config.json configs/xray/config.json \
 done
 
 # Load environment
-if [[ -f .env ]]; then
+# -r too: .env is root 0600; in the admin container (uid 2000) it exists but
+# is unreadable -- source would die with "Permission denied" under set -e. The
+# container gets the full .env via the compose env_file instead.
+if [[ -f .env && -r .env ]]; then
     set -a
     source .env
     set +a

--- a/scripts/wg-user-add.sh
+++ b/scripts/wg-user-add.sh
@@ -47,7 +47,10 @@ if [[ ! "$USERNAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
 fi
 
 # Load environment
-if [[ -f .env ]]; then
+# -r too: .env is root 0600; in the admin container (uid 2000) it exists but
+# is unreadable -- source would die with "Permission denied" under set -e. The
+# container gets the full .env via the compose env_file instead.
+if [[ -f .env && -r .env ]]; then
     set -a
     source .env
     set +a

--- a/tests/uuid-capture-test.sh
+++ b/tests/uuid-capture-test.sh
@@ -1,78 +1,94 @@
 #!/bin/bash
-# Regression test: user UUID capture must never yield two UUIDs.
+# Regression test: user credential generation must be local and single-valued,
+# and the add path must survive an unreadable .env.
 #
-# `moav user add` generated the UUID as:
-#   USER_UUID=$(compose_timeout exec -T sing-box sing-box generate uuid \
-#              2>/dev/null || uuidgen | tr ...)
-# When the box was contended the `docker compose exec` emitted a UUID and THEN
-# the timeout wrapper killed it (non-zero), so the `|| uuidgen` fallback ran too
-# and appended a SECOND UUID. USER_UUID became two lines, which:
-#   - corrupts credentials.env — the bare second UUID is sourced as a command
-#     ("<uuid>: command not found"), failing bootstrap and regenerate-users;
-#   - crash-loops xray/sing-box — the two-line UUID is rejected ("invalid UUID").
-# The fix takes the FIRST uuid-shaped token and validates it, falling back to
-# uuidgen only when nothing valid was produced.
+# Two live failures on `moav user add`, same root: generating the UUID via
+# `docker compose exec sing-box sing-box generate uuid` tied a pure-local
+# operation to docker-daemon health.
+#   1. Contended exec emitted a UUID and THEN got killed by the timeout wrapper;
+#      the `|| uuidgen` fallback ran too and appended a SECOND UUID. Two-line
+#      USER_UUID -> corrupt credentials.env (the bare second UUID is sourced as
+#      a command), failed bootstrap/regenerate-users, xray crash-loop.
+#   2. With the fallback removed, set -e/pipefail turned any exec failure (e.g.
+#      sing-box restarting from the PREVIOUS add's hot-reload fallback) into a
+#      silent instant death: "Failed to add sing-box user" with no detail.
+# Fix: generate the UUID locally (/proc/sys/kernel/random/uuid, uuidgen
+# fallback) — any RFC-4122 v4 UUID is valid for VLESS/VMess; the exec bought
+# nothing. Validate before use.
+#
+# Related: .env is root 0600, so the admin container (uid 2000) cannot read the
+# mounted copy — user-add.sh printed "sed: .env: Permission denied". The read is
+# now gated on -r, and compose injects .env via env_file (read host-side).
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 f="$ROOT/scripts/singbox-user-add.sh"
+ua="$ROOT/scripts/user-add.sh"
+compose="$ROOT/docker-compose.yml"
 pass=0; fail=0
 ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
 bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
 
-echo "user UUID capture tests"
+echo "user credential generation tests"
 
-UUID_RE='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+UUID_RE='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 
-# --- static: the fragile 'exec ... || uuidgen' one-liner must be gone ---------
-if grep -qE 'generate uuid[^|]*\|\| *uuidgen' "$f"; then
-    bad "still has 'exec generate uuid || uuidgen' — a timed-out exec + fallback double-captures"
+# --- UUID generation is local: no docker/compose exec involved ---------------
+if grep -nE 'USER_UUID=.*(compose|docker).*exec' "$f" >/dev/null; then
+    bad "USER_UUID still generated via a container exec — ties user add to docker-daemon health"
 else
-    ok "no 'exec generate uuid || uuidgen' double-capture one-liner"
-fi
-# and the capture must validate the UUID shape before trusting it
-if grep -qE '\[\[ ! "\$USER_UUID" =~' "$f" || grep -qE 'USER_UUID.*=~.*36' "$f"; then
-    ok "USER_UUID is validated before use"
-else
-    bad "USER_UUID is not validated — a malformed value would propagate to configs"
+    ok "USER_UUID is generated locally (no container exec)"
 fi
 
-# --- functional: the sanitizer collapses any output to one valid UUID ---------
-# Mirror the exact fix pipeline and feed it the failure inputs.
-sanitize() {
-    local raw="$1" u
-    u=$(printf '%s' "$raw" | grep -oiE "$UUID_RE" | head -1)
-    if [[ ! "$u" =~ ^[0-9a-fA-F-]{36}$ ]]; then
-        u=$(uuidgen | tr '[:upper:]' '[:lower:]')
+# --- the double-capture shape must never return: a generator that can emit
+# --- output AND fail, chained with || to a second generator -------------------
+if grep -nE 'generate uuid[^|]*\|\| *uuidgen' "$f" >/dev/null; then
+    bad "'exec generate uuid || uuidgen' is back — a timed-out exec double-captures"
+else
+    ok "no exec-then-uuidgen double-capture chain"
+fi
+
+# --- validated before use, with a loud failure path ---------------------------
+grep -qE '\[\[ ! "\$USER_UUID" =~' "$f" \
+    && ok "USER_UUID is validated before use" \
+    || bad "USER_UUID is not validated — a malformed value would reach configs"
+grep -qE 'Could not generate a UUID' "$f" \
+    && ok "generation failure is a loud error, not a silent set -e death" \
+    || bad "no explicit error when no UUID generator exists"
+
+# --- functional: run the exact generation line; must be ONE valid UUID --------
+gen() { cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' || true; }
+allok=true
+for i in 1 2 3; do
+    u=$(gen)
+    if ! { [[ "$(printf '%s' "$u" | wc -l)" -eq 0 ]] && printf '%s' "$u" | grep -qE "$UUID_RE"; }; then
+        bad "generation run $i produced invalid output: [$u]"
+        allok=false
+        break
     fi
-    printf '%s' "$u"
-}
-one_line() { [[ "$(printf '%s' "$1" | wc -l)" -eq 0 ]] && [[ -n "$1" ]]; }
+done
+$allok && ok "local generation yields exactly one valid lowercase UUID (3/3 runs)"
 
-# two UUIDs (the bug) -> exactly one, and it's the first
-two=$'ea901364-3597-4598-8628-161a381b63cf\n7f90d9d8-83a5-4e0d-b963-a1a8d268ea48'
-r=$(sanitize "$two")
-if one_line "$r" && [[ "$r" == "ea901364-3597-4598-8628-161a381b63cf" ]]; then
-    ok "two-line output collapses to the first single UUID"
-else
-    bad "two-line output not collapsed cleanly (got: $r)"
-fi
+# --- .env read survives the 0600 perms in the admin container -----------------
+# EVERY provisioning script the admin container runs must gate its .env read on
+# -r, not just -f: the first fix only covered user-add.sh and the web add still
+# died in singbox-user-add.sh's own `source .env` (line: ".env: Permission
+# denied" -> set -e death -> "Failed to add sing-box user").
+for s in user-add.sh singbox-user-add.sh wg-user-add.sh user-revoke.sh user-package.sh; do
+    sf="$ROOT/scripts/$s"
+    if grep -qE '\[\[ -f \.env \]\]' "$sf"; then
+        bad "$s reads .env with only -f — unreadable 0600 .env kills it in the admin container"
+    elif grep -qE '\-f \.env && -r \.env' "$sf"; then
+        ok "$s gates its .env read on readability (-r)"
+    else
+        ok "$s has no unguarded .env read"
+    fi
+done
 
-# empty output -> a freshly generated valid UUID
-r=$(sanitize "")
-if one_line "$r" && [[ "$r" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-    ok "empty output falls back to a valid single UUID"
-else
-    bad "empty output did not fall back to a valid UUID (got: $r)"
-fi
-
-# already-clean single UUID -> unchanged
-r=$(sanitize "2b2a0db8-b379-4ae6-a524-c6d37f78119b")
-if [[ "$r" == "2b2a0db8-b379-4ae6-a524-c6d37f78119b" ]]; then
-    ok "a clean single UUID passes through unchanged"
-else
-    bad "a clean single UUID was altered (got: $r)"
-fi
+# compose must hand the admin container the full .env via env_file instead
+awk '/^  admin:$/{f=1; next} f && /^  [a-z0-9_-]+:$/{f=0} f && /env_file:/{found=1} END{exit !found}' "$compose" \
+    && ok "compose injects .env into the admin container via env_file" \
+    || bad "admin service has no env_file — web-admin adds lose the ENABLE_*/PORT_* toggles"
 
 echo
 echo "  $pass passed, $fail failed"


### PR DESCRIPTION
## Owning it: #269 made things worse before better

My #269 fix removed the `|| uuidgen` from the UUID exec pipeline — but that fallback was *also* the error catch. Under `set -e`/`pipefail`, any failure of `docker compose exec sing-box sing-box generate uuid` (which reliably happens when sing-box is restarting from the **previous** add's hot-reload fallback) killed `singbox-user-add.sh` instantly and silently: `✗ Failed to add sing-box user` with no detail, then the same contention took out wg/awg. Verified from the reflog: the failing `kjguurd` add ran *with* #269 deployed.

## The right fix: no docker dependency at all

Any RFC-4122 v4 UUID is valid for VLESS/VMess — the exec bought nothing. The UUID is now generated **locally** (`/proc/sys/kernel/random/uuid`, `uuidgen` fallback), validated, with a loud error if no generator exists. The entire tie between `user add` and docker-daemon health is gone; no path can produce a two-line UUID.

## Second bug: web admin `sed: .env: Permission denied`

Exposed by the `.env` chmod-600 hardening: **five** provisioning scripts (`user-add.sh`, `singbox-user-add.sh`, `wg-user-add.sh`, `user-revoke.sh`, `user-package.sh`) source `.env` guarded only by `-f`. In the admin container (uid 2000, `/project:ro`) `.env` exists but is **unreadable** → `Permission denied` → `set -e` death; the web add died at `singbox-user-add.sh` line 54. All five now gate on `-f .env && -r .env`, and compose injects the full `.env` into the admin container via **`env_file`** (read host-side as root at `up` time, so file perms don't matter and the `ENABLE_*`/`PORT_*` toggles keep working in the web path).

## Verified live (fresh rc.3 install, 206.189.15.8)

- **CLI add immediately after a forced sing-box restart** (the exact failing scenario): sing-box ✓, WireGuard ✓, AmneziaWG ✓, single-line UUID ✓
- **Web-admin API add**: `success: true`, zero errors, full bundle (3 proto files), single-line UUID ✓

## Tests

`tests/uuid-capture-test.sh` rewritten — 11 asserts: local generation (no container exec), no double-capture chain, validation + loud failure, one-valid-UUID functional runs, all five `.env` guards, admin `env_file`.
