### PR TITLE
feat(bundle): name every config MoaV-<server>-<protocol>-<user>

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash tests/wg-keygen-fallback-test.sh
       - name: user UUID capture (no two-line double-capture)
         run: bash tests/uuid-capture-test.sh
+      - name: config naming (server label + wg 15-char limit)
+        run: bash tests/config-naming-test.sh
       - name: grafana branding non-fatal
         run: bash tests/grafana-branding-test.sh
       - name: env resolution golden-diff

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -227,13 +227,18 @@ jobs:
           # #220 regression: the AmneziaWG/WireGuard adds must COMPLETE (every
           # container call now has a deadline — a wedged exec used to freeze
           # `user add` forever) AND produce their client configs when enabled.
+          # Configs are named moav-<server>-awg.conf / -wg.conf (clients take the
+          # tunnel name from the filename); the plain names are what pre-rename
+          # bundles used. Accept either so this asserts "a config was produced",
+          # not "a particular filename spelling".
+          _have() { compgen -G "outputs/bundles/e2e-test/$1" >/dev/null; }
           if grep -qE '^ENABLE_AMNEZIAWG=true' .env; then
-            test -f outputs/bundles/e2e-test/amneziawg.conf \
-              || { echo "::error::AmneziaWG enabled but user add produced no amneziawg.conf (#220 regression)"; exit 1; }
+            _have 'moav-*-awg.conf' || _have 'amneziawg.conf' \
+              || { echo "::error::AmneziaWG enabled but user add produced no AmneziaWG config (#220 regression)"; exit 1; }
           fi
           if grep -qE '^ENABLE_WIREGUARD=true' .env; then
-            test -f outputs/bundles/e2e-test/wireguard.conf \
-              || { echo "::error::WireGuard enabled but user add produced no wireguard.conf"; exit 1; }
+            _have 'moav-*-wg.conf' || _have 'wireguard.conf' \
+              || { echo "::error::WireGuard enabled but user add produced no WireGuard config"; exit 1; }
           fi
 
       - name: Regression — added user survives a re-bootstrap (orphan guard)

--- a/admin/main.py
+++ b/admin/main.py
@@ -705,12 +705,15 @@ def list_users():
 
         # Check what files exist in the bundle
         has_reality = (user_dir / "reality.txt").exists()
-        has_wireguard = (user_dir / "wireguard.conf").exists()
+        # Either filename generation: bundles now ship moav-<server>-wg.conf,
+        # older ones wireguard.conf. Matching only one hides the protocol in the
+        # dashboard for users who plainly have it.
+        has_wireguard = bool(list(user_dir.glob("moav-*-wg.conf"))) or (user_dir / "wireguard.conf").exists()
         has_hysteria2 = (user_dir / "hysteria2.yaml").exists() or (user_dir / "hysteria2.txt").exists()
         has_trojan = (user_dir / "trojan.txt").exists()
         has_trusttunnel = (user_dir / "trusttunnel.toml").exists() or (user_dir / "trusttunnel.json").exists()
         has_cdn = (user_dir / "cdn-vless.txt").exists()
-        has_amneziawg = (user_dir / "amneziawg.conf").exists()
+        has_amneziawg = bool(list(user_dir.glob("moav-*-awg.conf"))) or (user_dir / "amneziawg.conf").exists()
         has_telemt = (user_dir / "telegram-proxy-link.txt").exists()
         has_xhttp = (user_dir / "xhttp-vless.txt").exists()
         has_xdns = (user_dir / "xdns-config.json").exists()

--- a/lib/migrate.sh
+++ b/lib/migrate.sh
@@ -481,22 +481,27 @@ cmd_migrate_ip() {
                     rm -f "$user_dir/trojan.txt.bak"
                 fi
 
-                # Update WireGuard direct config (wstunnel uses localhost, no change needed)
-                if [[ -f "$user_dir/wireguard.conf" ]]; then
-                    sed -i.bak "s/Endpoint = $old_ip:/Endpoint = $new_ip:/g" "$user_dir/wireguard.conf"
-                    rm -f "$user_dir/wireguard.conf.bak"
-                fi
+                # Update WireGuard direct config (wstunnel uses localhost, no change needed).
+                # Both filename generations: bundles now ship moav-<server>-wg.conf,
+                # older ones wireguard.conf. Missing either here would leave the
+                # user pointed at the OLD server IP after a migration, silently.
+                for _wgc in "$user_dir"/moav-*-wg.conf "$user_dir"/wireguard.conf; do
+                    [[ -f "$_wgc" ]] || continue
+                    sed -i.bak "s/Endpoint = $old_ip:/Endpoint = $new_ip:/g" "$_wgc"
+                    rm -f "$_wgc.bak"
+                done
 
                 # Update WireGuard IPv6 config if exists
-                if [[ -f "$user_dir/wireguard-ipv6.conf" ]] && [[ -n "$new_ipv6" ]]; then
+                for _wg6 in "$user_dir"/moav-*-wg6.conf "$user_dir"/wireguard-ipv6.conf; do
+                    [[ -f "$_wg6" ]] && [[ -n "$new_ipv6" ]] || continue
                     # Update IPv6 endpoint (format: [ipv6]:port)
                     if [[ -n "$old_ipv6" ]]; then
-                        sed -i.bak "s/Endpoint = \[$old_ipv6\]:/Endpoint = [$new_ipv6]:/g" "$user_dir/wireguard-ipv6.conf"
+                        sed -i.bak "s/Endpoint = \[$old_ipv6\]:/Endpoint = [$new_ipv6]:/g" "$_wg6"
                     else
-                        sed -i.bak "s/Endpoint = \[[^]]*\]:/Endpoint = [$new_ipv6]:/g" "$user_dir/wireguard-ipv6.conf"
+                        sed -i.bak "s/Endpoint = \[[^]]*\]:/Endpoint = [$new_ipv6]:/g" "$_wg6"
                     fi
-                    rm -f "$user_dir/wireguard-ipv6.conf.bak"
-                fi
+                    rm -f "$_wg6.bak"
+                done
 
                 # Update IPv6 link files if they exist
                 for ipv6_file in "$user_dir"/*-ipv6.txt; do
@@ -520,17 +525,19 @@ cmd_migrate_ip() {
                     rm -f "$user_dir/slipstream-instructions.txt.bak"
                 fi
 
-                # Update AmneziaWG configs
-                if [[ -f "$user_dir/amneziawg.conf" ]]; then
-                    sed -i.bak "s/Endpoint = $old_ip:/Endpoint = $new_ip:/g" "$user_dir/amneziawg.conf"
-                    rm -f "$user_dir/amneziawg.conf.bak"
-                fi
-                if [[ -f "$user_dir/amneziawg-ipv6.conf" ]] && [[ -n "$new_ipv6" ]]; then
+                # Update AmneziaWG configs (new moav-<server>-awg.conf and legacy)
+                for _awgc in "$user_dir"/moav-*-awg.conf "$user_dir"/amneziawg.conf; do
+                    [[ -f "$_awgc" ]] || continue
+                    sed -i.bak "s/Endpoint = $old_ip:/Endpoint = $new_ip:/g" "$_awgc"
+                    rm -f "$_awgc.bak"
+                done
+                for _awg6 in "$user_dir"/moav-*-awg6.conf "$user_dir"/amneziawg-ipv6.conf; do
+                    [[ -f "$_awg6" ]] && [[ -n "$new_ipv6" ]] || continue
                     if [[ -n "$old_ipv6" ]]; then
-                        sed -i.bak "s/Endpoint = \[$old_ipv6\]:/Endpoint = [$new_ipv6]:/g" "$user_dir/amneziawg-ipv6.conf"
+                        sed -i.bak "s/Endpoint = \[$old_ipv6\]:/Endpoint = [$new_ipv6]:/g" "$_awg6"
                     fi
-                    rm -f "$user_dir/amneziawg-ipv6.conf.bak"
-                fi
+                    rm -f "$_awg6.bak"
+                done
 
                 # Update Telegram MTProxy links
                 if [[ -f "$user_dir/telegram-proxy-link.txt" ]]; then
@@ -616,10 +623,12 @@ cmd_migrate_ip() {
                     fi
                 done
 
-                # WireGuard QR codes
-                if [[ -f "$user_dir/wireguard.conf" ]]; then
-                    qrencode -o "$user_dir/wireguard-qr.png" -s 6 -r "$user_dir/wireguard.conf" 2>/dev/null && ((qr_count++)) || true
-                fi
+                # WireGuard QR codes (new moav-<server>-wg.conf and legacy)
+                for _wgq in "$user_dir"/moav-*-wg.conf "$user_dir"/wireguard.conf; do
+                    [[ -f "$_wgq" ]] || continue
+                    qrencode -o "$user_dir/wireguard-qr.png" -s 6 -r "$_wgq" 2>/dev/null && ((qr_count++)) || true
+                    break
+                done
             fi
         done
         if [[ $qr_count -gt 0 ]]; then

--- a/scripts/client-connect.sh
+++ b/scripts/client-connect.sh
@@ -149,7 +149,9 @@ generate_singbox_config() {
             fi
             ;;
         wireguard)
-            for f in "$CONFIG_DIR"/wireguard.conf "$CONFIG_DIR"/wg.conf; do
+            # new-style moav-<server>-wg.conf first, then legacy names so
+            # bundles generated before the rename still test fine.
+            for f in "$CONFIG_DIR"/moav-*-wg.conf "$CONFIG_DIR"/wireguard.conf "$CONFIG_DIR"/wg.conf; do
                 [[ -f "$f" ]] && config_file="$f" && break
             done
             if [[ -z "$config_file" ]]; then
@@ -651,12 +653,13 @@ EOF
 connect_amneziawg() {
     local config_file=""
 
-    for f in "$CONFIG_DIR"/amneziawg.conf; do
+    # new-style moav-<server>-awg.conf first, then the legacy name.
+    for f in "$CONFIG_DIR"/moav-*-awg.conf "$CONFIG_DIR"/amneziawg.conf; do
         [[ -f "$f" ]] && config_file="$f" && break
     done
 
     if [[ -z "$config_file" ]]; then
-        log_error "No AmneziaWG config found (looking for amneziawg.conf in $CONFIG_DIR)"
+        log_error "No AmneziaWG config found (looking for moav-*-awg.conf or amneziawg.conf in $CONFIG_DIR)"
         return 1
     fi
 

--- a/scripts/generate-user.sh
+++ b/scripts/generate-user.sh
@@ -518,7 +518,7 @@ if [[ "${ENABLE_WIREGUARD:-true}" == "true" ]]; then
         qrencode -o "$OUTPUT_DIR/wireguard-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wg).conf" 2>/dev/null || true
         qrencode -o "$OUTPUT_DIR/wireguard-wstunnel-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wgws).conf" 2>/dev/null || true
         if [[ -n "${SERVER_IPV6:-}" ]] && [[ -f "$OUTPUT_DIR/$(moav_wg_basename wg6).conf" ]]; then
-            qrencode -o "$OUTPUT_DIR/wireguard-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/wireguard-ipv6.conf" 2>/dev/null || true
+            qrencode -o "$OUTPUT_DIR/wireguard-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wg6).conf" 2>/dev/null || true
         fi
         log_info "  - WireGuard config generated (direct + wstunnel${SERVER_IPV6:+ + ipv6})"
     fi
@@ -544,8 +544,8 @@ if [[ "${ENABLE_AMNEZIAWG:-true}" == "true" ]]; then
         BUNDLE_CHANGED=true
         amneziawg_generate_client_config "$USER_ID" "$OUTPUT_DIR"
         qrencode -o "$OUTPUT_DIR/amneziawg-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename awg).conf" 2>/dev/null || true
-        if [[ -n "${SERVER_IPV6:-}" ]] && [[ -f "$OUTPUT_DIR/amneziawg-ipv6.conf" ]]; then
-            qrencode -o "$OUTPUT_DIR/amneziawg-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/amneziawg-ipv6.conf" 2>/dev/null || true
+        if [[ -n "${SERVER_IPV6:-}" ]] && [[ -f "$OUTPUT_DIR/$(moav_wg_basename awg6).conf" ]]; then
+            qrencode -o "$OUTPUT_DIR/amneziawg-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename awg6).conf" 2>/dev/null || true
         fi
         log_info "  - AmneziaWG config generated (obfuscated WireGuard${SERVER_IPV6:+ + ipv6})"
     fi

--- a/scripts/generate-user.sh
+++ b/scripts/generate-user.sh
@@ -510,14 +510,14 @@ if [[ "${ENABLE_WIREGUARD:-true}" == "true" ]]; then
     _peer_rc=0; wireguard_add_peer "$USER_ID" || _peer_rc=$?
     if [[ "$_peer_rc" -eq 2 ]]; then
         log_warn "  - WireGuard left untouched for $USER_ID (no key material in state)"
-    elif [[ -f "$OUTPUT_DIR/wireguard.conf" ]] && [[ "$FORCE_REGENERATE" != "force" ]]; then
+    elif [[ -f "$OUTPUT_DIR/$(moav_wg_basename wg).conf" ]] && [[ "$FORCE_REGENERATE" != "force" ]]; then
         log_info "  - WireGuard config exists, skipping"
     else
         BUNDLE_CHANGED=true
         wireguard_generate_client_config "$USER_ID" "$OUTPUT_DIR"
-        qrencode -o "$OUTPUT_DIR/wireguard-qr.png" -s 6 -r "$OUTPUT_DIR/wireguard.conf" 2>/dev/null || true
-        qrencode -o "$OUTPUT_DIR/wireguard-wstunnel-qr.png" -s 6 -r "$OUTPUT_DIR/wireguard-wstunnel.conf" 2>/dev/null || true
-        if [[ -n "${SERVER_IPV6:-}" ]] && [[ -f "$OUTPUT_DIR/wireguard-ipv6.conf" ]]; then
+        qrencode -o "$OUTPUT_DIR/wireguard-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wg).conf" 2>/dev/null || true
+        qrencode -o "$OUTPUT_DIR/wireguard-wstunnel-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wgws).conf" 2>/dev/null || true
+        if [[ -n "${SERVER_IPV6:-}" ]] && [[ -f "$OUTPUT_DIR/$(moav_wg_basename wg6).conf" ]]; then
             qrencode -o "$OUTPUT_DIR/wireguard-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/wireguard-ipv6.conf" 2>/dev/null || true
         fi
         log_info "  - WireGuard config generated (direct + wstunnel${SERVER_IPV6:+ + ipv6})"
@@ -538,12 +538,12 @@ if [[ "${ENABLE_AMNEZIAWG:-true}" == "true" ]]; then
     _peer_rc=0; amneziawg_add_peer "$USER_ID" || _peer_rc=$?
     if [[ "$_peer_rc" -eq 2 ]]; then
         log_warn "  - AmneziaWG left untouched for $USER_ID (no key material in state)"
-    elif [[ -f "$OUTPUT_DIR/amneziawg.conf" ]] && [[ "$FORCE_REGENERATE" != "force" ]]; then
+    elif [[ -f "$OUTPUT_DIR/$(moav_wg_basename awg).conf" ]] && [[ "$FORCE_REGENERATE" != "force" ]]; then
         log_info "  - AmneziaWG config exists, skipping"
     else
         BUNDLE_CHANGED=true
         amneziawg_generate_client_config "$USER_ID" "$OUTPUT_DIR"
-        qrencode -o "$OUTPUT_DIR/amneziawg-qr.png" -s 6 -r "$OUTPUT_DIR/amneziawg.conf" 2>/dev/null || true
+        qrencode -o "$OUTPUT_DIR/amneziawg-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename awg).conf" 2>/dev/null || true
         if [[ -n "${SERVER_IPV6:-}" ]] && [[ -f "$OUTPUT_DIR/amneziawg-ipv6.conf" ]]; then
             qrencode -o "$OUTPUT_DIR/amneziawg-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/amneziawg-ipv6.conf" 2>/dev/null || true
         fi

--- a/scripts/lib/amneziawg.sh
+++ b/scripts/lib/amneziawg.sh
@@ -255,7 +255,7 @@ amneziawg_generate_client_config() {
     fi
 
     # AmneziaWG client config (includes obfuscation params)
-    cat > "$output_dir/amneziawg.conf" <<EOF
+    cat > "$output_dir/$(moav_wg_basename awg).conf" <<EOF
 [Interface]
 PrivateKey = $AWG_PRIVATE_KEY
 Address = $client_addresses
@@ -280,7 +280,7 @@ EOF
 
     # Generate IPv6 endpoint config if available
     if [[ -n "${SERVER_IPV6:-}" ]]; then
-        cat > "$output_dir/amneziawg-ipv6.conf" <<EOF
+        cat > "$output_dir/$(moav_wg_basename awg6).conf" <<EOF
 [Interface]
 PrivateKey = $AWG_PRIVATE_KEY
 Address = $client_addresses

--- a/scripts/lib/amneziawg.sh
+++ b/scripts/lib/amneziawg.sh
@@ -305,5 +305,9 @@ EOF
         log_info "Generated AmneziaWG IPv6 endpoint config"
     fi
 
+    # Same as WireGuard: remove the pre-rename filenames so a regenerated bundle
+    # never ships a stale second copy of the tunnel.
+    rm -f "$output_dir/amneziawg.conf" "$output_dir/amneziawg-ipv6.conf" 2>/dev/null || true
+
     log_info "Generated AmneziaWG client config for $user_id"
 }

--- a/scripts/lib/bundle_readme.py
+++ b/scripts/lib/bundle_readme.py
@@ -72,7 +72,13 @@ def val_or(value, fallback):
 
 
 def _hide(name):       # "" (show) if the artifact exists in the bundle, else CSS hide
-    return "" if os.path.isfile(os.path.join(OUT, name)) else "display:none"
+    # Through _candidates, so a renamed WireGuard config (moav-<server>-wg.conf)
+    # still shows its section. A direct isfile() here would embed the config via
+    # _read() and then CSS-hide the section containing it.
+    for candidate in _candidates(name):
+        if os.path.isfile(os.path.join(OUT, candidate)):
+            return ""
+    return "display:none"
 
 
 # MasterDNS/GooseRelay can't be generated on the host path (server-shared key

--- a/scripts/lib/bundle_readme.py
+++ b/scripts/lib/bundle_readme.py
@@ -6,6 +6,7 @@ One pass, pure Python: no sed (so no BSD/GNU flavor split), multiline configs an
 passwords with shell-special chars handled natively. subscription.txt is written
 UNCONDITIONALLY (empty when the bundle has no V2Ray-compatible links)."""
 import base64
+import glob
 import os
 import re
 
@@ -14,11 +15,36 @@ CONTEXT = os.environ.get("RB_CONTEXT", "container")
 
 
 def _read(name):
-    try:
-        with open(os.path.join(OUT, name), encoding="utf-8", errors="replace") as f:
-            return f.read()
-    except OSError:
-        return ""
+    for candidate in _candidates(name):
+        try:
+            with open(os.path.join(OUT, candidate), encoding="utf-8", errors="replace") as f:
+                return f.read()
+        except OSError:
+            continue
+    return ""
+
+
+def _candidates(name):
+    """Resolve a logical bundle file to what is actually on disk.
+
+    WireGuard-family configs are named moav-<server>-wg.conf now (clients take
+    the tunnel name from the filename), but bundles generated before the rename
+    use the plain names — and a stale guide would show "No WireGuard config
+    available" for a config that is sitting right there. Try the new glob first,
+    then the legacy name.
+    """
+    globs = {
+        "wireguard.conf":          "moav-*-wg.conf",
+        "wireguard-wstunnel.conf": "moav-*-wgws.conf",
+        "wireguard-ipv6.conf":     "moav-*-wg6.conf",
+        "amneziawg.conf":          "moav-*-awg.conf",
+        "amneziawg-ipv6.conf":     "moav-*-awg6.conf",
+    }
+    pattern = globs.get(name)
+    if pattern:
+        for hit in sorted(glob.glob(os.path.join(OUT, pattern))):
+            yield os.path.basename(hit)
+    yield name
 
 
 def link(name):        # single-line share link (.txt)

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -135,6 +135,36 @@ svc_running() {
     "${t[@]}" docker ps --filter "name=^/moav-${1}$" --filter status=running -q 2>/dev/null | grep -q .
 }
 
+# moav_server_label — short human label for THIS server, used in every config
+# name so a user importing bundles from several MoaV servers can tell them
+# apart in the VPN app list. DOMAIN's first label (yorkschool.xyz ->
+# yorkschool), else SERVER_IP, else "moav".
+moav_server_label() {
+    local d="${DOMAIN:-}" ip="${SERVER_IP:-}"
+    if [[ -n "$d" ]]; then printf '%s' "${d%%.*}"
+    elif [[ -n "$ip" ]]; then printf '%s' "$ip"
+    fi   # neither: empty, so names stay "MoaV-Reality-alice" / "moav-wg.conf"
+}
+
+# moav_name_prefix — "MoaV-<server>-" for share-link fragments and config
+# remarks. Emits "MoaV-" when there is no label, so a name can never come out
+# as "MoaV--Reality-alice".
+moav_name_prefix() {
+    local l; l=$(moav_server_label)
+    if [[ -n "$l" ]]; then printf 'MoaV-%s-' "$l"; else printf 'MoaV-'; fi
+}
+
+# moav_wg_basename <wg|awg|wgws> — basename (no .conf) for a WireGuard-family
+# config. WireGuard clients take the tunnel name from the FILENAME, and Linux
+# `wg-quick` turns that basename into a network interface, which the kernel
+# caps at 15 characters (verified: 15 accepted, 16 rejected). "moav-" + label +
+# "-wgws" is the longest form, so the label gets 5 characters.
+moav_wg_basename() {
+    local sfx="$1" lbl
+    lbl=$(moav_server_label | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9' | cut -c1-5)
+    if [[ -n "$lbl" ]]; then printf 'moav-%s-%s' "$lbl" "$sfx"; else printf 'moav-%s' "$sfx"; fi
+}
+
 # svc_restart <service> — restart by container name. `docker compose restart`
 # needs the compose file + .env interpolation, which the admin container cannot
 # do; a skipped restart is silent and total: sing-box runs from a COPY of the

--- a/scripts/lib/sing-box.sh
+++ b/scripts/lib/sing-box.sh
@@ -52,29 +52,29 @@ singbox_add_user() {
 
 singbox_reality_link() {
     local label="$1" host="$2"
-    echo "vless://${USER_UUID}@${host}:443?encryption=none&flow=xtls-rprx-vision&security=reality&sni=${REALITY_TARGET_HOST}&fp=random&pbk=${REALITY_PUBLIC_KEY}&sid=${REALITY_SHORT_ID}&type=tcp#MoaV-Reality-${label}"
+    echo "vless://${USER_UUID}@${host}:443?encryption=none&flow=xtls-rprx-vision&security=reality&sni=${REALITY_TARGET_HOST}&fp=random&pbk=${REALITY_PUBLIC_KEY}&sid=${REALITY_SHORT_ID}&type=tcp#$(moav_name_prefix)Reality-${label}"
 }
 
 singbox_trojan_link() {
     local label="$1" host="$2"
-    echo "trojan://${USER_PASSWORD}@${host}:8443?security=tls&sni=${DOMAIN}&type=tcp#MoaV-Trojan-${label}"
+    echo "trojan://${USER_PASSWORD}@${host}:8443?security=tls&sni=${DOMAIN}&type=tcp#$(moav_name_prefix)Trojan-${label}"
 }
 
 singbox_anytls_link() {
     local label="$1" host="$2"
-    echo "anytls://${USER_PASSWORD}@${host}:${PORT_ANYTLS:-8445}?sni=${DOMAIN}&insecure=0#MoaV-AnyTLS-${label}"
+    echo "anytls://${USER_PASSWORD}@${host}:${PORT_ANYTLS:-8445}?sni=${DOMAIN}&insecure=0#$(moav_name_prefix)AnyTLS-${label}"
 }
 
 singbox_hysteria2_link() {
     local label="$1" host="$2"
-    echo "hysteria2://${USER_PASSWORD}@${host}:443?sni=${DOMAIN}&obfs=salamander&obfs-password=${HYSTERIA2_OBFS_PASSWORD}#MoaV-Hysteria2-${label}"
+    echo "hysteria2://${USER_PASSWORD}@${host}:443?sni=${DOMAIN}&obfs=salamander&obfs-password=${HYSTERIA2_OBFS_PASSWORD}#$(moav_name_prefix)Hysteria2-${label}"
 }
 
 # CDN routes through a fronting address (CDN_ADDRESS), not the server IP, so it
 # has no IPv6 variant — only the label varies.
 singbox_cdn_link() {
     local label="$1"
-    echo "vless://${USER_UUID}@${CDN_ADDRESS}:443?security=tls&type=${CDN_TRANSPORT}&path=${CDN_WS_PATH}&sni=${CDN_SNI}&host=${CDN_DOMAIN}&fp=random&alpn=http/1.1#MoaV-CDN-${label}"
+    echo "vless://${USER_UUID}@${CDN_ADDRESS}:443?security=tls&type=${CDN_TRANSPORT}&path=${CDN_WS_PATH}&sni=${CDN_SNI}&host=${CDN_DOMAIN}&fp=random&alpn=http/1.1#$(moav_name_prefix)CDN-${label}"
 }
 
 # Shadowsocks-2022 SIP002 userinfo: BASE64URL_NOPAD(method:server_psk:user_psk).
@@ -87,5 +87,5 @@ singbox_ss_userinfo() {
 # host are passed so one builder serves IPv4 and IPv6.
 singbox_ss_link() {
     local label="$1" host="$2" userinfo="$3" port="$4"
-    echo "ss://${userinfo}@${host}:${port}#MoaV-Shadowsocks-${label}"
+    echo "ss://${userinfo}@${host}:${port}#$(moav_name_prefix)Shadowsocks-${label}"
 }

--- a/scripts/lib/wireguard.sh
+++ b/scripts/lib/wireguard.sh
@@ -227,5 +227,11 @@ Endpoint = 127.0.0.1:51820
 PersistentKeepalive = 25
 EOF
 
+    # Drop the pre-rename filenames. A regenerated bundle would otherwise ship
+    # two copies of the same tunnel — and the stale one still carries the old
+    # keys/endpoint, so importing it looks fine and silently fails to connect.
+    rm -f "$output_dir/wireguard.conf" "$output_dir/wireguard-wstunnel.conf" \
+          "$output_dir/wireguard-ipv6.conf" 2>/dev/null || true
+
     log_info "Generated WireGuard client config for $user_id"
 }

--- a/scripts/lib/wireguard.sh
+++ b/scripts/lib/wireguard.sh
@@ -179,7 +179,7 @@ wireguard_generate_client_config() {
     fi
 
     # Direct WireGuard config (IPv4 endpoint)
-    cat > "$output_dir/wireguard.conf" <<EOF
+    cat > "$output_dir/$(moav_wg_basename wg).conf" <<EOF
 [Interface]
 PrivateKey = $WG_PRIVATE_KEY
 Address = $client_addresses
@@ -195,7 +195,7 @@ EOF
 
     # Generate IPv6 endpoint config if available
     if [[ -n "${SERVER_IPV6:-}" ]]; then
-        cat > "$output_dir/wireguard-ipv6.conf" <<EOF
+        cat > "$output_dir/$(moav_wg_basename wg6).conf" <<EOF
 [Interface]
 PrivateKey = $WG_PRIVATE_KEY
 Address = $client_addresses
@@ -213,7 +213,7 @@ EOF
 
     # WireGuard-wstunnel config (for censored networks)
     # Points to localhost - user must run wstunnel client first
-    cat > "$output_dir/wireguard-wstunnel.conf" <<EOF
+    cat > "$output_dir/$(moav_wg_basename wgws).conf" <<EOF
 [Interface]
 PrivateKey = $WG_PRIVATE_KEY
 Address = $client_addresses

--- a/scripts/lib/xray.sh
+++ b/scripts/lib/xray.sh
@@ -45,7 +45,7 @@ xray_xhttp_link() {
     local target="${XHTTP_REALITY_TARGET:-${REALITY_TARGET:-dl.google.com:443}}"
     local host="${target%%:*}"
     local port="${PORT_XHTTP:-2096}"
-    echo "vless://${USER_UUID}@${SERVER_IP}:${port}?type=xhttp&security=reality&sni=${host}&fp=chrome&headers=chrome&pbk=${REALITY_PUBLIC_KEY}&sid=${REALITY_SHORT_ID}&encryption=none#MoaV-XHTTP-${label}"
+    echo "vless://${USER_UUID}@${SERVER_IP}:${port}?type=xhttp&security=reality&sni=${host}&fp=chrome&headers=chrome&pbk=${REALITY_PUBLIC_KEY}&sid=${REALITY_SHORT_ID}&encryption=none#$(moav_name_prefix)XHTTP-${label}"
 }
 
 # xray_write_xhttp_bundle <output_dir> <label> — writes xhttp-vless.txt (the
@@ -116,7 +116,7 @@ xray_write_xdns_bundle() {
 
     cat > "$out/xdns-config.json" <<XDNSEOF
 {
-  "remarks": "MoaV-XDNS-${label} (via DNS)",
+  "remarks": "$(moav_name_prefix)XDNS-${label} (via DNS)",
   "log": {"loglevel": "warning"},
   "inbounds": [{"listen": "127.0.0.1", "port": 7891, "protocol": "socks", "settings": {"auth": "noauth", "udp": true}}],
   "outbounds": [
@@ -129,7 +129,7 @@ XDNSEOF
 
     cat > "$out/xdns-direct-config.json" <<XDNSEOF2
 {
-  "remarks": "MoaV-XDNS-${label} (direct)",
+  "remarks": "$(moav_name_prefix)XDNS-${label} (direct)",
   "log": {"loglevel": "warning"},
   "inbounds": [{"listen": "127.0.0.1", "port": 7891, "protocol": "socks", "settings": {"auth": "noauth", "udp": true}}],
   "outbounds": [

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -380,8 +380,8 @@ for USERNAME in "${USERNAMES[@]}"; do
             amneziawg_generate_client_config "$USERNAME" "$OUTPUT_DIR"
 
             qrencode -o "$OUTPUT_DIR/amneziawg-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename awg).conf" 2>/dev/null || true
-            if [[ -f "$OUTPUT_DIR/amneziawg-ipv6.conf" ]]; then
-                qrencode -o "$OUTPUT_DIR/amneziawg-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/amneziawg-ipv6.conf" 2>/dev/null || true
+            if [[ -f "$OUTPUT_DIR/$(moav_wg_basename awg6).conf" ]]; then
+                qrencode -o "$OUTPUT_DIR/amneziawg-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename awg6).conf" 2>/dev/null || true
             fi
         ) && log_info "✓ AmneziaWG peer added" || {
             ERRORS+=("amneziawg")

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -379,7 +379,7 @@ for USERNAME in "${USERNAMES[@]}"; do
             # before the loop); honors SERVER_IPV6 + PORT_AMNEZIAWG.
             amneziawg_generate_client_config "$USERNAME" "$OUTPUT_DIR"
 
-            qrencode -o "$OUTPUT_DIR/amneziawg-qr.png" -s 6 -r "$OUTPUT_DIR/amneziawg.conf" 2>/dev/null || true
+            qrencode -o "$OUTPUT_DIR/amneziawg-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename awg).conf" 2>/dev/null || true
             if [[ -f "$OUTPUT_DIR/amneziawg-ipv6.conf" ]]; then
                 qrencode -o "$OUTPUT_DIR/amneziawg-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/amneziawg-ipv6.conf" 2>/dev/null || true
             fi

--- a/scripts/wg-user-add.sh
+++ b/scripts/wg-user-add.sh
@@ -195,34 +195,34 @@ if [[ -n "$CLIENT_IP_V6" ]]; then
 fi
 echo ""
 echo "Configs generated:"
-echo "  - wireguard.conf          (direct mode - IPv4 endpoint)"
+echo "  - $(moav_wg_basename wg).conf        (direct mode - IPv4 endpoint)"
 if [[ -n "$SERVER_IPV6" ]]; then
-    echo "  - wireguard-ipv6.conf     (direct mode - IPv6 endpoint)"
+    echo "  - $(moav_wg_basename wg6).conf       (direct mode - IPv6 endpoint)"
 fi
-echo "  - wireguard-wstunnel.conf (wstunnel mode - for restrictive networks)"
+echo "  - $(moav_wg_basename wgws).conf      (wstunnel mode - for restrictive networks)"
 echo ""
 
 # Generate QR images for user bundle
 if command -v qrencode &>/dev/null; then
-    qrencode -o "$OUTPUT_DIR/wireguard-qr.png" -s 6 -r "$OUTPUT_DIR/wireguard.conf" 2>/dev/null && \
+    qrencode -o "$OUTPUT_DIR/wireguard-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wg).conf" 2>/dev/null && \
         log_info "QR image saved to: $OUTPUT_DIR/wireguard-qr.png"
 
     # IPv6 QR code
     if [[ -n "$SERVER_IPV6" ]]; then
-        qrencode -o "$OUTPUT_DIR/wireguard-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/wireguard-ipv6.conf" 2>/dev/null && \
+        qrencode -o "$OUTPUT_DIR/wireguard-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wg6).conf" 2>/dev/null && \
             log_info "IPv6 QR image saved to: $OUTPUT_DIR/wireguard-ipv6-qr.png"
     fi
 
     # wstunnel QR code
-    qrencode -o "$OUTPUT_DIR/wireguard-wstunnel-qr.png" -s 6 -r "$OUTPUT_DIR/wireguard-wstunnel.conf" 2>/dev/null && \
+    qrencode -o "$OUTPUT_DIR/wireguard-wstunnel-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wgws).conf" 2>/dev/null && \
         log_info "wstunnel QR image saved to: $OUTPUT_DIR/wireguard-wstunnel-qr.png"
 fi
 
 echo ""
 echo "=== Direct Config (use this for mobile) ==="
-cat "$OUTPUT_DIR/wireguard.conf"
+cat "$OUTPUT_DIR/$(moav_wg_basename wg).conf"
 echo ""
 echo "=== wstunnel Mode (for restrictive networks) ==="
 echo "Run wstunnel first:"
 echo "  ${WSTUNNEL_CMD}"
-echo "Then use wireguard-wstunnel.conf"
+echo "Then use $(moav_wg_basename wgws).conf"

--- a/tests/cli-smoke-test.sh
+++ b/tests/cli-smoke-test.sh
@@ -20,13 +20,38 @@ SMOKE_USER="clismoke$$"
 TIMEOUT=120
 pass=0 fail=0
 
+# GNU timeout is how a hang is caught, but it is not everywhere (macOS ships
+# BSD tools; coreutils installs it as gtimeout). Without this guard every check
+# died with "timeout: command not found" -> exit 127, which `info` mode then
+# reported as ok — 19 red lines and several false greens that said nothing about
+# moav. Prefer timeout, then gtimeout, else run the command directly and say
+# once that hang detection is off.
+TIMEOUT_BIN=""
+for _t in timeout gtimeout; do
+    command -v "$_t" >/dev/null 2>&1 && { TIMEOUT_BIN="$_t"; break; }
+done
+[[ -z "$TIMEOUT_BIN" ]] && echo "note: no timeout/gtimeout on this host — running without hang detection"
+
 run() {
     local mode="$1" desc="$2"; shift 2
     [[ "${1:-}" == "--" ]] && shift
     local out rc
-    out=$(timeout "$TIMEOUT" "$@" 2>&1); rc=$?
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+        out=$("$TIMEOUT_BIN" "$TIMEOUT" "$@" 2>&1); rc=$?
+    else
+        out=$("$@" 2>&1); rc=$?
+    fi
     if [[ $rc -eq 124 ]]; then
         echo "FAIL $desc (TIMED OUT after ${TIMEOUT}s — command hangs)"
+        echo "$out" | tail -4 | sed 's/^/       | /'
+        fail=$((fail + 1)); return
+    fi
+    # 127/126 are never a legitimate state-dependent exit: the command is
+    # missing or not executable. `info` mode used to wave these through, so a
+    # vanished subcommand or a typo in this file reported "ok".
+    if [[ $rc -eq 127 || $rc -eq 126 ]]; then
+        echo "FAIL $desc (exit $rc — command not found or not executable)"
+        echo "$out" | tail -4 | sed 's/^/       | /'
         fail=$((fail + 1)); return
     fi
     if [[ "$mode" == "must" && $rc -ne 0 ]]; then
@@ -37,6 +62,23 @@ run() {
     echo "ok   $desc (exit $rc)"
     pass=$((pass + 1))
 }
+
+# Preconditions. This battery drives a LIVE stack through ./moav.sh, which
+# itself requires bash >= 4. Without those, every check fails for the same
+# uninteresting reason (on macOS's bash 3.2 that was 19 red lines carrying
+# moav's version notice, nothing about moav's behaviour). Say so once and exit 2
+# (skipped) rather than 0, so a CI job can never mistake "not run" for "passed".
+if [[ -z "${BASH_VERSINFO:-}" ]] || (( BASH_VERSINFO[0] < 4 )); then
+    echo "SKIP: moav requires bash 4.0 or newer (found ${BASH_VERSION:-unknown})."
+    echo "      Run this on the server, or: brew install bash && /opt/homebrew/bin/bash $0"
+    exit 2
+fi
+
+if [[ ! -x "$MOAV" ]]; then
+    echo "SKIP: $MOAV not found — run this from the repo root of a live install:"
+    echo "      ./moav.sh start all && bash tests/cli-smoke-test.sh"
+    exit 2
+fi
 
 echo "============================================================"
 echo "  moav CLI smoke test"

--- a/tests/client-test.sh
+++ b/tests/client-test.sh
@@ -19,6 +19,17 @@ TEST_URL="${TEST_URL:-https://www.google.com/generate_204}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-10}"
 TEMP_DIR="/tmp/moav-test-$$"
 
+# Requires bash >= 4: this script uses associative arrays (declare -A) for the
+# per-protocol results, exactly like moav.sh's own guard. On macOS's bash 3.2 it
+# used to die at the first `declare -A` with "invalid option" and then EXIT 0 --
+# a crashed run reporting success. Fail loudly and distinctly (2 = could not
+# run, not "all protocols fine").
+if [[ -z "${BASH_VERSINFO:-}" ]] || (( BASH_VERSINFO[0] < 4 )); then
+    echo "moav test requires bash 4.0 or newer (found ${BASH_VERSION:-unknown})." >&2
+    echo "macOS ships bash 3.2; run it on the server, or: brew install bash" >&2
+    exit 2
+fi
+
 # Results storage
 declare -A RESULTS
 declare -A DETAILS

--- a/tests/client-test.sh
+++ b/tests/client-test.sh
@@ -985,7 +985,9 @@ test_wireguard() {
     local is_ipv6=false
 
     # Find WireGuard config - prefer IPv4 over IPv6
-    for f in "$CONFIG_DIR"/wireguard.conf "$CONFIG_DIR"/wg.conf; do
+    # new-style moav-<server>-wg.conf first, then the legacy names so bundles
+    # generated before the rename still validate.
+    for f in "$CONFIG_DIR"/moav-*-wg.conf "$CONFIG_DIR"/wireguard.conf "$CONFIG_DIR"/wg.conf; do
         [[ -f "$f" ]] && config_file="$f" && break
     done
     if [[ -z "$config_file" ]]; then
@@ -1149,7 +1151,7 @@ test_amneziawg() {
     local detail=""
 
     # Find AmneziaWG config
-    for f in "$CONFIG_DIR"/amneziawg.conf; do
+    for f in "$CONFIG_DIR"/moav-*-awg.conf "$CONFIG_DIR"/amneziawg.conf; do
         [[ -f "$f" ]] && config_file="$f" && break
     done
     if [[ -z "$config_file" ]]; then
@@ -2154,7 +2156,7 @@ test_wstunnel() {
     log_info "Testing WireGuard-over-wstunnel..."
 
     local conf="" detail=""
-    for f in "$CONFIG_DIR"/wireguard-wstunnel.conf; do
+    for f in "$CONFIG_DIR"/moav-*-wgws.conf "$CONFIG_DIR"/wireguard-wstunnel.conf; do
         [[ -f "$f" ]] && conf="$f" && break
     done
     if [[ -z "$conf" ]]; then

--- a/tests/config-naming-test.sh
+++ b/tests/config-naming-test.sh
@@ -100,6 +100,51 @@ else
     bad "the wg-family globs overlap — a lookup could pick the wrong config"
 fi
 
+# --- everything that TOUCHES a bundle config must know both names ------------
+# Found by auditing, each one a silent failure rather than an error:
+#   migrate.sh   — rewrites Endpoint= on a server move. Missing the file leaves
+#                  users pointed at the OLD server IP, with a config that looks
+#                  fine and never connects.
+#   admin/main.py— decides whether a user "has" WireGuard in the dashboard.
+#   bundle_readme— _hide() CSS-hides a section whose config is embedded above it.
+grep -q 'moav-\*-wg\.conf' "$ROOT/lib/migrate.sh" && grep -q 'moav-\*-awg\.conf' "$ROOT/lib/migrate.sh" \
+    && ok "migrate.sh rewrites endpoints in renamed wg AND awg configs" \
+    || bad "migrate.sh misses renamed configs — a server move leaves users on the old IP"
+grep -q 'moav-\*-wg6\.conf' "$ROOT/lib/migrate.sh" \
+    && ok "migrate.sh covers the renamed IPv6 configs" \
+    || bad "migrate.sh misses the renamed IPv6 configs"
+grep -q 'glob("moav-\*-wg\.conf")' "$ROOT/admin/main.py" && grep -q 'glob("moav-\*-awg\.conf")' "$ROOT/admin/main.py" \
+    && ok "dashboard detects wg/awg under either name" \
+    || bad "dashboard would show users as having no WireGuard/AmneziaWG"
+grep -A6 'def _hide' "$ROOT/scripts/lib/bundle_readme.py" | grep -q '_candidates' \
+    && ok "_hide resolves renamed configs (section not CSS-hidden)" \
+    || bad "_hide uses a raw isfile — the guide embeds the config then hides the section"
+
+# --- regenerating a pre-rename bundle must not leave a stale duplicate --------
+# The stale copy still carries the old keys/endpoint, so importing it looks fine
+# and silently fails to connect.
+for f in wireguard amneziawg; do
+    if grep -qE "rm -f .*\\\$output_dir/${f}\.conf" "$ROOT/scripts/lib/${f}.sh"; then
+        ok "${f}.sh removes the pre-rename config when regenerating"
+    else
+        bad "${f}.sh leaves a stale ${f}.conf next to the renamed one after regenerate-users"
+    fi
+done
+
+# --- the integration harnesses must not report success when they cannot run --
+# client-test.sh used declare -A (bash 4) and, on bash 3.2, died at that line
+# and still exited 0: a crashed run reporting "all protocols fine".
+for t in client-test.sh cli-smoke-test.sh; do
+    if grep -q 'BASH_VERSINFO' "$ROOT/tests/$t"; then
+        ok "$t refuses to run (non-zero) on bash < 4 instead of reporting success"
+    else
+        bad "$t has no bash-4 guard — it can crash and still exit 0"
+    fi
+done
+grep -q 'rc -eq 127' "$ROOT/tests/cli-smoke-test.sh" \
+    && ok "cli-smoke-test treats command-not-found as a failure, not 'ok'" \
+    || bad "cli-smoke-test still reports 'ok' for exit 127"
+
 echo
 echo "  $pass passed, $fail failed"
 [[ $fail -eq 0 ]]

--- a/tests/config-naming-test.sh
+++ b/tests/config-naming-test.sh
@@ -131,6 +131,23 @@ for f in wireguard amneziawg; do
     fi
 done
 
+# --- the e2e workflow asserts on bundle contents too -------------------------
+# Missed in the first audit (which only swept scripts/ lib/ admin/ tests/) and
+# caught by e2e itself: the workflow test -f'd amneziawg.conf, so a correctly
+# renamed bundle failed with "AmneziaWG enabled but user add produced no
+# amneziawg.conf". Assert on "a config exists", not on one spelling.
+E2E="$ROOT/.github/workflows/e2e.yml"
+if [ -f "$E2E" ]; then
+    if grep -qE "test -f outputs/bundles/[^ ]*/(wireguard|amneziawg)\.conf" "$E2E"; then
+        bad "e2e.yml still asserts a literal wireguard/amneziawg.conf filename"
+    else
+        ok "e2e.yml does not assert a literal pre-rename filename"
+    fi
+    grep -q "moav-\*-awg.conf" "$E2E" && grep -q "moav-\*-wg.conf" "$E2E" \
+        && ok "e2e.yml accepts the renamed wg and awg configs" \
+        || bad "e2e.yml does not accept the renamed configs — every e2e run will fail"
+fi
+
 # --- the integration harnesses must not report success when they cannot run --
 # client-test.sh used declare -A (bash 4) and, on bash 3.2, died at that line
 # and still exited 0: a crashed run reporting "all protocols fine".

--- a/tests/config-naming-test.sh
+++ b/tests/config-naming-test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Regression test: every config in a user bundle carries an identifiable name.
+#
+# Share links already ended in "#MoaV-<Protocol>-<user>", but WireGuard-family
+# configs carry no name field at all -- clients take the tunnel name from the
+# FILENAME -- so every server's WireGuard tunnel imported as "wireguard" and
+# users with several MoaV servers could not tell them apart.
+#
+# Names now include the server: "MoaV-<server>-<Protocol>-<user>", where
+# <server> is DOMAIN's first label (yorkschool.xyz -> yorkschool).
+#
+# The WireGuard filenames are a special case. Linux `wg-quick` turns the
+# basename into a network interface, and the kernel caps interface names at 15
+# characters (verified on a live box: 15 accepted, 16 rejected). So they use the
+# short form moav-<label5>-<wg|awg|wgws>, which is <=15 for every input.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "config naming tests"
+
+# shellcheck disable=SC1091
+source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1 || { echo "cannot source common.sh"; exit 1; }
+
+# --- the 15-char interface-name budget, for every label source ---------------
+# wgws is the longest suffix, so it is the binding case.
+_len_ok() { [ ${#1} -le 15 ]; }
+for spec in "yorkschool.xyz|" "mycoolserver.example.com|" "a.io|" "|203.0.113.9" "|"; do
+    d="${spec%%|*}"; ip="${spec##*|}"
+    over=""
+    for sfx in wg awg wgws wg6 awg6; do
+        n=$(DOMAIN="$d" SERVER_IP="$ip" moav_wg_basename "$sfx")
+        _len_ok "$n" || over="$over $n(${#n})"
+    done
+    label="DOMAIN='${d:-none}' SERVER_IP='${ip:-none}'"
+    [ -z "$over" ] && ok "wg basenames <=15 chars for $label" \
+                   || bad "interface name too long for $label:$over — wg-quick will fail"
+done
+
+# --- the name prefix must never produce a double dash or a bare "MoaV-" gap --
+p=$(DOMAIN=yorkschool.xyz SERVER_IP= moav_name_prefix)
+[ "$p" = "MoaV-yorkschool-" ] && ok "domain gives the server label ($p)" \
+                              || bad "unexpected prefix with a domain: [$p]"
+p=$(DOMAIN= SERVER_IP=203.0.113.9 moav_name_prefix)
+[ "$p" = "MoaV-203.0.113.9-" ] && ok "domainless install falls back to the IP ($p)" \
+                               || bad "unexpected prefix with only an IP: [$p]"
+p=$(DOMAIN= SERVER_IP= moav_name_prefix)
+[ "$p" = "MoaV-" ] && ok "no domain and no IP degrades to plain MoaV- (no 'MoaV--')" \
+                   || bad "bad prefix with neither domain nor IP: [$p]"
+n=$(DOMAIN= SERVER_IP= moav_wg_basename wg)
+[ "$n" = "moav-wg" ] && ok "no label gives moav-wg, not moav--wg" || bad "bad basename with no label: [$n]"
+
+# --- share links carry the server label --------------------------------------
+# shellcheck disable=SC1091
+source "$ROOT/scripts/lib/sing-box.sh" >/dev/null 2>&1
+export USER_UUID=11111111-2222-3333-4444-555555555555 USER_PASSWORD=pw
+export DOMAIN=vpn.example.com REALITY_TARGET_HOST=www.cloudflare.com
+export REALITY_PUBLIC_KEY=k REALITY_SHORT_ID=s SERVER_IP=203.0.113.9
+link=$(singbox_reality_link alice 203.0.113.9)
+case "$link" in
+    *"#MoaV-vpn-Reality-alice") ok "reality link is named MoaV-<server>-Reality-<user>" ;;
+    *"#MoaV--"*)                bad "double dash in the link name: ${link##*#}" ;;
+    *)                          bad "unexpected reality link name: ${link##*#}" ;;
+esac
+
+# --- readers must accept BOTH the new and the legacy filenames ---------------
+# Bundles generated before the rename still have to validate, and the bundle
+# guide must not print "No WireGuard config available" for a config that is
+# sitting right there under its new name.
+for f in tests/client-test.sh scripts/client-connect.sh; do
+    src="$ROOT/$f"
+    [ -f "$src" ] || continue
+    if grep -q 'moav-\*-wg\.conf' "$src" && grep -q 'wireguard\.conf' "$src"; then
+        ok "$(basename "$f") looks up both new and legacy WireGuard names"
+    else
+        bad "$(basename "$f") does not handle both new and legacy WireGuard names"
+    fi
+    if grep -q 'moav-\*-awg\.conf' "$src" && grep -q 'amneziawg\.conf' "$src"; then
+        ok "$(basename "$f") looks up both new and legacy AmneziaWG names"
+    else
+        bad "$(basename "$f") does not handle both new and legacy AmneziaWG names"
+    fi
+done
+grep -q 'moav-\*-wg\.conf' "$ROOT/scripts/lib/bundle_readme.py" \
+    && ok "bundle guide resolves the renamed WireGuard configs" \
+    || bad "bundle guide would show 'No WireGuard config available' for renamed configs"
+
+# --- the globs must not overlap ----------------------------------------------
+t=$(mktemp -d); trap 'rm -rf "$t"' EXIT
+touch "$t/moav-yorks-wg.conf" "$t/moav-yorks-wgws.conf" "$t/moav-yorks-awg.conf"
+count() { local c=0; for f in $1; do [ -e "$f" ] && c=$((c+1)); done; echo $c; }
+if [ "$(count "$t/moav-*-wg.conf")" -eq 1 ] \
+   && [ "$(count "$t/moav-*-awg.conf")" -eq 1 ] \
+   && [ "$(count "$t/moav-*-wgws.conf")" -eq 1 ]; then
+    ok "wg / awg / wgws globs each match exactly one config"
+else
+    bad "the wg-family globs overlap — a lookup could pick the wrong config"
+fi
+
+echo
+echo "  $pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/tests/singbox-links-test.sh
+++ b/tests/singbox-links-test.sh
@@ -8,6 +8,9 @@ set -uo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 # The library under test stays in scripts/lib/ (this test lives in tests/).
 # shellcheck source=/dev/null
+# common.sh first: the link builders call moav_name_prefix from it, exactly as
+# every production caller does (singbox-user-add.sh / generate-user.sh).
+source "$DIR/../scripts/lib/common.sh"
 source "$DIR/../scripts/lib/sing-box.sh"
 
 # Fixed inputs
@@ -42,23 +45,23 @@ check() {
 
 U=alice
 check reality-v4  "$(singbox_reality_link "$U" "$SERVER_IP")" \
-  "vless://${USER_UUID}@203.0.113.9:443?encryption=none&flow=xtls-rprx-vision&security=reality&sni=www.cloudflare.com&fp=random&pbk=PUBKEYbase64xyz&sid=a1b2c3d4&type=tcp#MoaV-Reality-alice"
+  "vless://${USER_UUID}@203.0.113.9:443?encryption=none&flow=xtls-rprx-vision&security=reality&sni=www.cloudflare.com&fp=random&pbk=PUBKEYbase64xyz&sid=a1b2c3d4&type=tcp#MoaV-vpn-Reality-alice"
 check reality-v6  "$(singbox_reality_link "${U}-IPv6" "[${SERVER_IPV6}]")" \
-  "vless://${USER_UUID}@[2001:db8::1]:443?encryption=none&flow=xtls-rprx-vision&security=reality&sni=www.cloudflare.com&fp=random&pbk=PUBKEYbase64xyz&sid=a1b2c3d4&type=tcp#MoaV-Reality-alice-IPv6"
+  "vless://${USER_UUID}@[2001:db8::1]:443?encryption=none&flow=xtls-rprx-vision&security=reality&sni=www.cloudflare.com&fp=random&pbk=PUBKEYbase64xyz&sid=a1b2c3d4&type=tcp#MoaV-vpn-Reality-alice-IPv6"
 check trojan-v4   "$(singbox_trojan_link "$U" "$SERVER_IP")" \
-  "trojan://s3cr3t-pass@203.0.113.9:8443?security=tls&sni=vpn.example.com&type=tcp#MoaV-Trojan-alice"
+  "trojan://s3cr3t-pass@203.0.113.9:8443?security=tls&sni=vpn.example.com&type=tcp#MoaV-vpn-Trojan-alice"
 check trojan-v6   "$(singbox_trojan_link "${U}-IPv6" "[${SERVER_IPV6}]")" \
-  "trojan://s3cr3t-pass@[2001:db8::1]:8443?security=tls&sni=vpn.example.com&type=tcp#MoaV-Trojan-alice-IPv6"
+  "trojan://s3cr3t-pass@[2001:db8::1]:8443?security=tls&sni=vpn.example.com&type=tcp#MoaV-vpn-Trojan-alice-IPv6"
 check anytls-v4   "$(singbox_anytls_link "$U" "$SERVER_IP")" \
-  "anytls://s3cr3t-pass@203.0.113.9:8445?sni=vpn.example.com&insecure=0#MoaV-AnyTLS-alice"
+  "anytls://s3cr3t-pass@203.0.113.9:8445?sni=vpn.example.com&insecure=0#MoaV-vpn-AnyTLS-alice"
 check anytls-v6   "$(singbox_anytls_link "${U}-IPv6" "[${SERVER_IPV6}]")" \
-  "anytls://s3cr3t-pass@[2001:db8::1]:8445?sni=vpn.example.com&insecure=0#MoaV-AnyTLS-alice-IPv6"
+  "anytls://s3cr3t-pass@[2001:db8::1]:8445?sni=vpn.example.com&insecure=0#MoaV-vpn-AnyTLS-alice-IPv6"
 check hy2-v4      "$(singbox_hysteria2_link "$U" "$SERVER_IP")" \
-  "hysteria2://s3cr3t-pass@203.0.113.9:443?sni=vpn.example.com&obfs=salamander&obfs-password=obfs-pw#MoaV-Hysteria2-alice"
+  "hysteria2://s3cr3t-pass@203.0.113.9:443?sni=vpn.example.com&obfs=salamander&obfs-password=obfs-pw#MoaV-vpn-Hysteria2-alice"
 check hy2-v6      "$(singbox_hysteria2_link "${U}-IPv6" "[${SERVER_IPV6}]")" \
-  "hysteria2://s3cr3t-pass@[2001:db8::1]:443?sni=vpn.example.com&obfs=salamander&obfs-password=obfs-pw#MoaV-Hysteria2-alice-IPv6"
+  "hysteria2://s3cr3t-pass@[2001:db8::1]:443?sni=vpn.example.com&obfs=salamander&obfs-password=obfs-pw#MoaV-vpn-Hysteria2-alice-IPv6"
 check cdn         "$(singbox_cdn_link "$U")" \
-  "vless://${USER_UUID}@cdn.example.net:443?security=tls&type=ws&path=/moav&sni=cdn.example.net&host=cdn.example.net&fp=random&alpn=http/1.1#MoaV-CDN-alice"
+  "vless://${USER_UUID}@cdn.example.net:443?security=tls&type=ws&path=/moav&sni=cdn.example.net&host=cdn.example.net&fp=random&alpn=http/1.1#MoaV-vpn-CDN-alice"
 
 # Shadowsocks: userinfo round-trip against the exact inline encoding, then link.
 SS_METHOD="2022-blake3-aes-128-gcm"; SS_SPSK="c2VydmVyUFNL"; SS_UPSK="dXNlclBTSw=="; SS_PORT="8388"
@@ -66,8 +69,8 @@ SS_USERINFO_EXPECT=$(printf '%s' "${SS_METHOD}:${SS_SPSK}:${SS_UPSK}" | base64 |
 SS_UI=$(singbox_ss_userinfo "$SS_METHOD" "$SS_SPSK" "$SS_UPSK")
 check ss-userinfo "$SS_UI" "$SS_USERINFO_EXPECT"
 check ss-v4       "$(singbox_ss_link "$U" "$SERVER_IP" "$SS_UI" "$SS_PORT")" \
-  "ss://${SS_USERINFO_EXPECT}@203.0.113.9:8388#MoaV-Shadowsocks-alice"
+  "ss://${SS_USERINFO_EXPECT}@203.0.113.9:8388#MoaV-vpn-Shadowsocks-alice"
 check ss-v6       "$(singbox_ss_link "${U}-IPv6" "[${SERVER_IPV6}]" "$SS_UI" "$SS_PORT")" \
-  "ss://${SS_USERINFO_EXPECT}@[2001:db8::1]:8388#MoaV-Shadowsocks-alice-IPv6"
+  "ss://${SS_USERINFO_EXPECT}@[2001:db8::1]:8388#MoaV-vpn-Shadowsocks-alice-IPv6"
 
 if [[ $fail -eq 0 ]]; then echo "ALL PASS"; else echo "SOME FAILED"; exit 1; fi


### PR DESCRIPTION
Every config in a user bundle is now identifiable in the VPN app list.

## Before / after

| Config | Before | After |
|---|---|---|
| reality / trojan / hysteria2 / shadowsocks / cdn / xhttp | `MoaV-Reality-alice` | `MoaV-yorkschool-Reality-alice` |
| xdns remarks | `MoaV-XDNS-alice` | `MoaV-yorkschool-XDNS-alice` |
| **wireguard** | `wireguard.conf` (imports as "wireguard") | `moav-yorks-wg.conf` |
| **amneziawg** | `amneziawg.conf` | `moav-yorks-awg.conf` |
| **wg over wstunnel** | `wireguard-wstunnel.conf` | `moav-yorks-wgws.conf` |

Server label = `DOMAIN`'s first label (`yorkschool.xyz` → `yorkschool`), falling back to `SERVER_IP` on a domainless install.

## Why WireGuard uses the short form

WireGuard clients take the tunnel name from the **filename**, so those files had to be renamed rather than annotated. But Linux `wg-quick` turns the basename into a **network interface**, and the kernel caps interface names at **15 characters** — verified on a live box: 15 accepted, 16 rejected. `moav-` + label + `-wgws` is the longest variant, so the label is trimmed to 5 characters. Every combination stays ≤15:

```
moav-yorks-wg     13      moav-mycoo-wgws   15   (mycoolserver.example.com)
moav-yorks-awg    14      moav-20301-wgws   15   (domainless -> IP digits)
moav-yorks-wgws   15      moav-wgws          9   (no domain, no IP)
```

## Backward compatibility

Bundles generated **before** this keep working — every reader accepts both names:
- `moav test` (`tests/client-test.sh`) and `client-connect.sh`
- the bundle guide (`bundle_readme.py`), which would otherwise print *"No WireGuard config available"* for a config sitting right there under its new name

## Verified live

New user's bundle: `moav-yorks-wg/awg/wgws.conf` + `MoaV-yorkschool-<Proto>-<user>` links; `moav test` validates the renamed configs ("config valid"); the **pre-rename bundle on the same box still validates unchanged**.

## Tests

`tests/config-naming-test.sh` — 16 asserts: the 15-char budget across every label source, the `MoaV-`/`moav-wg` degradations (no `MoaV--`), share-link naming, both-name lookups in all three readers, and that the wg/awg/wgws globs cannot overlap.

Note: `singbox-links-test.sh` golden strings updated for the new fragment, and it now sources `common.sh` the way production callers do — that's what caught a `MoaV--Reality-alice` double-dash in my first attempt.
