### PR TITLE
fix(user-add): actually apply new users to sing-box/xray — bundles passed no traffic

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -135,6 +135,17 @@ svc_running() {
     "${t[@]}" docker ps --filter "name=^/moav-${1}$" --filter status=running -q 2>/dev/null | grep -q .
 }
 
+# svc_restart <service> — restart by container name. `docker compose restart`
+# needs the compose file + .env interpolation, which the admin container cannot
+# do; a skipped restart is silent and total: sing-box runs from a COPY of the
+# config made at container start, so a user added without a restart is
+# "unknown UUID" on every protocol until something else restarts it.
+svc_restart() {
+    local t=()
+    command -v timeout >/dev/null 2>&1 && t=(timeout -k 5 "${SVC_RESTART_TIMEOUT:-60}")
+    "${t[@]}" docker restart "moav-${1}" >/dev/null 2>&1
+}
+
 # svc_exec <service> <cmd...> — run a command in that container (stdin passes
 # through, so `echo KEY | svc_exec wireguard wg pubkey` works).
 svc_exec() {

--- a/scripts/singbox-user-add.sh
+++ b/scripts/singbox-user-add.sh
@@ -182,8 +182,8 @@ if [[ -z "${REALITY_PUBLIC_KEY:-}" ]] && [[ -n "${REALITY_PRIVATE_KEY:-}" ]]; th
     log_info "Reality public key missing, deriving from private key..."
     # x25519 uses the same curve as WireGuard — convert base64url→base64, use wg pubkey, convert back
     REALITY_KEY_B64=$(echo "${REALITY_PRIVATE_KEY}==" | tr '_-' '/+' | head -c 44)
-    if compose_timeout ps wireguard --status running 2>/dev/null | tail -n +2 | grep -q .; then
-        REALITY_PUBLIC_KEY=$(echo "$REALITY_KEY_B64" | compose_timeout exec -T wireguard wg pubkey 2>/dev/null | tr -d '\r\n' | tr '/+' '_-' | sed 's/=*$//' || echo "")
+    if svc_running wireguard; then
+        REALITY_PUBLIC_KEY=$(echo "$REALITY_KEY_B64" | svc_exec wireguard wg pubkey 2>/dev/null | tr -d '\r\n' | tr '/+' '_-' | sed 's/=*$//' || echo "")
     elif command -v wg &>/dev/null; then
         REALITY_PUBLIC_KEY=$(echo "$REALITY_KEY_B64" | wg pubkey 2>/dev/null | tr -d '\r\n' | tr '/+' '_-' | sed 's/=*$//' || echo "")
     fi
@@ -449,15 +449,37 @@ if [[ "${ENABLE_TELEMT:-true}" == "true" ]] && [[ -f "$TELEMT_CONFIG" ]]; then
     telemt_add_user_to_config "$USERNAME" "$TELEMT_SECRET" "$TELEMT_CONFIG"
 fi
 
-# Try to reload sing-box (hot reload) unless --no-reload was passed
+# Apply the new user to the running sing-box, unless --no-reload was passed
+# (batch mode reloads once at the end).
+#
+# A restart is the ONLY way: sing-box has no `reload` subcommand (check
+# `sing-box --help`: check / run / tools), and its entrypoint runs from a COPY
+# of the config taken at container start. So a user written to the config file
+# without a restart is simply not there for the running process — every
+# protocol answers "unknown UUID" and the operator gets a working-looking
+# bundle that passes no traffic. That is exactly how it shipped: the dashboard
+# said "sing-box not running, config will apply on next start" (it WAS running;
+# the compose-based check just cannot answer from inside the admin container),
+# skipped the restart, and every user created that way was dead on arrival.
+#
+# So: restart, then VERIFY the user is actually live, and say so loudly if not.
 if [[ "$NO_RELOAD" != "true" ]]; then
-    if compose_timeout ps sing-box --status running 2>/dev/null | tail -n +2 | grep -q .; then
-        log_info "Reloading sing-box..."
-        if compose_timeout exec -T sing-box sing-box reload 2>/dev/null; then
-            log_info "sing-box reloaded successfully"
+    if svc_running sing-box; then
+        log_info "Restarting sing-box to apply the new user..."
+        svc_restart sing-box
+        _live=false
+        for _i in $(seq 1 15); do
+            if svc_exec sing-box grep -q "$USER_UUID" /tmp/sing-box-config.json 2>/dev/null; then
+                _live=true; break
+            fi
+            sleep 1
+        done
+        if [[ "$_live" == true ]]; then
+            log_info "✓ sing-box is serving $USERNAME"
         else
-            log_info "Hot reload failed, restarting sing-box..."
-            COMPOSE_TIMEOUT=60 compose_timeout restart sing-box
+            log_warn "sing-box restarted but $USERNAME is NOT in its running config."
+            log_warn "  The user's Reality/Trojan/Hysteria2/Shadowsocks configs will not connect."
+            log_warn "  Fix with: moav restart sing-box"
         fi
     else
         log_info "sing-box not running, config will apply on next start"
@@ -465,25 +487,25 @@ if [[ "$NO_RELOAD" != "true" ]]; then
 
     # Try to reload TrustTunnel (if running)
     if [[ -f "$TRUSTTUNNEL_CREDS" ]]; then
-        if compose_timeout ps trusttunnel --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running trusttunnel; then
             log_info "Restarting TrustTunnel to apply new credentials..."
-            COMPOSE_TIMEOUT=60 compose_timeout restart trusttunnel
+            svc_restart trusttunnel
         fi
     fi
 
     # Try to reload Xray (if running)
     if [[ -f "$XRAY_CONFIG" ]] && [[ "${ENABLE_XHTTP:-true}" == "true" ]]; then
-        if compose_timeout --profile xhttp ps xray --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running xray; then
             log_info "Restarting Xray to apply new user..."
-            COMPOSE_TIMEOUT=60 compose_timeout --profile xhttp restart xray
+            svc_restart xray
         fi
     fi
 
     # Try to reload telemt (if running)
     if [[ -f "$TELEMT_CONFIG" ]]; then
-        if compose_timeout --profile telegram ps telemt --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running telemt; then
             log_info "Restarting telemt to apply new user..."
-            COMPOSE_TIMEOUT=60 compose_timeout --profile telegram restart telemt
+            svc_restart telemt
         fi
     fi
 fi

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -530,7 +530,7 @@ if [[ "$BATCH_MODE" == "true" ]] && [[ ${#CREATED_USERS[@]} -gt 0 ]]; then
                 log_info "✓ sing-box reloaded"
             else
                 log_info "Hot reload failed, restarting sing-box..."
-                compose_timeout restart sing-box || log_warn "Timed out restarting sing-box"
+                svc_restart sing-box || log_warn "Timed out restarting sing-box"
             fi
         fi
     fi
@@ -540,7 +540,7 @@ if [[ "$BATCH_MODE" == "true" ]] && [[ ${#CREATED_USERS[@]} -gt 0 ]]; then
         if svc_running wireguard; then
             log_info "Syncing WireGuard peers..."
             svc_exec wireguard wg syncconf wg0 <(svc_exec wireguard wg-quick strip wg0) 2>/dev/null || \
-                compose_timeout restart wireguard || log_warn "Timed out restarting WireGuard"
+                svc_restart wireguard || log_warn "Timed out restarting WireGuard"
             log_info "✓ WireGuard synced"
         fi
     fi
@@ -549,34 +549,34 @@ if [[ "$BATCH_MODE" == "true" ]] && [[ ${#CREATED_USERS[@]} -gt 0 ]]; then
     if [[ "${ENABLE_AMNEZIAWG:-true}" == "true" ]] && [[ -f "configs/amneziawg/awg0.conf" ]]; then
         if svc_running amneziawg; then
             log_info "Restarting AmneziaWG..."
-            compose_timeout restart amneziawg || log_warn "Timed out restarting AmneziaWG"
+            svc_restart amneziawg || log_warn "Timed out restarting AmneziaWG"
             log_info "✓ AmneziaWG restarted"
         fi
     fi
 
     # Reload TrustTunnel
     if [[ -f "configs/trusttunnel/credentials.toml" ]]; then
-        if compose_timeout ps trusttunnel --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running trusttunnel; then
             log_info "Restarting TrustTunnel..."
-            compose_timeout restart trusttunnel || log_warn "Timed out restarting TrustTunnel"
+            svc_restart trusttunnel || log_warn "Timed out restarting TrustTunnel"
             log_info "✓ TrustTunnel restarted"
         fi
     fi
 
     # Reload Xray (XHTTP)
     if [[ -f "configs/xray/config.json" ]]; then
-        if compose_timeout --profile xhttp ps xray --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running xray; then
             log_info "Restarting Xray..."
-            compose_timeout --profile xhttp restart xray || log_warn "Timed out restarting Xray"
+            svc_restart xray || log_warn "Timed out restarting Xray"
             log_info "✓ Xray restarted"
         fi
     fi
 
     # Reload telemt
     if [[ -f "configs/telemt/config.toml" ]]; then
-        if compose_timeout --profile telegram ps telemt --status running 2>/dev/null | tail -n +2 | grep -q .; then
+        if svc_running telemt; then
             log_info "Restarting telemt..."
-            compose_timeout --profile telegram restart telemt || log_warn "Timed out restarting telemt"
+            svc_restart telemt || log_warn "Timed out restarting telemt"
             log_info "✓ telemt restarted"
         fi
     fi


### PR DESCRIPTION
## The bug you hit

A user created from the dashboard got a **complete, correct bundle that could not connect on any protocol**. The sing-box log said:

```
inbound/vless[vless-reality-in]: process connection from …: unknown UUID: 1bfe5c3c-…
```

…while that exact UUID **was** present in `configs/sing-box/config.json`. The bundle was never the problem — I verified the Reality public key, short_id and UUID all matched the server perfectly.

## Cause

sing-box has **no `reload` subcommand** (`sing-box --help` → check / run / tools), and its entrypoint runs from a **copy** of the config taken at container start. So a new user only exists for the running process after a **restart**.

That restart was gated on `docker compose ps sing-box --status running`, which **cannot answer from inside the admin container** — compose has to interpolate `.env`, which is root `0600` and unreadable to uid 2000. So it reported "not running", logged the reassuring **"config will apply on next start"**, skipped the restart, and every dashboard-created user was dead on arrival. Same for xray, so XHTTP users were never applied either (the user wasn't even in xray's client list).

## Fix

- `singbox-user-add.sh` + `user-add.sh` use the container-name helpers for **every** remaining ps/exec/restart (sing-box, xray, trusttunnel, telemt, wireguard, amneziawg). No `docker compose` lookups remain in the add path.
- New `svc_restart` helper (`docker restart moav-<svc>`) — `docker compose restart` has the same `.env` problem.
- Dropped the pointless `sing-box reload` attempt (it always failed and logged "Hot reload failed"); restart is the only mechanism that works.
- **And we now verify**: after the restart, confirm the new UUID is in the *running* config, and warn loudly with the fix command if it isn't. A silently skipped apply is exactly what let this ship.

## Verified live (fresh v2 install, dashboard-created user)

| Protocol | Before | After |
|---|---|---|
| Reality | ❌ unknown UUID | ✅ exit IP correct |
| Trojan | ❌ | ✅ |
| Hysteria2 | ❌ auth failed | ✅ |
| Shadowsocks-2022 | ❌ | ✅ |
| CDN (VLESS+WS) | ❌ | ✅ |
| XHTTP (VLESS+XHTTP+Reality) | ❌ | ✅ |

Also confirmed the CLI path stays green, and that `moav test` on the *original* bundle passes once sing-box has actually applied the user.
