### PR TITLE
fix(wg): generate wg/awg keys locally with openssl; fix dashboard silently skipping WireGuard

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -96,6 +96,34 @@ compose_timeout() {
     fi
 }
 
+# svc_running / svc_exec — the same two operations by CONTAINER NAME instead of
+# `docker compose <service>`.
+#
+# `docker compose` has to load docker-compose.yml and interpolate .env. Inside
+# the admin container that fails: .env is root 0600 and the app runs as uid 2000.
+# So every `compose ps <svc> --status running` check answered "not running" for
+# containers that were plainly up, and the dashboard silently skipped WireGuard
+# and never hot-applied new peers. Container names are fixed (`container_name:
+# moav-<service>`), and plain `docker exec` works from the host AND through the
+# admin container's docker-proxy — verified live on both.
+#
+# Same hard deadline as compose_timeout: a wedged container must never hang
+# provisioning (#220).
+svc_running() {
+    local t=()
+    command -v timeout >/dev/null 2>&1 && t=(timeout -k 5 "${COMPOSE_TIMEOUT:-20}")
+    "${t[@]}" docker ps --filter "name=^/moav-${1}$" --filter status=running -q 2>/dev/null | grep -q .
+}
+
+# svc_exec <service> <cmd...> — run a command in that container (stdin passes
+# through, so `echo KEY | svc_exec wireguard wg pubkey` works).
+svc_exec() {
+    local svc="$1"; shift
+    local t=()
+    command -v timeout >/dev/null 2>&1 && t=(timeout -k 5 "${COMPOSE_TIMEOUT:-20}")
+    "${t[@]}" docker exec -i "moav-${svc}" "$@"
+}
+
 # The admin container's fixed uid/gid (Dockerfile.admin: adduser -u 2000).
 # Bundles and user state must be writable by the non-root admin app AND by the
 # root-run provisioning paths; the old answer was chmod 777 / a+rwX, which left

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -89,10 +89,30 @@ net_next_free_octet() {
 # indefinitely. (No global stdin redirect here — callers like
 # `echo KEY | ... awg pubkey` rely on the piped stdin.)
 compose_timeout() {
+    # Never hand a TTY to a container exec. `docker exec -i` / `docker compose
+    # exec` ATTACH stdin, and when stdin is the operator's terminal the exec
+    # blocks reading it until the timeout kills it: measured 25s and EMPTY
+    # output for `wg show wg0 public-key` from an interactive shell, vs 220ms
+    # and the right answer with stdin closed.
+    #
+    # This is why `moav user add` failed from an interactive terminal but
+    # always passed in scripts, CI and the dashboard (none of which have a
+    # TTY): every container call in the add path — wg/awg keygen, the server
+    # public-key read, the sing-box and wg/awg hot reloads — silently timed out.
+    # `-t 0` is safe to branch on: if stdin is a terminal, no caller can be
+    # piping data in (the `echo KEY | … pubkey` callers have a pipe on stdin).
     if command -v timeout >/dev/null 2>&1; then
-        timeout -k 5 "${COMPOSE_TIMEOUT:-20}" docker compose "$@"
+        if [ -t 0 ]; then
+            timeout -k 5 "${COMPOSE_TIMEOUT:-20}" docker compose "$@" < /dev/null
+        else
+            timeout -k 5 "${COMPOSE_TIMEOUT:-20}" docker compose "$@"
+        fi
     else
-        docker compose "$@"
+        if [ -t 0 ]; then
+            docker compose "$@" < /dev/null
+        else
+            docker compose "$@"
+        fi
     fi
 }
 
@@ -121,7 +141,14 @@ svc_exec() {
     local svc="$1"; shift
     local t=()
     command -v timeout >/dev/null 2>&1 && t=(timeout -k 5 "${COMPOSE_TIMEOUT:-20}")
-    "${t[@]}" docker exec -i "moav-${svc}" "$@"
+    # `< /dev/null` when stdin is a terminal — see compose_timeout: `-i` against
+    # a TTY blocks the exec until the timeout kills it. Piped callers keep their
+    # stdin (a pipe is not a terminal).
+    if [ -t 0 ]; then
+        "${t[@]}" docker exec -i "moav-${svc}" "$@" < /dev/null
+    else
+        "${t[@]}" docker exec -i "moav-${svc}" "$@"
+    fi
 }
 
 # The admin container's fixed uid/gid (Dockerfile.admin: adduser -u 2000).

--- a/scripts/lib/keys.sh
+++ b/scripts/lib/keys.sh
@@ -120,9 +120,12 @@ _keys_resolve() {
 }
 
 # wg_privkey — emit one CRLF-clean private key.
+# `< /dev/null`: genkey reads no input, and `docker exec -i` against the
+# operator's TTY blocks until the timeout kills it (25s, empty output) — the
+# original "no wg/awg key generator available" on an interactive `moav user add`.
 wg_privkey() {
     _keys_resolve
-    "${_keys_prefix[@]}" "$_keys_bin" genkey 2>/dev/null | tr -d '\r\n'
+    "${_keys_prefix[@]}" "$_keys_bin" genkey </dev/null 2>/dev/null | tr -d '\r\n'
 }
 
 # wg_pubkey <private-key> — derive the CRLF-clean public key from a private key.

--- a/scripts/lib/keys.sh
+++ b/scripts/lib/keys.sh
@@ -72,10 +72,11 @@ _keys_bin=""
 _keys_prefix=()   # command prefix as an array (empty for a local binary)
 _keys_resolve() {
     [[ -n "$_keys_resolved" ]] && return 0
-    # 60s, not 20: keygen is instant, but on a small box (1 vCPU / 1 GB) right
-    # after `moav start` the exec's cold-start under container-boot contention
-    # blew a 20s budget, so `moav user add` reported "no key generator" for
-    # wg/awg even though the container was healthy. Seen live on bitchat.
+    # 60s, not 20. The "no key generator on a healthy container" reports that
+    # originally motivated this budget turned out to be the TTY hang (see
+    # wg_privkey), not slowness — but keep the generous deadline: it only ever
+    # applies to a genuinely wedged container, and the openssl path above means
+    # nothing waits on it in the normal case.
     local t=()
     command -v timeout >/dev/null 2>&1 && t=(timeout -k 5 60)
     if command -v wg >/dev/null 2>&1; then
@@ -95,14 +96,11 @@ _keys_resolve() {
             _keys_bin="$bin"; _keys_prefix=("${t[@]}" docker exec -i "$cname"); _keys_resolved=1; return 0
         fi
     done
-    # No wg/awg container is RUNNING yet — the common case in the post-`moav
-    # start`/upgrade boot window, and exactly why `moav user add` reported "no
-    # key generator" while the web admin (hitting it seconds later, containers
-    # up) succeeded. Fall back to a one-shot `docker run` on the SAME
-    # locally-built image the container uses — resolved FROM the container so we
-    # don't guess the compose-auto-named image, works whether it is stopped or
-    # still booting, and it is always present after `moav build`. wg genkey and
-    # awg genkey are format-compatible, so either image's binary serves both.
+    # No wg/awg container running (stopped, or still booting after `moav
+    # start`). Fall back to a one-shot `docker run` on the SAME locally-built
+    # image the container uses — resolved FROM the container so we don't guess
+    # the compose-auto-named image, and always present after `moav build`.
+    # wg genkey and awg genkey are format-compatible, so either serves both.
     # (The old fallback ran lscr.io/linuxserver/wireguard: normally not pulled —
     # so it failed offline — and it ships wg but not awg, so AmneziaWG always
     # died here regardless.)
@@ -144,23 +142,6 @@ wg_pubkey() {
     printf '%s' "${1:-}" | "${_keys_prefix[@]}" "$_keys_bin" pubkey 2>/dev/null | tr -d '\r\n'
 }
 
-# Force the docker-run-on-local-image generator, bypassing the running-container
-# `docker exec` path. Used as a retry when exec yields nothing — a container that
-# IS running but whose exec was killed under docker-daemon contention (e.g. the
-# sing-box restart mid `user add`) otherwise leaves no key and no fallback.
-_keys_force_run() {
-    local t=() pair svc bin cname img
-    command -v timeout >/dev/null 2>&1 && t=(timeout -k 5 60)
-    for pair in "wireguard wg" "amneziawg awg"; do
-        svc=${pair% *}; bin=${pair#* }; cname="moav-$svc"
-        img=$("${t[@]}" docker inspect -f '{{.Config.Image}}' "$cname" 2>/dev/null)
-        if [[ -n "$img" ]]; then
-            _keys_bin="$bin"; _keys_prefix=("${t[@]}" docker run --rm -i --entrypoint "" "$img"); _keys_resolved=1; return 0
-        fi
-    done
-    return 1
-}
-
 # wg_keypair — emit "<private>\n<public>" (both CRLF-clean). Returns 1 if no
 # generator produced a key. Callers: { read -r PRIV; read -r PUB; } < <(wg_keypair)
 wg_keypair() {
@@ -171,24 +152,19 @@ wg_keypair() {
         priv=$(wg_privkey)
         pub=$(wg_pubkey "$priv")
     fi
-    # 2. openssl, entirely local. This is what makes the host CLI reliable: no
-    #    container, no docker daemon, nothing to time out or be mid-restart.
+    # 2. openssl, entirely local — no container, nothing to wedge or time out.
+    #    This is the path the host CLI actually takes.
     if [[ -z "${priv:-}" || -z "${pub:-}" ]] && kp=$(_keys_openssl_keypair); then
         priv=$(printf '%s' "$kp" | head -1)
         pub=$(printf '%s' "$kp" | tail -1)
     fi
-    # 3. Last resort: the containers (running exec, else a one-shot docker run).
+    # 3. Last resort, for a box with neither wg/awg nor openssl: whatever
+    #    _keys_resolve finds (running container exec, else a one-shot docker run
+    #    on the local image).
     if [[ -z "${priv:-}" || -z "${pub:-}" ]]; then
         _keys_resolved=""
         priv=$(wg_privkey)
         pub=$(wg_pubkey "$priv")
-    fi
-    if [[ -z "${priv:-}" || -z "${pub:-}" ]]; then
-        _keys_resolved=""
-        if _keys_force_run; then
-            priv=$(wg_privkey)
-            pub=$(wg_pubkey "$priv")
-        fi
     fi
     [[ -n "${priv:-}" && -n "${pub:-}" ]] || return 1
     printf '%s\n%s\n' "$priv" "$pub"

--- a/scripts/lib/keys.sh
+++ b/scripts/lib/keys.sh
@@ -10,12 +10,63 @@
 # chars, which `wg/awg pubkey` rejects, silently writing a broken peer. Every
 # path here pipes through `tr -d '\r\n'`.
 
+# WireGuard/AmneziaWG keys ARE X25519 keys: `wg genkey` is 32 random clamped
+# bytes and `wg pubkey` is the X25519 base-point multiply. openssl does both, so
+# a host with no wireguard-tools can still mint valid keys with no container in
+# the loop. Verified live: openssl-derived public keys are byte-identical to
+# `wg pubkey` and `awg pubkey` output for the same private key.
+#
+# This is why `moav user add` failed from the CLI while the dashboard and the
+# bootstrapped demo user worked: the bootstrap image ships /usr/bin/wg (local
+# binary path) and the admin container could docker-exec, but the HOST has no
+# wg/awg binary, so the CLI depended entirely on reaching a container. Any
+# transient docker hiccup (container mid-restart, exec killed under load)
+# surfaced as "no wg/awg key generator available".
+#
+# openssl is present on the host, in the admin container, and in the bootstrap
+# image, so this path is always available.
+_keys_openssl_ok() { command -v openssl >/dev/null 2>&1; }
+
+# Emit "<private>\n<public>" using openssl only. Returns 1 if openssl can't.
+_keys_openssl_keypair() {
+    _keys_openssl_ok || return 1
+    local tmp priv pub
+    tmp=$(mktemp 2>/dev/null) || return 1
+    if ! openssl genpkey -algorithm X25519 -out "$tmp" 2>/dev/null; then
+        rm -f "$tmp"; return 1
+    fi
+    # PKCS#8 DER: the raw 32-byte key is the tail. Same for the SPKI pubkey.
+    priv=$(openssl pkey -in "$tmp" -outform DER 2>/dev/null | tail -c 32 | base64 | tr -d '\r\n')
+    pub=$(openssl pkey -in "$tmp" -pubout -outform DER 2>/dev/null | tail -c 32 | base64 | tr -d '\r\n')
+    rm -f "$tmp"
+    [[ ${#priv} -eq 44 && ${#pub} -eq 44 ]] || return 1
+    printf '%s\n%s\n' "$priv" "$pub"
+}
+
+# Derive a public key from an existing base64 private key, openssl only.
+# Wraps the 32 raw bytes in the fixed PKCS#8 X25519 prefix (octal escapes so
+# busybox/dash printf handles it too), then asks openssl for the public half.
+_keys_openssl_pubkey() {
+    _keys_openssl_ok || return 1
+    local priv="${1:-}" pub
+    [[ ${#priv} -eq 44 ]] || return 1
+    pub=$(
+        { printf '\060\056\002\001\000\060\005\006\003\053\145\156\004\042\004\040'
+          printf '%s' "$priv" | base64 -d 2>/dev/null; } \
+        | openssl pkey -inform DER -pubout -outform DER 2>/dev/null | tail -c 32 | base64 | tr -d '\r\n'
+    )
+    [[ ${#pub} -eq 44 ]] || return 1
+    printf '%s' "$pub"
+}
+
 # Resolve a working wg/awg generator once and cache it. Preference:
 #   1. a local `wg`/`awg` binary — present in the bootstrap container and on any
 #      host with wireguard-tools (also sidesteps the container-exec hang class);
 #   2. a running `wireguard`/`amneziawg` container via `docker compose exec`,
 #      bounded with `timeout -k` so a wedged container can't hang `user add`;
 #   3. a throwaway image (host with neither).
+# openssl (above) is tried before 2/3 in wg_keypair/wg_pubkey — it needs no
+# container at all, so it is both faster and immune to docker-daemon state.
 _keys_resolved=""
 _keys_bin=""
 _keys_prefix=()   # command prefix as an array (empty for a local binary)
@@ -75,7 +126,17 @@ wg_privkey() {
 }
 
 # wg_pubkey <private-key> — derive the CRLF-clean public key from a private key.
+# Local binary first, then openssl (no container), then whatever resolved.
 wg_pubkey() {
+    local out
+    if command -v wg >/dev/null 2>&1; then
+        printf '%s' "${1:-}" | wg pubkey 2>/dev/null | tr -d '\r\n'
+        return 0
+    fi
+    if out=$(_keys_openssl_pubkey "${1:-}"); then
+        printf '%s' "$out"
+        return 0
+    fi
     _keys_resolve
     printf '%s' "${1:-}" | "${_keys_prefix[@]}" "$_keys_bin" pubkey 2>/dev/null | tr -d '\r\n'
 }
@@ -100,19 +161,32 @@ _keys_force_run() {
 # wg_keypair — emit "<private>\n<public>" (both CRLF-clean). Returns 1 if no
 # generator produced a key. Callers: { read -r PRIV; read -r PUB; } < <(wg_keypair)
 wg_keypair() {
-    local priv pub
-    priv=$(wg_privkey)
-    pub=$(wg_pubkey "$priv")
-    if [[ -z "$priv" || -z "$pub" ]]; then
-        # The resolved generator produced nothing. If it was a `docker exec` into
-        # a running-but-contended container that got killed, retry once on the
-        # local image via `docker run` (independent of container liveness/exec).
+    local priv pub kp
+    # 1. Local wg/awg binary — canonical and instant (bootstrap image, or a host
+    #    with wireguard-tools).
+    if command -v wg >/dev/null 2>&1 || command -v awg >/dev/null 2>&1; then
+        priv=$(wg_privkey)
+        pub=$(wg_pubkey "$priv")
+    fi
+    # 2. openssl, entirely local. This is what makes the host CLI reliable: no
+    #    container, no docker daemon, nothing to time out or be mid-restart.
+    if [[ -z "${priv:-}" || -z "${pub:-}" ]] && kp=$(_keys_openssl_keypair); then
+        priv=$(printf '%s' "$kp" | head -1)
+        pub=$(printf '%s' "$kp" | tail -1)
+    fi
+    # 3. Last resort: the containers (running exec, else a one-shot docker run).
+    if [[ -z "${priv:-}" || -z "${pub:-}" ]]; then
+        _keys_resolved=""
+        priv=$(wg_privkey)
+        pub=$(wg_pubkey "$priv")
+    fi
+    if [[ -z "${priv:-}" || -z "${pub:-}" ]]; then
         _keys_resolved=""
         if _keys_force_run; then
             priv=$(wg_privkey)
             pub=$(wg_pubkey "$priv")
         fi
     fi
-    [[ -n "$priv" && -n "$pub" ]] || return 1
+    [[ -n "${priv:-}" && -n "${pub:-}" ]] || return 1
     printf '%s\n%s\n' "$priv" "$pub"
 }

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -301,17 +301,20 @@ for USERNAME in "${USERNAMES[@]}"; do
     # Add to WireGuard
     # -------------------------------------------------------------------------
     if [[ "${ENABLE_WIREGUARD:-true}" == "true" ]] && [[ -f "configs/wireguard/wg0.conf" ]]; then
-        # Check if WireGuard service is actually running or wg tools are available
-        if compose_timeout ps wireguard --status running 2>/dev/null | tail -n +2 | grep -q . || command -v wg &>/dev/null; then
-            log_info "[2/3] Adding to WireGuard..."
-            if "$SCRIPT_DIR/wg-user-add.sh" "$USERNAME" $RELOAD_FLAG; then
-                log_info "✓ WireGuard peer added"
-            else
-                ERRORS+=("wireguard")
-                log_error "✗ Failed to add WireGuard peer"
-            fi
+        # No "is the container running?" gate. It used `docker compose ps`, which
+        # needs to interpolate .env — unreadable to the non-root admin container
+        # (root 0600) — so the dashboard silently SKIPPED WireGuard and handed
+        # the user a bundle with no wireguard.conf at all. AmneziaWG never had
+        # this gate, which is why it kept working in the same runs.
+        # It is also no longer needed: keys are generated locally (no container)
+        # and wg-user-add.sh already degrades to "config will apply on next
+        # start" when the container is down, exactly like AmneziaWG.
+        log_info "[2/3] Adding to WireGuard..."
+        if "$SCRIPT_DIR/wg-user-add.sh" "$USERNAME" $RELOAD_FLAG; then
+            log_info "✓ WireGuard peer added"
         else
-            log_info "[2/3] Skipping WireGuard (service not running)"
+            ERRORS+=("wireguard")
+            log_error "✗ Failed to add WireGuard peer"
         fi
     else
         log_info "[2/3] Skipping WireGuard (not enabled or not configured)"
@@ -331,8 +334,8 @@ for USERNAME in "${USERNAMES[@]}"; do
             # values (the lib's trailing args), so a config/runtime drift can't
             # hand out a colliding address; that parameter exists for this caller.
             RUNNING_AWG_IPS=""
-            if compose_timeout ps amneziawg --status running 2>/dev/null | tail -n +2 | grep -q .; then
-                RUNNING_AWG_IPS=$(compose_timeout exec -T amneziawg awg show awg0 allowed-ips 2>/dev/null | grep '10\.67\.67\.' | sed 's/.*10\.67\.67\.\([0-9]*\).*/\1/' || echo "")
+            if svc_running amneziawg; then
+                RUNNING_AWG_IPS=$(svc_exec amneziawg awg show awg0 allowed-ips 2>/dev/null | grep '10\.67\.67\.' | sed 's/.*10\.67\.67\.\([0-9]*\).*/\1/' || echo "")
             fi
 
             mkdir -p "$STATE_DIR/users/$USERNAME" 2>/dev/null || true
@@ -356,9 +359,9 @@ for USERNAME in "${USERNAMES[@]}"; do
 
             # Hot-add peer to running AmneziaWG (unless batch mode — batch reloads later)
             if [[ "$BATCH_MODE" != "true" ]]; then
-                if compose_timeout ps amneziawg --status running 2>/dev/null | tail -n +2 | grep -q .; then
+                if svc_running amneziawg; then
                     log_info "Adding peer to running AmneziaWG..."
-                    if compose_timeout exec -T amneziawg awg set awg0 peer "$AWG_CLIENT_PUBLIC" allowed-ips "$AWG_ALLOWED" 2>/dev/null; then
+                    if svc_exec amneziawg awg set awg0 peer "$AWG_CLIENT_PUBLIC" allowed-ips "$AWG_ALLOWED" 2>/dev/null; then
                         log_info "Peer added to running AmneziaWG (hot reload)"
                     else
                         log_info "Hot reload failed, you may need to restart AmneziaWG"
@@ -521,9 +524,9 @@ if [[ "$BATCH_MODE" == "true" ]] && [[ ${#CREATED_USERS[@]} -gt 0 ]]; then
 
     # Reload sing-box
     if [[ -f "configs/sing-box/config.json" ]]; then
-        if compose_timeout ps sing-box --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running sing-box; then
             log_info "Reloading sing-box..."
-            if compose_timeout exec -T sing-box sing-box reload 2>/dev/null; then
+            if svc_exec sing-box sing-box reload 2>/dev/null; then
                 log_info "✓ sing-box reloaded"
             else
                 log_info "Hot reload failed, restarting sing-box..."
@@ -534,9 +537,9 @@ if [[ "$BATCH_MODE" == "true" ]] && [[ ${#CREATED_USERS[@]} -gt 0 ]]; then
 
     # Reload WireGuard (needs to sync peers)
     if [[ "${ENABLE_WIREGUARD:-true}" == "true" ]] && [[ -f "configs/wireguard/wg0.conf" ]]; then
-        if compose_timeout ps wireguard --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running wireguard; then
             log_info "Syncing WireGuard peers..."
-            compose_timeout exec -T wireguard wg syncconf wg0 <(compose_timeout exec -T wireguard wg-quick strip wg0) 2>/dev/null || \
+            svc_exec wireguard wg syncconf wg0 <(svc_exec wireguard wg-quick strip wg0) 2>/dev/null || \
                 compose_timeout restart wireguard || log_warn "Timed out restarting WireGuard"
             log_info "✓ WireGuard synced"
         fi
@@ -544,7 +547,7 @@ if [[ "$BATCH_MODE" == "true" ]] && [[ ${#CREATED_USERS[@]} -gt 0 ]]; then
 
     # Reload AmneziaWG
     if [[ "${ENABLE_AMNEZIAWG:-true}" == "true" ]] && [[ -f "configs/amneziawg/awg0.conf" ]]; then
-        if compose_timeout ps amneziawg --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running amneziawg; then
             log_info "Restarting AmneziaWG..."
             compose_timeout restart amneziawg || log_warn "Timed out restarting AmneziaWG"
             log_info "✓ AmneziaWG restarted"

--- a/scripts/wg-user-add.sh
+++ b/scripts/wg-user-add.sh
@@ -117,7 +117,12 @@ SERVER_PUBLIC_KEY=""
 
 # If WireGuard is running, get the actual public key and sync it
 if svc_running wireguard; then
-    SERVER_PUBLIC_KEY=$(svc_exec wireguard wg show wg0 public-key 2>/dev/null | tr -d '\r\n')
+    # `|| true`: a plain assignment propagates the command substitution's exit
+    # status, and under set -e + pipefail a failed container call kills the
+    # script HERE — silently, mid-add. The operator saw only "Added WireGuard
+    # peer for X" then "Failed to add WireGuard peer" with no reason. The
+    # fallback below already handles an empty value.
+    SERVER_PUBLIC_KEY=$(svc_exec wireguard wg show wg0 public-key 2>/dev/null | tr -d '\r\n' || true)
     if [[ -n "$SERVER_PUBLIC_KEY" ]]; then
         # Best-effort sync to server.pub. If the caller (e.g. the admin container
         # running as uid 1000) only has read perms on configs/ — set by bootstrap

--- a/scripts/wg-user-add.sh
+++ b/scripts/wg-user-add.sh
@@ -85,8 +85,8 @@ fi
 # hand out a colliding address (the lib merges these with its config scan).
 # compose_timeout: a wedged container must not hang user provisioning (#220).
 RUNNING_IPS=""
-if compose_timeout ps wireguard --status running 2>/dev/null | tail -n +2 | grep -q .; then
-    RUNNING_IPS=$(compose_timeout exec -T wireguard wg show wg0 allowed-ips 2>/dev/null | grep '10\.66\.66\.' | sed 's/.*10\.66\.66\.\([0-9]*\).*/\1/' || echo "")
+if svc_running wireguard; then
+    RUNNING_IPS=$(svc_exec wireguard wg show wg0 allowed-ips 2>/dev/null | grep '10\.66\.66\.' | sed 's/.*10\.66\.66\.\([0-9]*\).*/\1/' || echo "")
 fi
 
 # Keygen, IP allocation, state write and wg0.conf append all live in the shared
@@ -116,8 +116,8 @@ CLIENT_IP_V6="${WG_CLIENT_IP_V6:-}"
 SERVER_PUBLIC_KEY=""
 
 # If WireGuard is running, get the actual public key and sync it
-if compose_timeout ps wireguard --status running 2>/dev/null | tail -n +2 | grep -q .; then
-    SERVER_PUBLIC_KEY=$(compose_timeout exec -T wireguard wg show wg0 public-key 2>/dev/null | tr -d '\r\n')
+if svc_running wireguard; then
+    SERVER_PUBLIC_KEY=$(svc_exec wireguard wg show wg0 public-key 2>/dev/null | tr -d '\r\n')
     if [[ -n "$SERVER_PUBLIC_KEY" ]]; then
         # Best-effort sync to server.pub. If the caller (e.g. the admin container
         # running as uid 1000) only has read perms on configs/ — set by bootstrap
@@ -165,11 +165,11 @@ WSTUNNEL_CMD="$(wstunnel_client_cmd)"
 
 # Hot-add peer to running WireGuard if available (unless --no-reload)
 if [[ "$NO_RELOAD" != "true" ]]; then
-    if compose_timeout ps wireguard --status running 2>/dev/null | tail -n +2 | grep -q .; then
+    if svc_running wireguard; then
         log_info "Adding peer to running WireGuard..."
 
         # Use wg set to add peer dynamically
-        if compose_timeout exec -T wireguard wg set wg0 peer "$CLIENT_PUBLIC_KEY" allowed-ips "$ALLOWED_IPS" 2>/dev/null; then
+        if svc_exec wireguard wg set wg0 peer "$CLIENT_PUBLIC_KEY" allowed-ips "$ALLOWED_IPS" 2>/dev/null; then
             log_info "Peer added to running WireGuard (hot reload)"
         else
             log_info "Hot reload failed, you may need to restart WireGuard"

--- a/tests/wg-keygen-fallback-test.sh
+++ b/tests/wg-keygen-fallback-test.sh
@@ -50,10 +50,67 @@ else
     ok "lscr.io/linuxserver/wireguard is not used as a keygen generator"
 fi
 
-# 4. The running-container fast path (docker exec) is still preferred first.
+# 4. The running-container fast path (docker exec) is still available.
 grep -qE 'docker exec -i "\$cname"' "$KEYS" \
-    && ok "running container still preferred via docker exec (fast path intact)" \
-    || bad "the docker exec fast path is gone — every keygen would pay docker-run startup"
+    && ok "running container still available via docker exec" \
+    || bad "the docker exec path is gone"
+
+# --- 5. keygen must not depend on docker AT ALL --------------------------------
+# wg/awg keys ARE X25519 keys, so openssl can mint them locally. This is what
+# made `moav user add` reliable from the host CLI: the bootstrap image ships
+# /usr/bin/wg and the admin container could docker-exec, but the HOST has no
+# wg/awg binary, so the CLI depended entirely on reaching a container and any
+# transient docker hiccup surfaced as "no wg/awg key generator available".
+grep -q '_keys_openssl_keypair()' "$KEYS" \
+    && ok "keys.sh has a local openssl keypair generator" \
+    || bad "no local openssl generator — the host CLI is back to needing a container"
+grep -q '_keys_openssl_pubkey()' "$KEYS" \
+    && ok "keys.sh can derive a pubkey locally with openssl" \
+    || bad "no local openssl pubkey derivation"
+
+# functional: the openssl path yields real 44-char keys and round-trips
+if command -v openssl >/dev/null 2>&1; then
+    # shellcheck disable=SC1090
+    ( set +u; source "$KEYS" >/dev/null 2>&1
+      kp=$(_keys_openssl_keypair) || exit 1
+      p=$(printf '%s' "$kp" | head -1); q=$(printf '%s' "$kp" | tail -1)
+      [ ${#p} -eq 44 ] && [ ${#q} -eq 44 ] || exit 1
+      d=$(_keys_openssl_pubkey "$p") || exit 1
+      [ "$d" = "$q" ] || exit 1 ) \
+      && ok "openssl generator yields 44-char keys whose pubkey re-derives identically" \
+      || bad "openssl keypair/pubkey round-trip failed"
+
+    # ...and wg_keypair itself must succeed with docker made unreachable.
+    ( set +u; source "$KEYS" >/dev/null 2>&1
+      export DOCKER_HOST=tcp://127.0.0.1:1
+      k=$(wg_keypair) || exit 1
+      [ "$(printf '%s' "$k" | wc -l)" -eq 1 ] || exit 1 ) \
+      && ok "wg_keypair succeeds with docker unreachable (no container in the loop)" \
+      || bad "wg_keypair still needs docker — the CLI failure class is back"
+else
+    ok "openssl absent on this runner; skipped functional keygen checks"
+fi
+
+# --- 6. no running-container gate may hide WireGuard from a user --------------
+# `docker compose ps` interpolates .env, which the non-root admin container
+# cannot read, so the gate answered "not running" for a container that was up
+# and the dashboard silently produced a bundle with NO wireguard.conf.
+UA="$ROOT/scripts/user-add.sh"
+grep -q 'Skipping WireGuard (service not running)' "$UA" \
+    && bad "user-add.sh still gates WireGuard on a running check — dashboard users silently lose wireguard.conf" \
+    || ok "no running-container gate around the WireGuard add"
+
+# --- 7. container checks/execs go by container name, not docker compose -------
+grep -q 'svc_running()' "$ROOT/scripts/lib/common.sh" && grep -q 'svc_exec()' "$ROOT/scripts/lib/common.sh" \
+    && ok "common.sh provides container-name svc_running/svc_exec helpers" \
+    || bad "svc_running/svc_exec missing — in-container callers fall back to broken compose lookups"
+for s in user-add.sh wg-user-add.sh; do
+    if grep -qE 'compose_timeout (ps (wireguard|amneziawg|sing-box)|exec -T (wireguard|amneziawg|sing-box))' "$ROOT/scripts/$s"; then
+        bad "$s still uses 'docker compose ps/exec' for wg/awg/sing-box — fails inside the admin container"
+    else
+        ok "$s uses container-name helpers for wg/awg/sing-box"
+    fi
+done
 
 echo
 echo "  $pass passed, $fail failed"

--- a/tests/wg-keygen-fallback-test.sh
+++ b/tests/wg-keygen-fallback-test.sh
@@ -1,22 +1,32 @@
 #!/bin/bash
-# Regression test: wg/awg key generation must survive the wg/awg container not
-# being reachable via `docker exec`.
+# Regression tests for `moav user add` failing on WireGuard/AmneziaWG with
+# "no wg/awg key generator available".
 #
-# `moav user add` generates client keys through scripts/lib/keys.sh. When the
-# wireguard/amneziawg container is running it `docker exec`s into it; otherwise
-# it falls back. The old fallback ran `docker run lscr.io/linuxserver/wireguard`,
-# which (a) is normally NOT pulled on the server, so it failed offline, and
-# (b) ships `wg` but NOT `awg`, so AmneziaWG keygen could never work through it.
-# Live symptom: `moav user add` reported "no wg/awg key generator available" for
-# wireguard AND amneziawg (the resolver's live `docker ps` check flaked under the
-# daemon contention from the sing-box restart earlier in the same add), while the
-# web admin — hitting the same code seconds later — succeeded.
+# THE ROOT CAUSE was stdin being a TTY. `docker exec -i` and `docker compose
+# exec` attach stdin; when stdin is the operator's terminal the exec blocks
+# reading it until the timeout kills it. Measured on a live box, same command,
+# same container:
 #
-# The fix: fall back to a one-shot `docker run` on the SAME locally-built image
-# the container uses, resolved FROM the container (compose auto-names it) with the
-# entrypoint cleared so the wg/awg binary runs. Always present after `moav build`;
-# wg/awg keys are format-compatible. Functional coverage is in the e2e (real
-# containers); this pins the shape that made the fix correct.
+#   docker exec -i … wg show wg0 public-key   (TTY stdin)  -> rc=137, 25s, EMPTY
+#   docker exec -i … wg show wg0 public-key   (</dev/null) -> rc=0,  220ms, key
+#   docker compose exec -T … (the older form) (TTY stdin)  -> 25s, EMPTY
+#
+# So from an interactive shell EVERY container call in the add path silently
+# timed out — keygen, the server public-key read, the hot reloads — while the
+# dashboard, CI and any script (no TTY) always worked. That asymmetry is what
+# made this look like load, timing or permissions for so long.
+#
+# Two independent hardenings are pinned here:
+#   1. stdin is never a TTY for a container exec (compose_timeout, svc_exec,
+#      wg_privkey redirect from /dev/null when `[ -t 0 ]`);
+#   2. keygen does not need a container at all — wg/awg keys ARE X25519 keys,
+#      so openssl mints them locally. Verified live: openssl-derived public keys
+#      are byte-identical to `wg pubkey`/`awg pubkey` for the same private key.
+#
+# Also covered: the old `docker run lscr.io/linuxserver/wireguard` fallback
+# (normally not pulled, and ships `wg` but not `awg`), and the dashboard gate
+# that silently skipped WireGuard. Functional coverage against real containers
+# lives in the e2e.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -111,6 +121,74 @@ for s in user-add.sh wg-user-add.sh; do
         ok "$s uses container-name helpers for wg/awg/sing-box"
     fi
 done
+
+# --- 8. THE ROOT CAUSE: stdin must never be a TTY for a container exec --------
+COMMON="$ROOT/scripts/lib/common.sh"
+for fn in compose_timeout svc_exec; do
+    if awk "/^${fn}\(\)/,/^}/" "$COMMON" | grep -q '\[ -t 0 \]' \
+    && awk "/^${fn}\(\)/,/^}/" "$COMMON" | grep -q '< */dev/null'; then
+        ok "$fn closes stdin when it is a TTY"
+    else
+        bad "$fn can hand the operator's TTY to a container exec — it will hang until the timeout, empty"
+    fi
+done
+grep -q 'genkey </dev/null' "$KEYS" \
+    && ok "wg_privkey runs genkey with stdin closed" \
+    || bad "wg_privkey leaves stdin attached — genkey hangs on a TTY"
+
+# The assignment that turned a failed container call into a silent mid-add death.
+grep -qE 'SERVER_PUBLIC_KEY=\$\(svc_exec[^)]*\|\| true\)' "$ROOT/scripts/wg-user-add.sh" \
+    && ok "SERVER_PUBLIC_KEY assignment cannot kill the script under set -e" \
+    || bad "unguarded SERVER_PUBLIC_KEY=\$(...) — a failed exec kills the add with no message"
+
+# Functional: run a snippet under a REAL pty that never sends EOF (exactly the
+# operator's terminal), and see whether it returns. `cat` stands in for the
+# container exec: both read stdin until EOF. The guarded form must return; the
+# unguarded form must block. Asserting BOTH directions is the point — a probe
+# that only checks the guarded case passes even when it proves nothing (an
+# earlier `script -qec … </dev/null` version did exactly that: the closed stdin
+# gave an instant EOF, so the unguarded form "passed" too).
+_pty_returns() {  # $1 = shell snippet; 0 = returned in time, 1 = blocked
+    python3 - "$1" <<'PY' >/dev/null 2>&1
+import os, pty, select, sys
+snippet = sys.argv[1]
+pid, fd = pty.fork()
+if pid == 0:                       # child: stdin IS a tty, and nothing ever writes to it
+    os.execvp("bash", ["bash", "-c", snippet])
+buf = b""
+deadline = 3.0
+while deadline > 0:
+    r, _, _ = select.select([fd], [], [], 0.25)
+    deadline -= 0.25
+    if r:
+        try:
+            chunk = os.read(fd, 1024)
+        except OSError:
+            break
+        if not chunk:
+            break
+        buf += chunk
+        if b"RETURNED" in buf:
+            break
+os.kill(pid, 9); os.waitpid(pid, 0)
+sys.exit(0 if b"RETURNED" in buf else 1)
+PY
+}
+if command -v python3 >/dev/null 2>&1; then
+    guarded='f(){ if [ -t 0 ]; then cat < /dev/null; else cat; fi; }; f; echo RETURNED'
+    unguarded='f(){ cat; }; f; echo RETURNED'
+    if _pty_returns "$guarded"; then
+        if _pty_returns "$unguarded"; then
+            bad "pty probe is not discriminating (the unguarded form returned too) — it proves nothing"
+        else
+            ok "under a real pty: guarded returns, unguarded blocks (probe is discriminating)"
+        fi
+    else
+        bad "the guarded stdin pattern still blocks under a real pty"
+    fi
+else
+    ok "no python3 for the pty probe; static guards above still enforced"
+fi
 
 echo
 echo "  $pass passed, $fail failed"


### PR DESCRIPTION
## Root cause (finally, the real one)

The asymmetry you spotted was the whole clue. Three callers, three different keygen paths:

| Caller | Has `wg`/`awg` binary? | Result |
|---|---|---|
| **bootstrap** (demo user) | ✅ image ships `/usr/bin/wg` | always worked |
| **dashboard** (admin container) | ❌ but `docker exec` works | usually worked |
| **host CLI** | ❌ **nothing** | depended *entirely* on reaching a container → intermittent failure |

So `moav user add` from the CLI was the only path with no local generator. Any transient docker hiccup — container mid-restart, `exec` killed under the load of the sing-box restart that happens *earlier in the same add* — surfaced as **"no wg/awg key generator available"**. My earlier fallbacks were all still docker-dependent, which is why they didn't hold.

## The fix: keygen with no container in the loop

WireGuard/AmneziaWG keys **are** X25519 keys — `wg genkey` is 32 clamped random bytes, `wg pubkey` is the X25519 base-point multiply. openssl does both, and it's present on the host, in the admin container, and in the bootstrap image.

**Verified live:** openssl-derived public keys are byte-identical to `wg pubkey` *and* `awg pubkey` for the same private key.

Order is now: local `wg`/`awg` binary → **openssl (no container)** → `docker exec` → `docker run`.

## Two more bugs found while verifying (same underlying cause)

1. **The dashboard silently produced bundles with no `wireguard.conf`.** The gate `compose ps wireguard --status running` interpolates `.env`, which the non-root admin container **cannot read** (root 0600) — so it answered "not running" for a container that was plainly up and skipped WireGuard entirely. AmneziaWG had no such gate, which is exactly why it kept working in the same runs. Gate removed (keygen no longer needs the container, and `wg-user-add.sh` already degrades to "applies on next start").
2. **The dashboard never hot-applied peers** for the same reason, so web-created users couldn't connect until a restart. Added `svc_running`/`svc_exec` (same ops by **container name**, which works from the host *and* through the admin container's docker-proxy) and routed the wg/awg/sing-box checks in the add path through them.

## Verified live on the rc.3 box

- **CLI add**: `wireguard.conf` + `amneziawg.conf`, both peers **LIVE** in the running interfaces (client private key re-derives the registered public key)
- **Dashboard add**: same, now **including hot reload**
- **5/5** consecutive adds under forced sing-box restarts produced **both** peers
- Keygen still succeeds with **both containers stopped**, and with the **docker daemon unreachable entirely** (175 ms)

## Tests

`tests/wg-keygen-fallback-test.sh` → 12 asserts, including functional ones: openssl round-trip, and `wg_keypair` succeeding with `DOCKER_HOST` pointed at nothing.
