### PR TITLE
docs(llms.txt): operating essentials, refreshed links, community

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,23 @@
 # MoaV
 
-> Multi-protocol Internet censorship circumvention stack optimized for hostile network environments. Bundles 16+ transports — Reality (VLESS), Trojan, AnyTLS (defeats TLS-in-TLS fingerprinting), Hysteria2, XHTTP, Shadowsocks-2022, CDN VLESS+WS, WireGuard (direct + over wss:// WebSocket via wstunnel), AmneziaWG, TrustTunnel (HTTP/2+QUIC), Telegram MTProxy, plus four DNS tunnels (dnstt, Slipstream, MasterDNS, XDNS) sharing port 53 through a subdomain-routing daemon. Optional bandwidth donation paths via Psiphon Conduit, Tor Snowflake, and GooseRelay. Single-host Docker Compose deployment with per-user bundle generation (configs, QR codes, V2Ray subscription), automatic Let's Encrypt certificate renewal, and an optional Prometheus + Grafana monitoring stack.
+> Multi-protocol Internet censorship circumvention stack for hostile network environments. Bundles 16+ transports and fallback paths — Reality (VLESS), Trojan, AnyTLS (resists TLS-in-TLS fingerprinting), Hysteria2, XHTTP, Shadowsocks-2022, CDN VLESS+WS, WireGuard (direct + over wss:// WebSocket via wstunnel), AmneziaWG, TrustTunnel (HTTP/2+QUIC), Telegram MTProxy, plus four DNS tunnels (dnstt, Slipstream, MasterDNS, XDNS) sharing port 53 through a subdomain-routing daemon. Optional bandwidth-donation integrations via Psiphon Conduit, Tor Snowflake and GooseRelay, which relay for other networks rather than serving your own users. Single-host Docker Compose deployment with per-user bundle generation (configs, QR codes, V2Ray subscription), automatic Let's Encrypt certificate renewal, and an optional Prometheus + Grafana monitoring stack.
 
 This is the **source repository**. `moav.sh` is a bash dispatcher over `lib/*.sh` modules; protocol servers run as containers.
+
+## Operating a server: the essentials
+
+Enough to deploy and find your way around. Everything else is linked below.
+
+- **Install** (installs Docker, clones to `/opt/moav`, prompts for domain, ACME email and admin password):
+  ```bash
+  curl -fsSL moav.sh/install.sh | bash
+  ```
+- **Configuration** lives in one file: `/opt/moav/.env` (root-owned, mode 0600). `.env.example` is the annotated reference; commonly-changed variables are above the "ADVANCED" separator. A domain is optional — leaving `DOMAIN=` empty starts only the transports that need no certificate.
+- **Admin dashboard**: `https://<server>:9443` — log in with **any username** and your `ADMIN_PASSWORD`; only the password is checked. Uses the Let's Encrypt certificate when `DOMAIN` is set, a self-signed one in domainless mode.
+- **Grafana**: `https://<server>:9444` — username `admin`, same password. Needs the `monitoring` profile and roughly 2 GB RAM.
+- **Discover every command**: `moav help`, or run `moav` with no arguments for an interactive menu.
+- **First moves after install**: `moav status` (what is running), `moav doctor` (diagnose DNS, ports, certificates, resources), `moav user add NAME --package` (create a user and build their bundle .zip), `moav test NAME` (prove that user's configs actually pass traffic).
+- **Applying config changes**: edit `.env`, then `moav restart <service-or-profile>`. A plain `docker compose restart` does **not** re-read `.env`. Structural changes need `moav bootstrap`, and existing users are preserved.
 
 ## For agents working in this repo
 
@@ -13,19 +28,45 @@ This is the **source repository**. `moav.sh` is a bash dispatcher over `lib/*.sh
 - [docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md](docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md): adding a new protocol
 - [docs/devdocs/VERSION-BUMP-CHECKLIST.md](docs/devdocs/VERSION-BUMP-CHECKLIST.md): bumping a component version
 
-## Documentation (moav.sh)
+## Why MoaV exists
 
-- [Quick Start](https://moav.sh/docs/quick-start/): one-command install and minimal first run
-- [Setup Guide](https://moav.sh/docs/SETUP/): full deployment — domain, DNS, certbot, ports, firewall, bootstrap
-- [DNS Configuration](https://moav.sh/docs/DNS/): NS delegations for the DNS tunnels, dns-router fan-out, freeing port 53
-- [Supported Protocols](https://moav.sh/docs/protocols/): per-protocol cipher, port, transport, client compatibility
+- [Mission](https://moav.sh/docs/mission/): what MoaV is for, who it serves, what it deliberately is not
+- [Threat Model](https://moav.sh/docs/threat-model/): adversaries assumed, what is and is not protected, operator and user safety
+- [Impact](https://moav.sh/docs/impact/): theory of change and the outcomes tracked
+- [Philosophy](https://moav.sh/docs/philosophy/): the multi-protocol thesis and why no single transport is enough
+
+## Deploying and configuring
+
+- [Quick Start](https://moav.sh/docs/quick-start/): one-command install through to a first user, about ten minutes
+- [Setup Guide](https://moav.sh/docs/SETUP/): every option — domain, DNS, certbot, ports, firewall, bootstrap, domainless and CDN modes
+- [VPS Deployment](https://moav.sh/docs/DEPLOY/): provider-by-provider server setup
+- [DNS Configuration](https://moav.sh/docs/DNS/): which protocols need a domain, NS delegations for the DNS tunnels, dns-router fan-out, freeing port 53
 - [CLI Reference](https://moav.sh/docs/CLI/): every `moav` command, profile filtering, environment variables
 - [Architecture](https://moav.sh/docs/architecture/): container topology, bundle generation flow, monitoring stack
-- [Monitoring](https://moav.sh/docs/MONITORING/): Grafana dashboards, Conduit lifetime bandwidth, GeoIP
-- [Troubleshooting](https://moav.sh/docs/TROUBLESHOOTING/): common failure modes with diagnostic recipes
-- [OPSEC Guide](https://moav.sh/docs/OPSEC/): operator-side hardening and threat-model notes
 
-## Optional
+## Protocols and clients
 
-- [Full documentation in one file](https://moav.sh/llms-full.txt): every docs page concatenated
+- [Supported Protocols](https://moav.sh/docs/protocols/): per-protocol cipher, port, transport, stealth and client compatibility
+- [Client Apps](https://moav.sh/docs/CLIENTS/): per-platform setup for the apps users actually install
+- [MahsaNG Import](https://moav.sh/docs/mahsanet/): V2Ray subscription import and the MahsaNet config-donation flow
+- [MoaV Client](https://moav.sh/docs/client/): the optional companion client for testing bundles
+
+## Running it well
+
+- [Monitoring](https://moav.sh/docs/MONITORING/): Grafana dashboards, Conduit lifetime bandwidth, GeoIP setup
+- [Troubleshooting](https://moav.sh/docs/TROUBLESHOOTING/): symptom-first failure modes with diagnostic recipes
+- [OPSEC Guide](https://moav.sh/docs/OPSEC/): operator-side hardening, safe bundle distribution, domain and payment considerations
+
+## Contributing
+
+- [Development & Testing](https://moav.sh/docs/development/): running from source, how CI and the end-to-end suite work, the rule that every fix ships a regression test
+- [Translating the Docs](https://moav.sh/docs/TRANSLATING/): Farsi and Russian are scaffolded; one page is a complete contribution
+- [Support MoaV](https://moav.sh/docs/support/): run a server, contribute code, translate, or donate
+
+## Elsewhere
+
+- [Full documentation in one file](https://moav.sh/llms-full.txt): every docs page concatenated, for agents that can take the whole corpus
 - [Website / project home](https://moav.sh): landing page and hosted docs
+- [Source and issues](https://github.com/MotherofallVPNs/MoaV): bug reports and pull requests
+- [Telegram](https://t.me/motherofallvpns): community and support
+- [X / Twitter](https://x.com/motherofallvpns): release announcements


### PR DESCRIPTION
Companion to **MotherofallVPNs/moav-site#10** (the docs consistency audit). `llms.txt` is authored here and published as a release asset, so it could not go in that PR.

## Why

`llms.txt` was a link index. An agent reading it could not do anything without fetching another page first, and it was missing eleven pages that now exist.

## The essentials section

New, at the top — the minimum to deploy and navigate:

- the one-command install
- `.env` location, ownership and mode, and that a domain is optional
- **admin dashboard** URL, and that **any username** works — only the password is checked (`verify_auth` never compares the username)
- **Grafana** URL, its `admin` user, the ~2 GB monitoring requirement
- **`moav help`** and the interactive menu as the discovery path
- the first four commands worth running (`status`, `doctor`, `user add --package`, `test`)
- how to apply `.env` changes: `moav restart <service>`, because a plain `docker compose restart` does not re-read `.env`

## Links

Eleven existing pages were absent: mission, threat-model, impact, philosophy, CLIENTS, mahsanet, client, DEPLOY, development, TRANSLATING, support. Now grouped by intent (Why it exists / Deploying / Protocols and clients / Running it well / Contributing) rather than one flat list.

Verified: **all 25 URLs return 200**, and all six repo-relative paths exist. Added Telegram, X and the repo.

## Consistency with the docs audit

Two claims changed to match moav-site#10, so an agent retrieving `llms.txt` and `llms-full.txt` cannot get contradictory answers:

- AnyTLS "defeats TLS-in-TLS fingerprinting" → "resists"
- Psiphon/Tor/GooseRelay described as relaying for other networks, rather than sitting in the same list as user transports

## Separately: the site is not picking this file up

Worth knowing before merge — **`moav.sh/llms.txt` is currently serving moav-site's stale committed fallback, not the release asset.** Verified:

```
v2.0.1 release asset == this repo's llms.txt   (31 lines)  ✓
served moav.sh/llms.txt == moav-site/site/llms.txt (34 lines)  ✗
```

Cause: the release ran at 20:51Z, the last moav-site deploy at 18:10Z, and **no `repository_dispatch` run exists** on moav-site — the `SITE_DISPATCH_TOKEN` secret appears to be unset, so the release→site trigger is skipped. `install.sh` is unaffected (served copy is byte-identical to the asset).

So merging this alone will not change what `moav.sh/llms.txt` serves. Two actions needed, both outside this PR:

1. Add `SITE_DISPATCH_TOKEN` to this repo's secrets so releases redeploy the site.
2. Run moav-site's **Deploy Site & Docs** workflow once manually to pick up the current asset.

The `deploy-site.yml` fetch is best-effort and silently keeps the fallback, which is what hid this. Carding a loud warning when the asset and fallback differ.