### PR TITLE
feat(release): llms.txt release asset + auto-dispatch moav-site deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,5 +166,32 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           gh release upload "$TAG" install.sh --clobber
+          # llms.txt rides along the same way: authored here, served from
+          # moav.sh/llms.txt by moav-site fetching the latest release asset.
+          if [ -f llms.txt ]; then gh release upload "$TAG" llms.txt --clobber; fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger moav-site deploy
+        # moav-site only redeploys on ITS OWN pushes, so without this nudge
+        # moav.sh/install.sh keeps serving the previous release until someone
+        # remembers to deploy the site (exactly what happened at v2.0.0).
+        # Best-effort: a missing/expired token must not fail the release —
+        # the site deploy can always be run by hand.
+        # Prereleases are skipped on the site side by 'releases/latest' itself
+        # (GitHub never points 'latest' at a prerelease), so dispatching on
+        # every tag is safe.
+        run: |
+          if [ -n "${SITE_DISPATCH_TOKEN}" ]; then
+            curl -fsS -X POST \
+              -H "Authorization: Bearer ${SITE_DISPATCH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/MotherofallVPNs/moav-site/dispatches \
+              -d '{"event_type":"moav-release"}' \
+              && echo "moav-site deploy dispatched." \
+              || echo "::warning::moav-site dispatch failed — deploy the site manually (Actions → Deploy Site & Docs → Run workflow)."
+          else
+            echo "::warning::SITE_DISPATCH_TOKEN not set — deploy moav-site manually so moav.sh serves this release's install.sh."
+          fi
+        env:
+          SITE_DISPATCH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}


### PR DESCRIPTION
Closes the release-to-live gap that bit v2.0.0: moav-site only redeploys on its own pushes, so `moav.sh/install.sh` kept serving 1.9.1 after the v2 tag until a manual site deploy.

- **Auto-dispatch**: after uploading release assets, `release.yml` POSTs a `repository_dispatch` (`moav-release`) to moav-site, which now listens for it (companion PR there). Best-effort — a missing `SITE_DISPATCH_TOKEN` or failed POST degrades to a `::warning` with the manual instruction, never a failed release. Prereleases are naturally excluded because the site pulls `releases/latest`, which GitHub never points at a prerelease.
- **llms.txt as a release asset**: authored in this repo (#253), now uploaded next to `install.sh` so the site serves it from the release instead of hand-maintaining a drifting copy. if-guarded so a missing file can't fail the step under `bash -e`.

**One-time setup:** create a fine-grained PAT (moav-site, Contents: read/write) and store it as `SITE_DISPATCH_TOKEN` in this repo's secrets.

Docs-adjacent workflow change only; no server code.