### PR TITLE
docs(readme): correct claims and facts; Farsi rebuild to follow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         run: bash tests/refactor-verify.sh
       - name: protocol-roster drift gate
         run: python3 scripts/gen-protocol-docs.py --check
+      - name: funding block drift gate (README from FUNDING.yml)
+        run: bash scripts/render-funding.sh --check
 
   go-test:
     name: go test dns-router

--- a/README-fa.md
+++ b/README-fa.md
@@ -1,100 +1,139 @@
-<div dir="rtl">
+<div align="center">
 
-# MoaV
+<img src="branding/logo.png" alt="MoaV logo" width="130">
 
-[![Website](https://img.shields.io/badge/website-moav.sh-cyan.svg)](https://moav.sh)  [![Docs](https://img.shields.io/badge/docs-moav.sh%2Fdocs-cyan.svg)](https://moav.sh/docs/)  [![Version](https://img.shields.io/badge/version-1.8.2-blue.svg)](CHANGELOG.md)  [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+# مادر همهٔ VPN‌ها
 
-**[English](README.md)** | فارسی
+**پشتهٔ چندپروتکلی عبور از سانسور اینترنت، ساخته‌شده برای شبکه‌های خصمانه.**
 
-استک عبور از سانسور چند پروتکلی بهینه‌سازی شده برای محیط‌های شبکه‌ای خصمانه.
+[![Website](https://img.shields.io/badge/website-moav.sh-06b6d4.svg)](https://moav.sh) [![Docs](https://img.shields.io/badge/docs-moav.sh%2Fdocs-2563eb.svg)](https://moav.sh/docs/) [![Release](https://img.shields.io/github/v/release/MotherofallVPNs/MoaV?label=release&color=16a34a&logo=github&logoColor=white)](https://github.com/MotherofallVPNs/MoaV/releases/latest) [![Pre-release](https://img.shields.io/github/v/release/MotherofallVPNs/MoaV?include_prereleases&label=pre-release&color=f59e0b&logo=github&logoColor=white)](https://github.com/MotherofallVPNs/MoaV/releases)
+
+[![Protocols](https://img.shields.io/badge/protocols-16%2B-ef4444.svg)](#protocols) [![moav-client](https://img.shields.io/badge/client-moav--client-06b6d4.svg?logo=github&logoColor=white)](https://github.com/MotherofallVPNs/moav-client) [![AI agents](https://img.shields.io/badge/AI_agents-AGENTS.md-8b5cf6.svg)](AGENTS.md) [![Telegram](https://img.shields.io/badge/Telegram-motherofallvpns-2CA5E0.svg?logo=telegram)](https://t.me/motherofallvpns) [![X](https://img.shields.io/badge/X-@motherofallvpns-000000.svg?logo=x)](https://x.com/motherofallvpns)
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-22c55e.svg)](LICENSE) [![Stars](https://img.shields.io/github/stars/MotherofallVPNs/MoaV?style=social)](https://github.com/MotherofallVPNs/MoaV/stargazers) [![Forks](https://img.shields.io/github/forks/MotherofallVPNs/MoaV?style=social)](https://github.com/MotherofallVPNs/MoaV/network/members) [![Last commit](https://img.shields.io/github/last-commit/MotherofallVPNs/MoaV/dev?label=last%20commit&color=64748b)](https://github.com/MotherofallVPNs/MoaV/commits/dev)
+
+🇬🇧 [English](README.md) &nbsp;·&nbsp; 🇮🇷 [فارسی](README-fa.md)
+
+ساخته و نگهداری‌شده توسط جامعهٔ **[MoaV](https://github.com/MotherofallVPNs)**.
+
+</div>
+
+---
+
+<a id="why"></a>
+
+## چرا MoaV وجود دارد
+
+هیچ ترابردی از دست هر سانسورگری جان سالم به در نمی‌برد. پروتکلی که امروز صبح کار می‌کند
+می‌تواند تا بعدازظهر شناسایی و انگشت‌نگاری شود، و کسی که به آن تکیه کرده هیچ راهی ندارد که
+از قبل بداند کدام یکی دوام می‌آورد.
+
+پس MoaV چندتا را با هم راه می‌اندازد، از یک سرور و در یک بستهٔ کاربری. وقتی یک مسیر از کار
+می‌افتد، کاربر به مسیر دیگری سوئیچ می‌کند، نه این‌که منتظر بماند کسی چیزی را از نو نصب کند.
+کل ایده همین است؛ باقی چیزها در خدمت آن هستند.
+
+[مأموریت](https://moav.sh/docs/mission)، [مدل تهدید](https://moav.sh/docs/threat-model)
+برای این‌که MoaV از چه چیزی محافظت می‌کند و از چه چیزی نه، و
+[فلسفه](https://moav.sh/docs/philosophy) برای استدلال بلندتر را بخوانید.
+
+---
+
+## فهرست مطالب
+
+**لینک‌ها** &nbsp;·&nbsp; [وب‌سایت](https://moav.sh) &nbsp;·&nbsp; [مستندات](https://moav.sh/docs/) &nbsp;·&nbsp; [تلگرام](https://t.me/motherofallvpns) &nbsp;·&nbsp; [moav-client](https://github.com/MotherofallVPNs/moav-client)
+
+**شروع کنید** &nbsp;·&nbsp; [چرا MoaV وجود دارد](#why) &nbsp;·&nbsp; [ویژگی‌ها](#features) &nbsp;·&nbsp; [شروع سریع](#quick-start) &nbsp;·&nbsp; [پیش‌نیازها](#requirements) &nbsp;·&nbsp; [اجرا بدون دامنه](#domainless)
+
+**استفاده** &nbsp;·&nbsp; [کار با MoaV](#using) &nbsp;·&nbsp; [اپلیکیشن‌های کاربر](#clients) &nbsp;·&nbsp; [مستندات](#docs)
+
+**زیر پوسته** &nbsp;·&nbsp; [معماری](#architecture) &nbsp;·&nbsp; [پروتکل‌ها](#protocols) &nbsp;·&nbsp; [ساختار پروژه](#structure) &nbsp;·&nbsp; [امنیت](#security)
+
+**کمک کنید** &nbsp;·&nbsp; [حمایت از پروژه](#support) &nbsp;·&nbsp; [جامعه](#community) &nbsp;·&nbsp; [پروژه‌های مرتبط](#related)
+
+---
+
+![نمای کلی](https://github.com/user-attachments/assets/60e1726f-2733-4d49-9fa2-30be8c2dbeb5)
+
+---
+
+<a id="features"></a>
 
 ## ویژگی‌ها
 
-- **پروتکل‌های متعدد** — ۱۶+ پروتکل برای هر سناریوی سانسور:
+- **چند پروتکل هم‌زمان** — بیش از ۱۶ ترابرد و مسیر جایگزین عبور از فیلترینگ، به‌همراه یکپارچه‌سازی‌های اختیاری اهدای پهنای‌باند با Psiphon، Tor و MahsaNet:
   - **پروکسی با پنهان‌کاری بالا** — Reality (VLESS)، Trojan، Hysteria2، XHTTP (VLESS+XHTTP+Reality)، CDN (VLESS+WS از طریق Cloudflare)
-  - **VPN کامل** — WireGuard (مستقیم و wstunnel)، AmneziaWG
-  - **تخصصی** — TrustTunnel (HTTP/2+QUIC)، Telegram MTProxy (Fake-TLS)، Shadowsocks-2022، GooseRelay (SOCKS5 از طریق Google Apps Script)
-  - **تونل‌های DNS** — dnstt، Slipstream، MasterDNS و XDNS — همه چهار تونل به‌صورت هم‌زمان روی پورت ۵۳ از طریق `dns-router` کار می‌کنند
-- **اولویت پنهان‌کاری** - تمام ترافیک شبیه HTTPS معمولی، WebSocket، DNS، یا IMAPS به نظر می‌رسد
-- **اعتبارنامه‌های جداگانه برای هر کاربر** - ایجاد، لغو و مدیریت کاربران به صورت مستقل
-- **نصب آسان** - مبتنی بر Docker Compose، راه‌اندازی با یک دستور
-- **سازگار با موبایل** - کدهای QR و لینک‌ها برای وارد کردن آسان در کلاینت
-- **وب‌سایت پوششی** - ارائه محتوای بی‌خطر به بازدیدکنندگان احراز هویت نشده
-- **قابل نصب در خانه** - اجرا روی Raspberry Pi یا هر سیستم لینوکس ARM64/x64 به عنوان VPN شخصی
-- **[Psiphon Conduit](https://github.com/Psiphon-Inc/conduit)** - اهدای پهنای باند اختیاری برای کمک به دیگران در عبور از سانسور
-- **[Tor Snowflake](https://snowflake.torproject.org/)** - اهدای پهنای باند اختیاری برای کمک به کاربران Tor در عبور از سانسور
-- **[MahsaNet](https://www.mahsaserver.com/)** - اهدای کانفیگ VPN به کاربران اپلیکیشن مهسا (۲+ میلیون کاربر در ایران)
-- **مانیتورینگ** - Grafana + Prometheus برای نظارت بر عملکرد سرور (اختیاری)
+  - **VPN کامل** — WireGuard (مستقیم و روی wstunnel)، AmneziaWG
+  - **ویژه** — TrustTunnel (HTTP/2+QUIC)، Telegram MTProxy (fake-TLS)، Shadowsocks-2022، GooseRelay (SOCKS5 روی Google Apps Script)
+  - **تونل‌های DNS** — dnstt، Slipstream، MasterDNS و XDNS — هر چهار تا هم‌زمان روی پورت ۵۳ از طریق `dns-router`
+- **پنهان‌کاری در اولویت** — ترافیک شبیه HTTPS، WebSocket، DNS یا IMAPS معمولی دیده می‌شود
+- **اعتبارنامهٔ مستقل برای هر کاربر** — ساخت، لغو و مدیریت کاربران به‌صورت جداگانه
+- **راه‌اندازی ساده** — بر پایهٔ Docker Compose، با یک فرمان
+- **مناسب موبایل** — کد QR و لینک برای واردکردن آسان در اپلیکیشن‌ها
+- **وب‌سایت پوششی** — به بازدیدکنندهٔ بدون اعتبارنامه محتوای بی‌خطر نشان می‌دهد
+- **آمادهٔ سرور خانگی** — روی Raspberry Pi یا هر لینوکس ARM64/x64 به‌عنوان VPN شخصی
+- **[Psiphon Conduit](https://github.com/Psiphon-Inc/conduit)** — اهدای اختیاری پهنای‌باند برای کمک به عبور دیگران از سانسور
+- **[Tor Snowflake](https://snowflake.torproject.org/)** — اهدای اختیاری پهنای‌باند برای کمک به کاربران Tor
+- **[MahsaNet](https://www.mahsaserver.com/)** — اهدای کانفیگ به کاربران Mahsa VPN (بیش از ۲ میلیون کاربر در ایران)
+- **مانیتورینگ** — پشتهٔ اختیاری Grafana و Prometheus
 
-> **[مستندات کامل](https://moav.sh/docs/)** — راهنمای نصب، مرجع دستورات، اپلیکیشن‌های کلاینت، مانیتورینگ، امنیت عملیاتی و موارد بیشتر.
+> **[مستندات کامل را بخوانید](https://moav.sh/docs/)** — راهنمای نصب، مرجع خط فرمان، اپلیکیشن‌های کاربر، مانیتورینگ، OPSEC و بیشتر.
+
+<a id="quick-start"></a>
 
 ## شروع سریع
 
-**نصب با یک دستور** (پیشنهادی):
-
-<div dir="ltr">
+**نصب با یک فرمان** (پیشنهادی):
 
 ```bash
 curl -fsSL moav.sh/install.sh | bash
 ```
 
-</div>
-
 این کار:
-- پیش‌نیازها را نصب می‌کند (Docker، git، qrencode) در صورت نیاز
+- پیش‌نیازها را نصب می‌کند (Docker، git، qrencode) اگر نبودند
 - MoaV را در `/opt/moav` کلون می‌کند
-- دامنه، ایمیل و رمز عبور ادمین را درخواست می‌کند
-- پیشنهاد نصب سراسری دستور `moav` را می‌دهد
-- نصب تعاملی را راه‌اندازی می‌کند
+- دامنه، ایمیل و رمز مدیریت را می‌پرسد
+- پیشنهاد می‌کند فرمان `moav` را به‌صورت سراسری نصب کند
+- راه‌اندازی تعاملی را اجرا می‌کند
 
 **نصب دستی** (جایگزین):
-
-<div dir="ltr">
 
 ```bash
 git clone https://github.com/MotherofallVPNs/moav.git
 cd moav
 cp .env.example .env
-nano .env  # تنظیم DOMAIN، ACME_EMAIL، ADMIN_PASSWORD
+nano .env  # مقادیر DOMAIN، ACME_EMAIL و ADMIN_PASSWORD را تنظیم کنید
 ./moav.sh
 ```
 
-</div>
+<img src="docs/assets/moav.sh.png" alt="منوی تعاملی MoaV" width="350">
 
-<img src="docs/assets/moav.sh.png" alt="منوی تعاملی MoaV" width="400">
-
-**پس از نصب، از هر مکانی از `moav` استفاده کنید:**
-
-<div dir="ltr">
+**بعد از نصب، `moav` را از هر جایی اجرا کنید:**
 
 ```bash
 moav                      # منوی تعاملی
-moav start                # شروع سرویس‌ها
-moav status               # نمایش وضعیت سرویس‌ها
-moav user add alice       # افزودن کاربر (کانفیگ + QR code)
-moav user add --batch 10  # ساخت دسته‌ای کاربران
+moav start                # اجرای سرویس‌ها
+moav status               # وضعیت سرویس‌ها
+moav user add alice       # افزودن کاربر (کانفیگ و کد QR می‌سازد)
+moav user add --batch 10  # ساخت گروهی کاربر
 moav donate               # اهدای کانفیگ به MahsaNet/Psiphon/Snowflake
-moav doctor               # تشخیص مشکلات (DNS، پورت‌ها، سرویس‌ها)
+moav doctor               # عیب‌یابی (DNS، پورت‌ها، سرویس‌ها)
 moav update               # به‌روزرسانی MoaV
-moav admin password       # تغییر رمز ادمین/Grafana
-moav help                 # نمایش تمام دستورات
+moav admin password       # تغییر رمز پنل و Grafana
+moav help                 # نمایش همهٔ فرمان‌ها
 ```
 
-</div>
+برای دستورهای کامل [راهنمای نصب](https://moav.sh/docs/SETUP)، برای همهٔ فرمان‌ها
+[مرجع خط فرمان](https://moav.sh/docs/CLI)، یا [مستندات کامل](https://moav.sh/docs/) را ببینید.
 
-برای دستورالعمل‌های کامل نصب به [راهنمای نصب](https://moav.sh/docs/SETUP)، برای لیست دستورات به [مرجع دستورات](https://moav.sh/docs/CLI)، یا [مستندات کامل](https://moav.sh/docs/) مراجعه کنید.
+### سرور خودتان را راه بیندازید
 
-### راه‌اندازی سرور خود
+[![Deploy on Hetzner](https://img.shields.io/badge/Deploy%20on-Hetzner-d50c2d?style=for-the-badge&logo=hetzner&logoColor=white)](https://moav.sh/docs/DEPLOY#hetzner)  [![Deploy on Linode](https://img.shields.io/badge/Deploy%20on-Linode-00a95c?style=for-the-badge&logo=linode&logoColor=white)](https://moav.sh/docs/DEPLOY#linode)  [![Deploy on Vultr](https://img.shields.io/badge/Deploy%20on-Vultr-007bfc?style=for-the-badge&logo=vultr&logoColor=white)](https://moav.sh/docs/DEPLOY#vultr)  [![Deploy on DigitalOcean](https://img.shields.io/badge/Deploy%20on-DigitalOcean-0080ff?style=for-the-badge&logo=digitalocean&logoColor=white)](https://moav.sh/docs/DEPLOY#digitalocean)
 
-[![Deploy on Hetzner](https://img.shields.io/badge/نصب%20روی-Hetzner-d50c2d?style=for-the-badge&logo=hetzner&logoColor=white)](https://moav.sh/docs/DEPLOY#hetzner)
-[![Deploy on Linode](https://img.shields.io/badge/نصب%20روی-Linode-00a95c?style=for-the-badge&logo=linode&logoColor=white)](https://moav.sh/docs/DEPLOY#linode)
-[![Deploy on Vultr](https://img.shields.io/badge/نصب%20روی-Vultr-007bfc?style=for-the-badge&logo=vultr&logoColor=white)](https://moav.sh/docs/DEPLOY#vultr)
-[![Deploy on DigitalOcean](https://img.shields.io/badge/نصب%20روی-DigitalOcean-0080ff?style=for-the-badge&logo=digitalocean&logoColor=white)](https://moav.sh/docs/DEPLOY#digitalocean)
 
+
+<a id="architecture"></a>
 
 ## معماری
-
-<div dir="ltr">
 
 ```
                                                               ┌───────────────┐  ┌───────────────┐
@@ -140,253 +179,337 @@ moav help                 # نمایش تمام دستورات
 └─────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-</div>
+<a id="protocols"></a>
 
 ## پروتکل‌ها
 
 | پروتکل | پورت | پنهان‌کاری | سرعت | پیش‌فرض | کاربرد |
-|--------|------|---------|-------|---------|--------|
-| Reality (VLESS) | 443/tcp | ★★★★★ | ★★★★☆ | ✅ | اصلی، قابل اعتمادترین |
-| Hysteria2 | 443/udp | ★★★★☆ | ★★★★★ | ✅ | سریع، کار می‌کند وقتی TCP محدود است |
-| Trojan | 8443/tcp | ★★★★☆ | ★★★★☆ | ✅ | پشتیبان، از دامنه شما استفاده می‌کند |
-| AnyTLS | 8445/tcp | ★★★★★ | ★★★★☆ | ⬜ | خنثی‌سازی اثرانگشت TLS-in-TLS، از دامنه شما استفاده می‌کند |
-| Shadowsocks-2022 | 8388/tcp+udp | ★★★★☆ | ★★★★☆ | ⬜ | AEAD-2022 ضد پروب فعال؛ سازگار با اپ Outline |
-| CDN (VLESS+WS) | 443 از Cloudflare | ★★★★★ | ★★★☆☆ | ✅ | وقتی IP سرور مسدود است |
-| TrustTunnel | 4443/tcp+udp | ★★★★★ | ★★★★☆ | ✅ | HTTP/2 و QUIC، شبیه HTTPS |
-| WireGuard (مستقیم) | 51820/udp | ★★★☆☆ | ★★★★★ | ✅ | VPN کامل، نصب ساده |
-| AmneziaWG | 51821/udp | ★★★★★ | ★★★★☆ | ✅ | وایرگارد مبهم‌سازی شده، دور زدن DPI |
-| WireGuard (wstunnel) | 8080/tcp | ★★★★☆ | ★★★★☆ | ✅ | VPN وقتی UDP مسدود است |
-| تونل DNS (dnstt) | 53/udp | ★★★☆☆ | ★☆☆☆☆ | ✅ | آخرین راه‌حل، سخت برای مسدود کردن |
-| Slipstream | 53/udp | ★★★☆☆ | ★★☆☆☆ | ✅ | QUIC-over-DNS، ۱.۵-۵ برابر سریعتر از dnstt |
-| MasterDNS | 53/udp | ★★★☆☆ | ★★★☆☆ | ✅ | تونل DNS پیشرفته (ARQ + تعادل بار)، مهسا v16 |
-| XDNS (VLESS+mKCP+DNS) | 53/udp | ★★★☆☆ | ★☆☆☆☆ | ✅ | تونل DNS با FinalMask؛ هر ۴ تونل DNS پورت ۵۳ را شریک می‌شوند |
-| GooseRelay | 8444/tcp | ★★★★★ | ★★☆☆☆ | ⬜ | SOCKS5 از طریق Google Apps Script، مهسا v16 |
+|----------|------|---------|-------|---------|----------|
+| Reality (VLESS) | 443/tcp | ★★★★★ | ★★★★☆ | ✅ | اصلی؛ نخستین انتخاب خوب در شبکه‌هایی که کار می‌کند |
+| Hysteria2 | 443/udp | ★★★★☆ | ★★★★★ | ✅ | سریع، وقتی TCP کند شده کار می‌کند |
+| Trojan | 8443/tcp | ★★★★☆ | ★★★★☆ | ✅ | پشتیبان، از دامنهٔ شما استفاده می‌کند |
+| AnyTLS | 8445/tcp | ★★★★★ | ★★★★☆ | ⬜ | مقاوم در برابر انگشت‌نگاری TLS-in-TLS، از دامنهٔ شما استفاده می‌کند |
+| Shadowsocks-2022 | 8388/tcp+udp | ★★★★☆ | ★★★★☆ | ✅ | AEAD-2022 ضد کاوش فعال؛ سازگار با اپ Outline |
+| CDN (VLESS+WS) | 443 via Cloudflare | ★★★★★ | ★★★☆☆ | ✅ | وقتی IP سرور بسته شده |
+| TrustTunnel | 4443/tcp+udp | ★★★★★ | ★★★★☆ | ✅ | HTTP/2 و QUIC، شبیه HTTPS دیده می‌شود |
+| WireGuard (Direct) | 51820/udp | ★★★☆☆ | ★★★★★ | ✅ | VPN کامل، راه‌اندازی ساده |
+| AmneziaWG | 51821/udp | ★★★★★ | ★★★★☆ | ✅ | WireGuard مبهم‌شده، مقاوم در برابر امضاهای رایج DPI |
+| WireGuard (wstunnel) | 8080/tcp | ★★★★☆ | ★★★★☆ | ✅ | VPN وقتی UDP بسته است |
+| DNS Tunnel (dnstt) | 53/udp | ★★★☆☆ | ★☆☆☆☆ | ✅ | آخرین راه، سخت‌بستنی |
+| Slipstream | 53/udp | ★★★☆☆ | ★★☆☆☆ | ✅ | QUIC روی DNS، ۱.۵ تا ۵ برابر سریع‌تر از dnstt |
+| MasterDNS | 53/udp | ★★★☆☆ | ★★★☆☆ | ✅ | تونل DNS پیشرفته (ARQ و توزیع بار resolver)، MahsaNG v16 |
+| XDNS (VLESS+mKCP+DNS) | 53/udp | ★★★☆☆ | ★☆☆☆☆ | ✅ | تونل DNS با Xray FinalMask؛ هر چهار تونل DNS پورت ۵۳ را مشترک دارند |
+| GooseRelay | 8444/tcp | ★★★★★ | ★★☆☆☆ | ⬜ | SOCKS5 روی Google Apps Script، با نمای google.com، MahsaNG v16 |
 | Telegram MTProxy | 993/tcp | ★★★★☆ | ★★★☆☆ | ✅ | Fake-TLS V2، دسترسی مستقیم به تلگرام |
 | XHTTP (VLESS+XHTTP+Reality) | 2096/tcp | ★★★★★ | ★★★★☆ | ✅ | Xray-core، بدون نیاز به دامنه |
-| Psiphon Conduit | — | — | — | ⬜ | اهدای پهنای باند به Psiphon (۲+ میلیون کاربر) |
-| Tor Snowflake | — | — | — | ⬜ | اهدای پهنای باند به شبکه Tor |
-| MahsaNet | — | — | — | ⬜ | اهدای کانفیگ VPN به مهسا VPN (۲+ میلیون کاربر) |
+| Psiphon Conduit | — | — | — | ✅ | اهدای پهنای‌باند به Psiphon (بیش از ۲ میلیون کاربر) |
+| Tor Snowflake | — | — | — | ✅ | اهدای پهنای‌باند به شبکهٔ Tor |
+| MahsaNet | — | — | — | ⬜ | اهدای کانفیگ به Mahsa VPN (بیش از ۲ میلیون کاربر) |
 
-## مدیریت کاربران
+**Default** = enabled in `.env.example`. Services still only run under their
+profile, so `moav start conduit` is what actually starts Conduit. MahsaNet is an
+action (`moav donate`), not a service.
 
-<div dir="ltr">
+<a id="using"></a>
 
-```bash
-moav user list            # لیست تمام کاربران
-moav user add joe         # افزودن کاربر به تمام پروتکل‌ها
-moav user add alice bob   # افزودن چند کاربر
-moav user add --batch 10 --prefix team  # ساخت دسته‌ای team01..team10
-moav user revoke joe      # لغو دسترسی کاربر
-moav user package joe     # ایجاد فایل zip
-```
-
-</div>
-
-هر کاربر یک بسته در `outputs/bundles/<username>/` دریافت میکنه شامل فایل کانفیگ، QR code و راهنمای README.html.
-
-**دانلود بسته‌ها** از داشبورد ادمین در `https://سرور:9443` یا با SCP.
-
-## داشبورد ادمین و مانیتورینگ
-
-- **داشبورد ادمین**: `https://سرور:9443` — مدیریت کاربران، وضعیت سرویس‌ها، اهدای MahsaNet
-- **Grafana**: `https://سرور:9444` — ترافیک هر کاربر، تفکیک پروتکل‌ها، توزیع جغرافیایی
-- **نام کاربری**: `admin` | **رمز عبور**: هنگام نصب تنظیم میشه (در `.env` با نام `ADMIN_PASSWORD`)
-- **تغییر رمز**: `moav admin password`
-
-## مدیریت سرویس‌ها
-
-<div dir="ltr">
+## کار با MoaV
 
 ```bash
-moav status               # نمایش وضعیت تمام سرویس‌ها
-moav start                # شروع سرویس‌ها
-moav start proxy admin    # شروع پروفایل‌های خاص
-moav stop                 # توقف تمام سرویس‌ها
-moav restart sing-box     # راه‌اندازی مجدد سرویس خاص
-moav logs sing-box        # مشاهده لاگ‌های سرویس
-moav doctor               # تشخیص مشکلات
-moav doctor dns           # بررسی تنظیمات DNS
-moav donate               # اهدای کانفیگ به MahsaNet/Psiphon/Snowflake
+moav                          # منوی تعاملی روی همهٔ موارد زیر
+moav status                   # چه چیزی در حال اجراست، کدام پروفایل‌ها، سلامت در یک نگاه
+moav doctor                   # عیب‌یابی DNS، پورت‌ها، گواهی‌ها، منابع
+moav logs sing-box            # دیدن لاگ یک سرویس
+
+moav user add alice --package # ساخت کاربر و ساختن فایل zip بستهٔ او
+moav user add --batch 10      # ده کاربر یک‌جا
+moav user list                # چه کسانی هستند
+moav user revoke alice        # لغو فوری دسترسی
+moav test alice               # اثبات این‌که کانفیگ‌های alice واقعاً ترافیک را رد می‌کنند
+
+moav start proxy admin        # اجرای پروفایل‌های مشخص
+moav restart sing-box         # اعمال تغییر .env روی یک سرویس
+moav donate                   # اهدای کانفیگ و پهنای‌باند (MahsaNet، Psiphon، Snowflake)
 ```
 
-</div>
+هر کاربر پوشهٔ `outputs/bundles/<username>/` را می‌گیرد با فایل‌های کانفیگ، کدهای QR و
+راهنمای `README.html`، به‌همراه یک **اشتراک V2Ray** به‌صورت base64 در `subscription.txt`
+که با یک بار چسباندن همهٔ پروتکل‌های پروکسی را در
+[MahsaNG](https://github.com/GFW-knocker/MahsaNG)، v2rayNG یا Hiddify وارد می‌کند.
+[راهنمای واردکردن در MahsaNG](https://moav.sh/docs/mahsanet) را ببینید.
 
-**پروفایل‌ها:** `proxy`، `wireguard`، `amneziawg`، `dnstunnel`، `trusttunnel`، `telegram`، `xhttp`، `admin`، `conduit`، `snowflake`، `monitoring`، `all`
+برای بررسی یک بسته از دید کاربر، [**moav-client**](https://github.com/MotherofallVPNs/moav-client)
+اشتراک را می‌خواند، هر نقطهٔ اتصال را از تونل خودش آزمایش می‌کند و از سالم‌ترین و سریع‌ترین
+مسیر عبور می‌دهد.
 
-## مهاجرت سرور
+**پنل‌ها** — رمز هر دو در زمان نصب تنظیم می‌شود (`ADMIN_PASSWORD` در `.env`) و با
+`moav admin password` قابل تغییر است:
 
-خروجی گرفتن و انتقال MoaV به سرور جدید:
+| | نشانی | ورود |
+|---|---|---|
+| **پنل مدیریت** | `https://your-server:9443` | هر نام کاربری — فقط رمز بررسی می‌شود |
+| **Grafana** | `https://your-server:9444` | کاربر `admin` |
 
-<div dir="ltr">
+**پروفایل‌ها:** `proxy`، `wireguard`، `amneziawg`، `dnstunnel`، `trusttunnel`، `telegram`، `xhttp`، `admin`، `conduit`، `snowflake`، `gooserelay`، `monitoring`، `all`
 
-```bash
-# خروجی کامل (کلیدها، کاربران، تنظیمات)
-moav export                        # ایجاد moav-backup-TIMESTAMP.tar.gz
+**انتقال به سرور جدید:** `moav export`، بعد روی سرور تازه `moav import moav-backup-*.tar.gz`
+و `moav migrate-ip <new-ip>`. مرحله‌به‌مرحله در [راهنمای نصب](https://moav.sh/docs/SETUP#server-migration).
 
-# در سرور جدید: وارد کردن و به‌روزرسانی IP
-moav import moav-backup-*.tar.gz   # بازیابی تنظیمات
-moav migrate-ip 1.2.3.4            # به‌روزرسانی همه تنظیمات با IP جدید
-moav start                         # شروع سرویس‌ها
-```
+**Psiphon Conduit:** به‌محض اجرای `conduit`، از طریق استخر عمومی به کاربران Psiphon خدمت
+می‌دهد و چیزی برای اشتراک‌گذاری نیست. `moav conduit link` یک لینک/QR خصوصی برای افراد
+مشخص می‌سازد؛ این لینک کلید خصوصی را در خود دارد، پس فقط از راه Personal Pairing داخل Ryve
+به اشتراک بگذارید. [Psiphon Conduit](https://moav.sh/docs/protocols#psiphon-conduit) را ببینید.
 
-</div>
+همهٔ فرمان‌ها، گزینه‌ها و متغیرهای محیطی: **[مرجع خط فرمان](https://moav.sh/docs/CLI)**.
 
-برای جزئیات بیشتر به [راهنمای نصب](https://moav.sh/docs/SETUP#server-migration) مراجعه کنید.
+<a id="clients"></a>
 
-MoaV شامل یک کانتینر کلاینت داخلی برای تست اتصال و اتصال از طریق سرور شماست.
-## تست
+## اپلیکیشن‌های کاربر
 
-<div dir="ltr">
-
-```bash
-moav test user1           # تست تمام پروتکل‌ها برای یک کاربر
-moav test user1 -v        # خروجی مفصل برای دیباگ
-moav client connect user1 # اتصال به عنوان کاربر (پراکسی SOCKS5/HTTP محلی)
-```
-
-</div>
-
-## اپلیکیشن‌های کلاینت
-
-| پلتفرم | اپلیکیشن‌های توصیه شده |
-|--------|----------------------|
+| سیستم‌عامل | اپلیکیشن‌های پیشنهادی |
+|----------|------------------|
 | iOS | Happ، Streisand، Hiddify، WireGuard، Shadowrocket |
 | Android | Happ، v2rayNG، Hiddify، WireGuard، NekoBox |
 | macOS | Happ، Hiddify، Streisand، WireGuard |
 | Windows | Happ، v2rayN، Hiddify، WireGuard |
 | Linux | Hiddify، sing-box، WireGuard |
 
-برای دستورالعمل‌های راه‌اندازی به [راهنمای کلاینت](https://moav.sh/docs/CLIENTS) مراجعه کنید.
+فهرست کامل و دستور راه‌اندازی در [راهنمای اپلیکیشن‌های کاربر](https://moav.sh/docs/CLIENTS)،
+یا [**moav-client**](https://github.com/MotherofallVPNs/moav-client)
+([مستندات](https://moav.sh/docs/client)) برای کلاینت دسکتاپ/خط فرمان با جابه‌جایی خودکار.
+
+<a id="docs"></a>
 
 ## مستندات
 
-- [راهنمای نصب](https://moav.sh/docs/SETUP) - دستورالعمل‌های کامل نصب
-- [مرجع CLI](https://moav.sh/docs/CLI) - تمام دستورات و گزینه‌های moav
-- [پیکربندی DNS](https://moav.sh/docs/DNS) - تنظیم رکوردهای DNS
-- [راه‌اندازی کلاینت](https://moav.sh/docs/CLIENTS) - نحوه اتصال از دستگاه‌ها
-- [نصب روی VPS](https://moav.sh/docs/DEPLOY) - نصب یک‌کلیکی روی سرور ابری
-- [مانیتورینگ](https://moav.sh/docs/MONITORING) - Grafana + Prometheus برای نظارت
-- [عیب‌یابی](https://moav.sh/docs/TROUBLESHOOTING) - مشکلات رایج و راه‌حل‌ها
-- [راهنمای امنیت عملیاتی](https://moav.sh/docs/OPSEC) - بهترین روش‌های امنیتی
+مستندات کامل: **[moav.sh/docs](https://moav.sh/docs/)**
+
+**راه‌اندازی** — [شروع سریع](https://moav.sh/docs/quick-start) · [راهنمای نصب](https://moav.sh/docs/SETUP) · [راه‌اندازی روی VPS](https://moav.sh/docs/DEPLOY) · [تنظیمات DNS](https://moav.sh/docs/DNS)
+
+**درک پروژه** — [پروتکل‌های پشتیبانی‌شده](https://moav.sh/docs/protocols) · [معماری](https://moav.sh/docs/architecture) · [مدل تهدید](https://moav.sh/docs/threat-model) · [مأموریت](https://moav.sh/docs/mission) · [فلسفه](https://moav.sh/docs/philosophy)
+
+**اتصال کاربران** — [اپلیکیشن‌های کاربر](https://moav.sh/docs/CLIENTS) · [واردکردن در MahsaNG](https://moav.sh/docs/mahsanet) · [کلاینت MoaV](https://moav.sh/docs/client)
+
+**بهره‌برداری** — [مرجع خط فرمان](https://moav.sh/docs/CLI) · [مانیتورینگ](https://moav.sh/docs/MONITORING) · [عیب‌یابی](https://moav.sh/docs/TROUBLESHOOTING) · [راهنمای OPSEC](https://moav.sh/docs/OPSEC)
+
+**مشارکت** — [توسعه و تست](https://moav.sh/docs/development) · [ترجمهٔ مستندات](https://moav.sh/docs/TRANSLATING) · [حمایت از MoaV](https://moav.sh/docs/support)
+
+**برای عامل‌های هوش مصنوعی** — [AGENTS.md](AGENTS.md) برای کار در این مخزن، [llms.txt](https://moav.sh/llms.txt) به‌عنوان فهرست فشرده، و [llms-full.txt](https://moav.sh/llms-full.txt) برای کل مستندات.
+
+<a id="requirements"></a>
 
 ## پیش‌نیازها
 
 **سرور:**
-- Debian 12، Ubuntu 22.04/24.04
-- حداقل 1 vCPU، 1 GB RAM (2 vCPU، 2 GB RAM برای مانیتورینگ)
+- Debian 12، Ubuntu 22.04 یا 24.04
+- کمینه ۱ هستهٔ پردازنده و ۱ گیگابایت رم (۲ هسته و ۲ گیگابایت در صورت استفاده از مانیتورینگ)
 - IPv4 عمومی
-- نام دامنه (اختیاری - حالت بدون دامنه را ببینید)
+- دامنه (اختیاری — بخش بعد را ببینید)
 
-**پورت‌ها (در صورت نیاز باز کنید):**
-
+**پورت‌ها (به‌اندازهٔ نیاز باز کنید):**
 | پورت | پروتکل | سرویس | نیاز به دامنه |
-|------|--------|-------|---------------|
-| 443/tcp | TCP | Reality (VLESS) | بله |
+|------|----------|---------|-----------------|
+| 443/tcp | TCP | Reality (VLESS) | خیر — از یک SNI عمومی با `REALITY_TARGET` استفاده می‌کند |
 | 443/udp | UDP | Hysteria2 | بله |
 | 8443/tcp | TCP | Trojan | بله |
 | 8445/tcp | TCP | AnyTLS | بله |
 | 8388/tcp+udp | TCP+UDP | Shadowsocks-2022 | خیر |
 | 4443/tcp+udp | TCP+UDP | TrustTunnel | بله |
-| 2082/tcp | TCP | CDN WebSocket | بله (Cloudflare) |
+| 2082/tcp | TCP | CDN WebSocket | Cloudflare: بله · CloudFront: خیر |
 | 51820/udp | UDP | WireGuard | خیر |
 | 51821/udp | UDP | AmneziaWG | خیر |
 | 8080/tcp | TCP | wstunnel | خیر |
 | 993/tcp | TCP | Telegram MTProxy | خیر |
 | 2096/tcp | TCP | XHTTP (VLESS+XHTTP+Reality) | خیر |
-| 9443/tcp | TCP | داشبورد ادمین | خیر |
-| 9444/tcp | TCP | Grafana (مانیتورینگ) | خیر |
-| 53/udp | UDP | تونل‌های DNS (dnstt / Slipstream / MasterDNS / XDNS — همه پورت ۵۳ را شریک می‌شوند) | بله |
-| 8444/tcp | TCP | GooseRelay (وقتی `ENABLE_GOOSERELAY=true`) | خیر |
-| 80/tcp | TCP | Let's Encrypt | بله (هنگام نصب) |
+| 8444/tcp | TCP | GooseRelay exit (when `ENABLE_GOOSERELAY=true`) | خیر |
+| 9443/tcp | TCP | Admin dashboard | خیر |
+| 9444/tcp | TCP | Grafana (monitoring) | خیر |
+| 53/udp | UDP | DNS tunnels (dnstt / Slipstream / MasterDNS / XDNS — all share this port) | بله |
+| 80/tcp | TCP | Let's Encrypt | بله (در زمان نصب) |
 
-### حالت بدون دامنه
+<a id="domainless"></a>
 
-دامنه ندارید؟ MoaV می‌تواند در **حالت بدون دامنه** با سرویس‌های زیر اجرا شود:
+## اجرا بدون دامنه
+
+دامنه ندارید؟ MoaV می‌تواند در **حالت بی‌دامنه** اجرا شود با:
 - **Reality** (VLESS+Reality، پروتکل اصلی)
-- **XHTTP** (VLESS+XHTTP+Reality، بدون نیاز به دامنه)
-- **WireGuard** (UDP مستقیم + تونل WebSocket)
-- **AmneziaWG** (وایرگارد مبهم‌سازی شده، دور زدن DPI)
-- **Telegram MTProxy** (Fake-TLS، دسترسی مستقیم به تلگرام)
-- **داشبورد ادمین** (با گواهی خودامضا)
-- **Conduit** (اهدای پهنای باند Psiphon)
-- **Snowflake** (اهدای پهنای باند Tor)
+- **XHTTP** (VLESS+XHTTP+Reality روی Xray-core)
+- **WireGuard** (UDP مستقیم و تونل WebSocket)
+- **AmneziaWG** (WireGuard مبهم‌شده، مقاوم در برابر امضاهای رایج DPI)
+- **Shadowsocks-2022** (AEAD-2022، بدون نیاز به گواهی)
+- **Telegram MTProxy** (fake-TLS، دسترسی مستقیم به تلگرام)
+- **GooseRelay** (SOCKS5 روی Google Apps Script — بدون دامنه)
+- **پنل مدیریت** (با گواهی خودامضا)
+- **Conduit** (اهدای پهنای‌باند به Psiphon)
+- **Snowflake** (اهدای پهنای‌باند به Tor)
 
-دستور `moav` را اجرا کنید و وقتی پرسیده شد "بدون دامنه" را انتخاب کنید، یا از `moav domainless` استفاده کنید.
+`moav` را اجرا کنید و در پرسش دامنه گزینهٔ «بدون دامنه» را انتخاب کنید، یا از `moav domainless` استفاده کنید.
 
-**VPS توصیه شده:**
-- VPS Price Trackers: [VPS-PRICES](https://vps-prices.com/)، [VPS Price Tracker](https://vpspricetracker.com/), [Cheap VPS Price Cheat Sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vTOC_THbM2RZzfRUhFCNp3SDXKdYDkfmccis4vxr7WtVIcPmXM-2lGKuZTBr8o_MIJ4XgIUYz1BmcqM/pubhtml)
-- [Time4VPS](https://www.time4vps.com/?affid=8471): 1 vCPU، 1GB RAM، IPv4، 3.99€/ماه 
+<a id="structure"></a>
 
 ## ساختار پروژه
 
-<div dir="ltr">
-
 ```
 MoaV/
-├── moav.sh                 # ابزار مدیریت CLI (نصب با: ./moav.sh install)
-├── docker-compose.yml      # فایل compose اصلی
-├── .env.example            # قالب متغیرهای محیطی
-├── Dockerfile.*            # تعاریف کانتینر
-├── configs/                # پیکربندی‌های سرویس‌ها
-│   ├── sing-box/
-│   ├── wireguard/
-│   ├── amneziawg/
-│   ├── trusttunnel/
-│   ├── dnstt/
-│   ├── masterdns/
-│   ├── gooserelay/
-│   ├── telemt/
-│   └── monitoring/
-├── scripts/                # اسکریپت‌های مدیریت
-│   ├── bootstrap.sh
-│   ├── user-add.sh
-│   ├── user-revoke.sh
-│   └── lib/
-├── outputs/                # پیکربندی‌های تولید شده (gitignore شده)
-│   └── bundles/
-├── web/                    # وب‌سایت پوششی
-├── admin/                  # داشبورد آمار
-└── docs/                   # مستندات توسعه و دارایی‌ها
+├── moav.sh              # خط فرمان: تفسیر آرگومان‌ها و رفتن به تابع cmd_*
+├── lib/                 # ۱۵ ماژول سمت میزبان — service، users، bootstrap، doctor،
+│                        #   cert، migrate، donate، nettune، dns، peers، menu، …
+├── scripts/             # نقطهٔ ورود کانتینرها و آماده‌سازی
+│   ├── *-entrypoint.sh  #   یکی برای هر سرویس
+│   └── lib/             #   کتابخانه‌های مشترک، سوارشده در کانتینرها روی /app/lib
+├── configs/             # فایل‌های *.template (در گیت) که به *.json/*.conf رندر می‌شوند (بیرون از گیت)
+├── dockerfiles/         # ساخت ایمیج‌ها، یکی برای هر سرویس
+├── exporters/           # exporter‌های Prometheus (sing-box، xray، wireguard، amneziawg، …)
+├── dns-router/          # دیمن Go که پورت ۵۳ را بین چهار تونل DNS پخش می‌کند
+├── admin/               # پنل FastAPI
+├── web/                 # وب‌سایت پوششی
+├── data/                # protocols.json — فهرست مرجع پروتکل‌ها
+├── tests/               # مجموعهٔ تست، هر کدام به نام دسته‌ای از باگ که مهار می‌کند
+├── docs/devdocs/        # مستندات مشارکت‌کننده (مستندات کاربر در moav-site است)
+├── docker-compose.yml
+└── .env.example         # مرجع تنظیمات با توضیح؛ متغیرهای پرکاربرد در بالا
 ```
 
-</div>
+`moav.sh` فقط توزیع‌کنندهٔ فرمان‌هاست — منطق در `lib/` است. پوشه‌های `outputs/` (بسته‌های
+کاربران) و `state/` (کلیدها) ساخته می‌شوند و در گیت نیستند.
+
+<a id="security"></a>
 
 ## امنیت
 
-- تمام پروتکل‌ها نیاز به احراز هویت دارند
-- وب‌سایت پوششی برای ترافیک احراز هویت نشده
-- اعتبارنامه‌های جداگانه برای هر کاربر با قابلیت لغو فوری
-- حداقل لاگ‌گیری (بدون URL، بدون محتوا)
-- TLS 1.3 همه جا
+- همهٔ پروتکل‌ها احراز هویت می‌خواهند
+- وب‌سایت پوششی برای ترافیک بدون اعتبارنامه
+- اعتبارنامهٔ مستقل برای هر کاربر با امکان لغو فوری
+- لاگ حداقلی (بدون URL، بدون محتوا)
+- TLS 1.3 در همه جا
 
-برای راهنمای امنیتی به [راهنمای امنیت عملیاتی](https://moav.sh/docs/OPSEC) مراجعه کنید.
+**سطح دسترسی کانتینرها.** دسترسی به Docker API محدود به یک پروکسی سوکت فیلترشده روی یک
+شبکهٔ مدیریتی جداست، و exporter‌های مانیتورینگ به‌جای سوکت، فایل‌های وضعیت منتشرشده را
+می‌خوانند. تنها استثنای پذیرفته‌شده **cAdvisor** است (پروفایل اختیاری `monitoring`): آمار
+پردازنده/حافظه/دیسک هر کانتینر به حالت privileged با mount‌های فقط‌خواندنی نیاز دارد، که
+همان شیوهٔ استقرار بالادستی خودش است. اگر این معاوضه برایتان قابل قبول نیست، بدون پروفایل
+مانیتورینگ اجرا کنید.
+
+[راهنمای OPSEC](https://moav.sh/docs/OPSEC) را برای اصول امنیتی ببینید.
+
+<a id="support"></a>
+
+## حمایت از پروژه
+
+**سرور راه بیندازید.** مؤثرترین کاری که می‌توانید بکنید. هر سرور MoaV ظرفیتی است که پیش‌تر
+وجود نداشت — برای خانواده‌تان، همکارانتان، یا کسانی که هرگز نمی‌بینید. هیچ‌کس به‌جای شما
+زیرساخت نمی‌گرداند؛ این شبکه *همان* آدم‌هایی است که سرور می‌گردانند. یک VPS پنج‌دلاری یا یک
+Raspberry Pi کافی است.
+
+**ظرفیتی که همین حالا دارید را اهدا کنید.** می‌توانید بدون داشتن کاربر، برای شبکه‌های دیگر
+عبور از سانسور رله کنید — `moav start conduit` (Psiphon) و `moav start snowflake` (Tor)،
+هر دو اختیاری و سقف‌دار. یا با `moav donate` کانفیگ به [MahsaNet](https://www.mahsaserver.com/)
+اهدا کنید، که آن‌ها را به کاربران ایرانی می‌رساند که خودشان نمی‌توانند سرور راه بیندازند.
+
+**کد بنویسید یا ترجمه کنید.** باگ، پروتکل، بسته‌بندی، مستندات — [توسعه و تست](https://moav.sh/docs/development)
+را ببینید. ترجمه مفیدترین مشارکت غیرکدنویسی است: مستندات برای فارسی و روسی آماده شده و
+ترجمهٔ یک صفحه هم یک مشارکت کامل است ([راهنمای ترجمه](https://moav.sh/docs/TRANSLATING)).
+گزارش باگ هم به‌حساب می‌آید — یک گزارش قابل‌بازتولید همراه خروجی `moav doctor` معمولاً از
+خود رفع اشکال زحمت بیشتری دارد.
+
+> هرگز بستهٔ کاربر، محتوای `.env` یا لینک اشتراک را در یک issue نگذارید — این‌ها کلید زندهٔ در آن‌ها هست.
+
+**هزینهٔ زیرساخت را تأمین کنید.** سرورهای تست برای مجموعهٔ تست سرتاسری، دامنه‌ها و ظرفیت
+ساخت. نه حقوق و دستمزد.
+
+<!-- FUNDING:START -->
+| پلتفرم | لینک |
+|---|---|
+| **GitHub Sponsors** | [github.com/sponsors/shayanb](https://github.com/sponsors/shayanb) |
+| **Buy Me a Coffee** | [buymeacoffee.com/pangana](https://buymeacoffee.com/pangana) |
+
+| ارز | نشانی |
+|---|---|
+| **Bitcoin (BTC)** | `bc1qkfq3hg5kpzgy7muc8m3pmh6zemhv820a0ndqgg` |
+| **Ethereum (ETH)**¹ | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
+| **Zcash (ZEC)** | `u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587` |
+| **Tron**² | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+
+¹ **Ethereum (ETH)** — همین نشانی روی همهٔ زنجیره‌های EVM کار می‌کند و برای هر توکن ERC-20
+² **Tron** — فقط TRX و TRC-20 — با نشانی EVM بالا یکی نیست
+<!-- FUNDING:END -->
+
+نشانی‌ها از [`.github/FUNDING.yml`](.github/FUNDING.yml) ساخته می‌شوند، که تنها مرجع است، پس
+آنچه اینجا می‌بینید همان است که در آن فایل نوشته شده. نشانی را از همین صفحه یا از مخزن روی
+HTTPS بردارید و بعد از چسباندن، چند نویسهٔ اول و آخرش را بررسی کنید.
+**ما هرگز نشانی را برایتان دایرکت نمی‌فرستیم.**
+
+<a id="community"></a>
+
+## جامعه
+
+- **تلگرام:** [t.me/motherofallvpns](https://t.me/motherofallvpns) — پرسش، کمک و اطلاع‌رسانی نسخه‌ها
+- **X:** [@motherofallvpns](https://x.com/motherofallvpns)
+- **Issues:** [GitHub Issues](https://github.com/MotherofallVPNs/MoaV/issues) برای باگ و پیشنهاد ویژگی
+- **مستندات:** [moav.sh/docs](https://moav.sh/docs)
+
+<a id="related"></a>
+
+## پروژه‌های مرتبط
+
+MoaV یک لایهٔ استقرار است. کار روی خود پروتکل‌ها به این پروژه‌ها تعلق دارد:
+
+**کلاینت همراه** — [moav-client](https://github.com/MotherofallVPNs/moav-client): کلاینت
+دسکتاپ/خط فرمان که اشتراک MoaV را می‌خواند، هر نقطهٔ اتصال را از تونل خودش آزمایش می‌کند و
+از سالم‌ترین و سریع‌ترین مسیر عبور می‌دهد ([مستندات](https://moav.sh/docs/client)).
+
+**موتورهای پروتکل**
+
+| پروژه | MoaV از آن برای چه استفاده می‌کند |
+|---|---|
+| [sing-box](https://github.com/SagerNet/sing-box) | Reality، Trojan، AnyTLS، Hysteria2، Shadowsocks-2022، CDN VLESS+WS |
+| [Xray-core](https://github.com/XTLS/Xray-core) | XHTTP و XDNS |
+| [REALITY](https://github.com/XTLS/REALITY) | پوشش TLS که Reality و XHTTP روی آن ساخته شده‌اند |
+| [AmneziaWG](https://github.com/amnezia-vpn/amneziawg-go) · [ابزارها](https://github.com/amnezia-vpn/amneziawg-tools) | WireGuard مقاوم در برابر DPI |
+| [WireGuard](https://www.wireguard.com/) | VPN مستقیم روی UDP |
+| [wstunnel](https://github.com/erebe/wstunnel) | WireGuard روی `wss://` وقتی UDP بسته است |
+| [TrustTunnel](https://github.com/TrustTunnel/TrustTunnel) · [کلاینت](https://github.com/TrustTunnel/TrustTunnelClient) | ترابرد HTTP/2 و QUIC |
+| [telemt](https://github.com/telemt/telemt) | Telegram MTProxy (fake-TLS) |
+| [dnstt](https://www.bamsoftware.com/software/dnstt/) | تونل DNS اصلی |
+| [Slipstream](https://github.com/net2share/slipstream-rust-build) | QUIC روی DNS |
+| [MasterDNS](https://github.com/masterking32/MasterDnsVPN) | تونل DNS با ARQ و توزیع بار روی resolver‌ها |
+| [GooseRelay](https://github.com/kianmhz/GooseRelayVPN) | SOCKS5 روی Google Apps Script |
+
+**شبکه‌هایی که می‌توانید به آن‌ها ظرفیت اهدا کنید**
+
+| پروژه | |
+|---|---|
+| [Psiphon Conduit](https://github.com/Psiphon-Inc/conduit) | رله برای کاربران Psiphon |
+| [Tor Snowflake](https://snowflake.torproject.org/) | رله برای کاربران Tor |
+| [MahsaNet](https://www.mahsaserver.com/) · [MahsaNG](https://github.com/GFW-knocker/MahsaNG) | اهدای کانفیگ و کلاینتی که بیشتر کاربران ایرانی دارند |
+
+**مانیتورینگ** — [Prometheus](https://github.com/prometheus/prometheus)، [Grafana](https://github.com/grafana/grafana)،
+[node_exporter](https://github.com/prometheus/node_exporter)، [cAdvisor](https://github.com/google/cadvisor)،
+[clash-exporter](https://github.com/zxh326/clash-exporter).
+
+نسخه‌های پین‌شدهٔ همهٔ این‌ها در [`.env.example`](.env.example) است.
 
 ## مجوز
 
 MIT
 
 ## تغییرات
+[CHANGELOG.md](CHANGELOG.md) را برای یادداشت نسخه‌ها و تاریخ تغییرات ببینید.
 
-برای یادداشت‌های انتشار و تاریخچه نسخه‌ها به [CHANGELOG.md](CHANGELOG.md) مراجعه کنید.
-
+---
 ## سلب مسئولیت
 
-این پروژه **فقط نرم‌افزار شبکه متن‌باز با کاربرد عمومی** ارائه می‌دهد.
+این پروژه فقط **نرم‌افزار شبکه‌ای آزاد و همه‌منظوره** ارائه می‌کند.
 
-این یک سرویس، پلتفرم، یا شبکه عملیاتی نیست.
+این یک سرویس نیست، یک پلتفرم نیست، و یک شبکهٔ تحت بهره‌برداری نیست.
 
 نویسندگان و مشارکت‌کنندگان:
-- زیرساختی را اداره نمی‌کنند
+- زیرساختی نمی‌گردانند
 - دسترسی ارائه نمی‌دهند
 - اعتبارنامه توزیع نمی‌کنند
-- کاربران را مدیریت نمی‌کنند
-- استقرارها را هماهنگ نمی‌کنند
+- کاربری را مدیریت نمی‌کنند
+- استقراری را هماهنگ نمی‌کنند
 
-تمام استفاده، استقرار و بهره‌برداری مسئولیت کامل اشخاص ثالث است.
+همهٔ استفاده، استقرار و بهره‌برداری تنها بر عهدهٔ اشخاص ثالث است.
 
-این نرم‌افزار **«همانطور که هست»** ارائه می‌شود، بدون هیچ گونه ضمانتی.
-نویسندگان و مشارکت‌کنندگان **هیچ مسئولیتی** در قبال هرگونه استفاده یا سوء استفاده از این نرم‌افزار نمی‌پذیرند.
-
-کاربران مسئول رعایت تمام قوانین و مقررات قابل اعمال هستند.
-
-</div>
+این نرم‌افزار **«همان‌گونه که هست»** ارائه می‌شود، بدون هیچ‌گونه ضمانت.
+نویسندگان و مشارکت‌کنندگان **هیچ مسئولیتی** در قبال استفاده یا سوءاستفاده از آن نمی‌پذیرند.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Built and maintained by the **[MoaV](https://github.com/MotherofallVPNs)** commu
 
 ## Features
 
-- **Multiple protocols** — 16+ protocols covering every censorship scenario:
+- **Multiple protocols** — 16+ circumvention transports and fallback paths, plus optional Psiphon, Tor and MahsaNet donation integrations:
   - **High-stealth proxy** — Reality (VLESS), Trojan, Hysteria2, XHTTP (VLESS+XHTTP+Reality), CDN (VLESS+WS via Cloudflare)
   - **Full VPN** — WireGuard (direct & wstunnel), AmneziaWG
   - **Specialty** — TrustTunnel (HTTP/2+QUIC), Telegram MTProxy (fake-TLS), Shadowsocks-2022, GooseRelay (SOCKS5 via Google Apps Script)
@@ -163,7 +163,7 @@ See the [Setup Guide](https://moav.sh/docs/SETUP) for complete instructions, the
 
 | Protocol | Port | Stealth | Speed | Default | Use Case |
 |----------|------|---------|-------|---------|----------|
-| Reality (VLESS) | 443/tcp | ★★★★★ | ★★★★☆ | ✅ | Primary, most reliable |
+| Reality (VLESS) | 443/tcp | ★★★★★ | ★★★★☆ | ✅ | Primary; a strong first choice where it works |
 | Hysteria2 | 443/udp | ★★★★☆ | ★★★★★ | ✅ | Fast, works when TCP throttled |
 | Trojan | 8443/tcp | ★★★★☆ | ★★★★☆ | ✅ | Backup, uses your domain |
 | AnyTLS | 8445/tcp | ★★★★★ | ★★★★☆ | ⬜ | Defeats TLS-in-TLS fingerprinting, uses your domain |
@@ -171,7 +171,7 @@ See the [Setup Guide](https://moav.sh/docs/SETUP) for complete instructions, the
 | CDN (VLESS+WS) | 443 via Cloudflare | ★★★★★ | ★★★☆☆ | ✅ | When server IP is blocked |
 | TrustTunnel | 4443/tcp+udp | ★★★★★ | ★★★★☆ | ✅ | HTTP/2 & QUIC, looks like HTTPS |
 | WireGuard (Direct) | 51820/udp | ★★★☆☆ | ★★★★★ | ✅ | Full VPN, simple setup |
-| AmneziaWG | 51821/udp | ★★★★★ | ★★★★☆ | ✅ | Obfuscated WireGuard, defeats DPI |
+| AmneziaWG | 51821/udp | ★★★★★ | ★★★★☆ | ✅ | Obfuscated WireGuard, resists common DPI signatures |
 | WireGuard (wstunnel) | 8080/tcp | ★★★★☆ | ★★★★☆ | ✅ | VPN when UDP is blocked |
 | DNS Tunnel (dnstt) | 53/udp | ★★★☆☆ | ★☆☆☆☆ | ✅ | Last resort, hard to block |
 | Slipstream | 53/udp | ★★★☆☆ | ★★☆☆☆ | ✅ | QUIC-over-DNS, 1.5-5x faster than dnstt |
@@ -205,7 +205,9 @@ Each user gets a bundle in `outputs/bundles/<username>/` with config files, QR c
 
 - **Admin dashboard**: `https://your-server:9443` — user management, service status, MahsaNet donations
 - **Grafana**: `https://your-server:9444` — per-user traffic, protocol breakdown, GeoIP distribution
-- **Username**: `admin` | **Password**: set during install (stored in `.env` as `ADMIN_PASSWORD`)
+- **Admin dashboard login**: any username — only the password is checked
+- **Grafana login**: user `admin`
+- **Password** for both: set during install (stored in `.env` as `ADMIN_PASSWORD`)
 - **Reset password**: `moav admin password`
 
 ## Service Management
@@ -225,7 +227,7 @@ moav conduit link         # Psiphon Conduit claim link, QR & sharing guide
 
 **Psiphon Conduit:** once `conduit` is running it already serves Psiphon users (including in Iran) through the public pool — no link to share. To give specific people a private path, `moav conduit link` prints the Ryve claim link/QR and the Personal Pairing steps. The claim link embeds the private key — keep it secret; share with users only via Personal Pairing inside Ryve. See [Psiphon Conduit in docs/protocols.md](https://moav.sh/docs/protocols#psiphon-conduit).
 
-**Profiles:** `proxy`, `wireguard`, `amneziawg`, `dnstunnel`, `trusttunnel`, `telegram`, `xhttp`, `admin`, `conduit`, `snowflake`, `monitoring`, `all`
+**Profiles:** `proxy`, `wireguard`, `amneziawg`, `dnstunnel`, `trusttunnel`, `telegram`, `xhttp`, `admin`, `conduit`, `snowflake`, `gooserelay`, `monitoring`, `all`
 
 ## Server Migration
 
@@ -286,13 +288,13 @@ See the [Client Setup guide](https://moav.sh/docs/CLIENTS) for complete list and
 **Ports (open as needed):**
 | Port | Protocol | Service | Requires Domain |
 |------|----------|---------|-----------------|
-| 443/tcp | TCP | Reality (VLESS) | Yes |
+| 443/tcp | TCP | Reality (VLESS) | No — borrows a public SNI via `REALITY_TARGET` |
 | 443/udp | UDP | Hysteria2 | Yes |
 | 8443/tcp | TCP | Trojan | Yes |
 | 8445/tcp | TCP | AnyTLS | Yes |
 | 8388/tcp+udp | TCP+UDP | Shadowsocks-2022 | No |
 | 4443/tcp+udp | TCP+UDP | TrustTunnel | Yes |
-| 2082/tcp | TCP | CDN WebSocket | Yes (Cloudflare) |
+| 2082/tcp | TCP | CDN WebSocket | Cloudflare: yes · CloudFront: no |
 | 51820/udp | UDP | WireGuard | No |
 | 51821/udp | UDP | AmneziaWG | No |
 | 8080/tcp | TCP | wstunnel | No |
@@ -310,7 +312,7 @@ Don't have a domain? MoaV can run in **domainless mode** with:
 - **Reality** (VLESS+Reality, primary protocol)
 - **XHTTP** (VLESS+XHTTP+Reality via Xray-core)
 - **WireGuard** (direct UDP + WebSocket tunnel)
-- **AmneziaWG** (obfuscated WireGuard, defeats DPI)
+- **AmneziaWG** (obfuscated WireGuard, resists common DPI signatures)
 - **Telegram MTProxy** (fake-TLS, direct Telegram access)
 - **GooseRelay** (SOCKS5 over Google Apps Script — no domain needed)
 - **Admin dashboard** (uses self-signed certificate)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Website](https://img.shields.io/badge/website-moav.sh-06b6d4.svg)](https://moav.sh) [![Docs](https://img.shields.io/badge/docs-moav.sh%2Fdocs-2563eb.svg)](https://moav.sh/docs/) [![Release](https://img.shields.io/github/v/release/MotherofallVPNs/MoaV?label=release&color=16a34a&logo=github&logoColor=white)](https://github.com/MotherofallVPNs/MoaV/releases/latest) [![Pre-release](https://img.shields.io/github/v/release/MotherofallVPNs/MoaV?include_prereleases&label=pre-release&color=f59e0b&logo=github&logoColor=white)](https://github.com/MotherofallVPNs/MoaV/releases)
 
-[![Protocols](https://img.shields.io/badge/protocols-16%2B-ef4444.svg)](#protocols) [![AI agents](https://img.shields.io/badge/AI_agents-AGENTS.md-8b5cf6.svg)](AGENTS.md) [![Telegram](https://img.shields.io/badge/Telegram-motherofallvpns-2CA5E0.svg?logo=telegram)](https://t.me/motherofallvpns) [![X](https://img.shields.io/badge/X-@motherofallvpns-000000.svg?logo=x)](https://x.com/motherofallvpns)
+[![Protocols](https://img.shields.io/badge/protocols-16%2B-ef4444.svg)](#protocols) [![moav-client](https://img.shields.io/badge/client-moav--client-06b6d4.svg?logo=github&logoColor=white)](https://github.com/MotherofallVPNs/moav-client) [![AI agents](https://img.shields.io/badge/AI_agents-AGENTS.md-8b5cf6.svg)](AGENTS.md) [![Telegram](https://img.shields.io/badge/Telegram-motherofallvpns-2CA5E0.svg?logo=telegram)](https://t.me/motherofallvpns) [![X](https://img.shields.io/badge/X-@motherofallvpns-000000.svg?logo=x)](https://x.com/motherofallvpns)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e.svg)](LICENSE) [![Stars](https://img.shields.io/github/stars/MotherofallVPNs/MoaV?style=social)](https://github.com/MotherofallVPNs/MoaV/stargazers) [![Forks](https://img.shields.io/github/forks/MotherofallVPNs/MoaV?style=social)](https://github.com/MotherofallVPNs/MoaV/network/members) [![Last commit](https://img.shields.io/github/last-commit/MotherofallVPNs/MoaV/dev?label=last%20commit&color=64748b)](https://github.com/MotherofallVPNs/MoaV/commits/dev)
 
@@ -16,9 +16,23 @@
 
 Built and maintained by the **[MoaV](https://github.com/MotherofallVPNs)** community.
 
-**Local client:** **[moav-client](https://github.com/MotherofallVPNs/moav-client)** — the desktop/CLI app that ingests a MoaV subscription bundle and picks the best live endpoint.
-
 </div>
+
+---
+
+## Why MoaV exists
+
+No single transport survives every censor. A protocol that works this morning can be
+fingerprinted by the afternoon, and the person depending on it has no way to know in
+advance which one will hold.
+
+So MoaV ships many at once, from the same server and the same user bundle. When one
+path stops working the user switches to another instead of waiting for someone to
+re-deploy. That is the whole idea; everything else here is in service of it.
+
+Read the [Mission](https://moav.sh/docs/mission), the [Threat Model](https://moav.sh/docs/threat-model)
+for what MoaV does and does not protect, and the [Philosophy](https://moav.sh/docs/philosophy)
+for the longer argument.
 
 ---
 
@@ -26,15 +40,15 @@ Built and maintained by the **[MoaV](https://github.com/MotherofallVPNs)** commu
 
 **Links** &nbsp;·&nbsp; [Website](https://moav.sh) &nbsp;·&nbsp; [Docs](https://moav.sh/docs/) &nbsp;·&nbsp; [Telegram](https://t.me/motherofallvpns) &nbsp;·&nbsp; [moav-client](https://github.com/MotherofallVPNs/moav-client)
 
-**Get started** &nbsp;·&nbsp; [Features](#features) &nbsp;·&nbsp; [Quick Start](#quick-start) &nbsp;·&nbsp; [Requirements](#requirements)
+**Get started** &nbsp;·&nbsp; [Why MoaV exists](#why-moav-exists) &nbsp;·&nbsp; [Features](#features) &nbsp;·&nbsp; [Quick Start](#quick-start) &nbsp;·&nbsp; [Requirements](#requirements) &nbsp;·&nbsp; [Running without a domain](#running-without-a-domain)
 
-**Use it** &nbsp;·&nbsp; [User Management](#user-management) &nbsp;·&nbsp; [Admin Dashboard & Monitoring](#admin-dashboard--monitoring) &nbsp;·&nbsp; [Service Management](#service-management) &nbsp;·&nbsp; [Testing](#testing) &nbsp;·&nbsp; [Client Apps](#client-apps)
+**Use it** &nbsp;·&nbsp; [Using MoaV](#using-moav) &nbsp;·&nbsp; [Client Apps](#client-apps) &nbsp;·&nbsp; [Documentation](#documentation)
 
-**Under the hood** &nbsp;·&nbsp; [Architecture](#architecture) &nbsp;·&nbsp; [Protocols](#protocols) &nbsp;·&nbsp; [Project Structure](#project-structure) &nbsp;·&nbsp; [Documentation](#documentation)
+**Under the hood** &nbsp;·&nbsp; [Architecture](#architecture) &nbsp;·&nbsp; [Protocols](#protocols) &nbsp;·&nbsp; [Project Structure](#project-structure) &nbsp;·&nbsp; [Security](#security)
 
-**Operate** &nbsp;·&nbsp; [Server Migration](#server-migration) &nbsp;·&nbsp; [Security](#security)
+**Help out** &nbsp;·&nbsp; [Support the project](#support-the-project) &nbsp;·&nbsp; [Community](#community) &nbsp;·&nbsp; [Related projects](#related-projects)
 
-**More** &nbsp;·&nbsp; [License](#license) &nbsp;·&nbsp; [Changelog](#changelog) &nbsp;·&nbsp; [Community & Support](#community--support) &nbsp;·&nbsp; [Disclaimer](#disclaimer)
+**More** &nbsp;·&nbsp; [License](#license) &nbsp;·&nbsp; [Changelog](#changelog) &nbsp;·&nbsp; [Disclaimer](#disclaimer)
 
 ---
 
@@ -184,74 +198,51 @@ See the [Setup Guide](https://moav.sh/docs/SETUP) for complete instructions, the
 | Tor Snowflake | — | — | — | ⬜ | Donate bandwidth to Tor network |
 | MahsaNet | — | — | — | ⬜ | Donate VPN configs to Mahsa VPN (2M+ users) |
 
-## User Management
+## Using MoaV
 
 ```bash
-moav user list            # List all users
-moav user add joe         # Add user to all protocols
-moav user add alice bob   # Add multiple users
-moav user add --batch 10 --prefix team  # Batch create team01..team10
-moav user revoke joe      # Revoke user
-moav user package joe     # Create zip bundle
+moav                          # interactive menu over everything below
+moav status                   # what's running, which profiles, health at a glance
+moav doctor                   # diagnose DNS, ports, certificates, resources
+moav logs sing-box            # tail a service
+
+moav user add alice --package # create a user and build their .zip bundle
+moav user add --batch 10      # ten at once
+moav user list                # who exists
+moav user revoke alice        # revoke immediately
+moav test alice               # prove alice's configs actually pass traffic
+
+moav start proxy admin        # start specific profiles
+moav restart sing-box         # apply an .env change to one service
+moav donate                   # donate configs/bandwidth (MahsaNet, Psiphon, Snowflake)
 ```
 
-Each user gets a bundle in `outputs/bundles/<username>/` with config files, QR codes, and a README.html guide.
+Each user gets `outputs/bundles/<username>/` with config files, QR codes and a
+`README.html` guide, plus a base64 **V2Ray subscription** in `subscription.txt` that
+imports every proxy protocol at once into [MahsaNG](https://github.com/GFW-knocker/MahsaNG),
+v2rayNG or Hiddify. See the [MahsaNG import guide](https://moav.sh/docs/mahsanet).
 
-**MahsaNG / V2Ray users (MahsaNG has 2M+ in Iran):** every bundle includes a standard base64 **V2Ray subscription** — in `subscription.txt` and as a click-to-copy block at the top of the bundle's README — so users paste it once into [MahsaNG](https://github.com/GFW-knocker/MahsaNG), v2rayNG, Hiddify, or any V2Ray app to import all proxy protocols at once. See the [MahsaNG import guide](https://moav.sh/docs/mahsanet).
+To verify a bundle from a client's point of view, [**moav-client**](https://github.com/MotherofallVPNs/moav-client) ingests the subscription, probes every endpoint through its own tunnel and routes through whichever is live and fastest.
 
-**Download bundles** from the admin dashboard at `https://your-server:9443` or via SCP.
+**Dashboards** — password for both is set during install (`ADMIN_PASSWORD` in `.env`),
+reset with `moav admin password`:
 
-## Admin Dashboard & Monitoring
-
-- **Admin dashboard**: `https://your-server:9443` — user management, service status, MahsaNet donations
-- **Grafana**: `https://your-server:9444` — per-user traffic, protocol breakdown, GeoIP distribution
-- **Admin dashboard login**: any username — only the password is checked
-- **Grafana login**: user `admin`
-- **Password** for both: set during install (stored in `.env` as `ADMIN_PASSWORD`)
-- **Reset password**: `moav admin password`
-
-## Service Management
-
-```bash
-moav status               # Show all service status
-moav start                # Start services
-moav start proxy admin    # Start specific profiles
-moav stop                 # Stop all services
-moav restart sing-box     # Restart specific service
-moav logs sing-box        # View service logs
-moav doctor               # Run diagnostics
-moav doctor dns           # Check DNS configuration
-moav donate               # Donate configs to MahsaNet/Psiphon/Snowflake
-moav conduit link         # Psiphon Conduit claim link, QR & sharing guide
-```
-
-**Psiphon Conduit:** once `conduit` is running it already serves Psiphon users (including in Iran) through the public pool — no link to share. To give specific people a private path, `moav conduit link` prints the Ryve claim link/QR and the Personal Pairing steps. The claim link embeds the private key — keep it secret; share with users only via Personal Pairing inside Ryve. See [Psiphon Conduit in docs/protocols.md](https://moav.sh/docs/protocols#psiphon-conduit).
+| | URL | Login |
+|---|---|---|
+| **Admin dashboard** | `https://your-server:9443` | any username — only the password is checked |
+| **Grafana** | `https://your-server:9444` | user `admin` |
 
 **Profiles:** `proxy`, `wireguard`, `amneziawg`, `dnstunnel`, `trusttunnel`, `telegram`, `xhttp`, `admin`, `conduit`, `snowflake`, `gooserelay`, `monitoring`, `all`
 
-## Server Migration
+**Moving to a new server:** `moav export`, then on the new host `moav import moav-backup-*.tar.gz`
+and `moav migrate-ip <new-ip>`. Walkthrough in the [Setup Guide](https://moav.sh/docs/SETUP#server-migration).
 
-Export and migrate your MoaV installation to a new server:
+**Psiphon Conduit:** once `conduit` is running it already serves Psiphon users through the
+public pool — nothing to share. `moav conduit link` prints a private claim link/QR for
+specific people; it embeds the private key, so share it only via Personal Pairing inside
+Ryve. See [Psiphon Conduit](https://moav.sh/docs/protocols#psiphon-conduit).
 
-```bash
-# Export full backup (keys, users, configs)
-moav export                        # Creates moav-backup-TIMESTAMP.tar.gz
-
-# On new server: import and update IP
-moav import moav-backup-*.tar.gz   # Restore configuration
-moav migrate-ip 1.2.3.4            # Update all configs to new IP
-moav start                         # Start services
-```
-
-See the [Setup Guide → Server Migration](https://moav.sh/docs/SETUP#server-migration) for detailed migration workflow.
-
-## Testing
-
-```bash
-moav test user1           # Test all protocols for a user
-moav test user1 -v        # Verbose output for debugging
-moav client connect user1 # Connect as user (exposes local SOCKS5/HTTP proxy)
-```
+Every command, flag and environment variable: **[CLI Reference](https://moav.sh/docs/CLI)**.
 
 ## Client Apps
 
@@ -263,19 +254,23 @@ moav client connect user1 # Connect as user (exposes local SOCKS5/HTTP proxy)
 | Windows | Happ, v2rayN, Hiddify, WireGuard |
 | Linux | Hiddify, sing-box, WireGuard |
 
-See the [Client Setup guide](https://moav.sh/docs/CLIENTS) for complete list and setup instructions.
+See the [Client Setup guide](https://moav.sh/docs/CLIENTS) for the complete list and setup instructions, or [**moav-client**](https://github.com/MotherofallVPNs/moav-client) ([docs](https://moav.sh/docs/client)) for a desktop/CLI client with automatic failover.
 
 ## Documentation
 
-- [Setup Guide](https://moav.sh/docs/SETUP) - Complete installation instructions
-- [CLI Reference](https://moav.sh/docs/CLI) - All moav commands and options
-- [DNS Configuration](https://moav.sh/docs/DNS) - DNS records setup
-- [Client Setup](https://moav.sh/docs/CLIENTS) - How to connect from devices
-- [MahsaNG Import](https://moav.sh/docs/mahsanet) - Import MoaV configs into the MahsaNG app (Iran)
-- [VPS Deployment](https://moav.sh/docs/DEPLOY) - One-click cloud deployment
-- [Monitoring](https://moav.sh/docs/MONITORING) - Grafana + Prometheus observability
-- [Troubleshooting](https://moav.sh/docs/TROUBLESHOOTING) - Common issues and solutions
-- [OpSec Guide](https://moav.sh/docs/OPSEC) - Security best practices
+Full docs: **[moav.sh/docs](https://moav.sh/docs/)**
+
+**Deploy** — [Quick Start](https://moav.sh/docs/quick-start) · [Setup Guide](https://moav.sh/docs/SETUP) · [VPS Deployment](https://moav.sh/docs/DEPLOY) · [DNS Configuration](https://moav.sh/docs/DNS)
+
+**Understand** — [Supported Protocols](https://moav.sh/docs/protocols) · [Architecture](https://moav.sh/docs/architecture) · [Threat Model](https://moav.sh/docs/threat-model) · [Mission](https://moav.sh/docs/mission) · [Philosophy](https://moav.sh/docs/philosophy)
+
+**Connect users** — [Client Apps](https://moav.sh/docs/CLIENTS) · [MahsaNG Import](https://moav.sh/docs/mahsanet) · [MoaV Client](https://moav.sh/docs/client)
+
+**Operate** — [CLI Reference](https://moav.sh/docs/CLI) · [Monitoring](https://moav.sh/docs/MONITORING) · [Troubleshooting](https://moav.sh/docs/TROUBLESHOOTING) · [OPSEC Guide](https://moav.sh/docs/OPSEC)
+
+**Contribute** — [Development & Testing](https://moav.sh/docs/development) · [Translating the Docs](https://moav.sh/docs/TRANSLATING) · [Support MoaV](https://moav.sh/docs/support)
+
+**For AI agents** — [AGENTS.md](AGENTS.md) for working in this repo, [llms.txt](https://moav.sh/llms.txt) as a compact index, [llms-full.txt](https://moav.sh/llms-full.txt) for the whole corpus.
 
 ## Requirements
 
@@ -306,7 +301,7 @@ See the [Client Setup guide](https://moav.sh/docs/CLIENTS) for complete list and
 | 53/udp | UDP | DNS tunnels (dnstt / Slipstream / MasterDNS / XDNS — all share this port) | Yes |
 | 80/tcp | TCP | Let's Encrypt | Yes (during setup) |
 
-### Domainless Mode
+## Running without a domain
 
 Don't have a domain? MoaV can run in **domainless mode** with:
 - **Reality** (VLESS+Reality, primary protocol)
@@ -321,40 +316,31 @@ Don't have a domain? MoaV can run in **domainless mode** with:
 
 Run `moav` and select "No domain" when prompted, or use `moav domainless` to configure.
 
-**Recommended VPS:**
-- VPS Price Trackers: [VPS-PRICES](https://vps-prices.com/)، [VPS Price Tracker](https://vpspricetracker.com/), [Cheap VPS Price Cheat Sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vTOC_THbM2RZzfRUhFCNp3SDXKdYDkfmccis4vxr7WtVIcPmXM-2lGKuZTBr8o_MIJ4XgIUYz1BmcqM/pubhtml)
-- [Time4VPS](https://www.time4vps.com/?affid=8471): 1 vCPU، 1GB RAM، IPv4، 3.99€/Month
-
-
 ## Project Structure
 
 ```
 MoaV/
-├── moav.sh                 # CLI management tool (install with: ./moav.sh install)
-├── docker-compose.yml      # Main compose file
-├── .env.example            # Environment template
-├── Dockerfile.*            # Container definitions
-├── configs/                # Service configurations
-│   ├── sing-box/
-│   ├── wireguard/
-│   ├── amneziawg/
-│   ├── trusttunnel/
-│   ├── dnstt/
-│   ├── masterdns/
-│   ├── gooserelay/
-│   ├── telemt/
-│   └── monitoring/
-├── scripts/                # Management scripts
-│   ├── bootstrap.sh
-│   ├── user-add.sh
-│   ├── user-revoke.sh
-│   └── lib/
-├── outputs/                # Generated configs (gitignored)
-│   └── bundles/
-├── web/                    # Decoy website
-├── admin/                  # Stats dashboard
-└── docs/                   # Dev docs (devdocs/) + README assets
+├── moav.sh              # the CLI: argument parsing, then straight into a cmd_* function
+├── lib/                 # 15 host-side modules — service, users, bootstrap, doctor,
+│                        #   cert, migrate, donate, nettune, dns, peers, menu, …
+├── scripts/             # container entrypoints + provisioning
+│   ├── *-entrypoint.sh  #   one per service
+│   └── lib/             #   shared libraries, mounted into containers as /app/lib
+├── configs/             # *.template files (tracked) rendered into *.json/*.conf (gitignored)
+├── dockerfiles/         # image builds, one per service
+├── exporters/           # Prometheus exporters (sing-box, xray, wireguard, amneziawg, …)
+├── dns-router/          # Go daemon fanning port 53 out to the four DNS tunnels
+├── admin/               # FastAPI dashboard
+├── web/                 # decoy website
+├── data/                # protocols.json — the protocol roster, source of truth
+├── tests/               # the regression suite, named after the bug class each pins
+├── docs/devdocs/        # contributor docs (the user docs live in moav-site)
+├── docker-compose.yml
+└── .env.example         # annotated config reference; commonly-changed vars up top
 ```
+
+`moav.sh` is a dispatcher — the logic lives in `lib/`. `outputs/` (user bundles) and
+`state/` (keys) are generated and gitignored.
 
 ## Security
 
@@ -373,6 +359,94 @@ mode. If that trade-off is not acceptable, run without the monitoring profile.
 
 See the [OPSEC guide](https://moav.sh/docs/OPSEC) for security guidelines.
 
+## Support the project
+
+**Run a server.** The highest-leverage thing you can do. Every MoaV server is capacity
+that did not exist before — for your family, your colleagues, or people you will never
+meet. Nobody runs infrastructure on your behalf; the network *is* the people running
+servers. A $5/month VPS or a Raspberry Pi is enough.
+
+**Donate capacity you already have.** Relay for other circumvention networks without
+having users of your own — `moav start conduit` (Psiphon) and `moav start snowflake`
+(Tor), both opt-in and capped. Or donate configs to [MahsaNet](https://www.mahsaserver.com/)
+with `moav donate`, which hands them to users in Iran who cannot set up a server.
+
+**Contribute or translate.** Bugs, protocols, packaging, docs — see
+[Development & Testing](https://moav.sh/docs/development). Translation is the most useful
+non-code contribution: the docs are scaffolded for Farsi and Russian and one page is a
+complete contribution ([how to translate](https://moav.sh/docs/TRANSLATING)). Bug reports
+count too — a reproducible report with `moav doctor` output is often more work than the fix.
+
+> Never paste bundles, `.env` contents or share links into an issue — they contain live keys.
+
+**Fund the infrastructure.** Test servers for the end-to-end suite, domains, build
+capacity. Not salaries.
+
+<!-- FUNDING:START -->
+| Platform | Link |
+|---|---|
+| **GitHub Sponsors** | [github.com/sponsors/shayanb](https://github.com/sponsors/shayanb) |
+| **Buy Me a Coffee** | [buymeacoffee.com/pangana](https://buymeacoffee.com/pangana) |
+
+| Coin | Address |
+|---|---|
+| **Bitcoin (BTC)** | `bc1qkfq3hg5kpzgy7muc8m3pmh6zemhv820a0ndqgg` |
+| **Ethereum (ETH)**<br>same address on every EVM chain (Arbitrum, Optimism, Base, Polygon, Gnosis…) and any ERC-20 | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
+| **Zcash (ZEC)** | `u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587` |
+| **Tron**<br>TRX and TRC-20 only — not interchangeable with the EVM address | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+<!-- FUNDING:END -->
+
+Addresses are generated from [`.github/FUNDING.yml`](.github/FUNDING.yml), the single
+source of truth, so what you see here is whatever that file says. Take them from this
+page or the repository over HTTPS and check the first and last characters after pasting.
+**We will never DM you an address.**
+
+## Community
+
+- **Telegram:** [t.me/motherofallvpns](https://t.me/motherofallvpns) — questions, help, release announcements
+- **X:** [@motherofallvpns](https://x.com/motherofallvpns)
+- **Issues:** [GitHub Issues](https://github.com/MotherofallVPNs/MoaV/issues) for bugs and feature requests
+- **Docs:** [moav.sh/docs](https://moav.sh/docs)
+
+## Related projects
+
+MoaV is a deployment layer. The protocol work belongs to these projects:
+
+**Companion client** — [moav-client](https://github.com/MotherofallVPNs/moav-client): desktop/CLI
+client that ingests a MoaV subscription, probes every endpoint through its own tunnel and routes
+through whichever is live and fastest ([docs](https://moav.sh/docs/client)).
+
+**Protocol engines**
+
+| Project | What MoaV uses it for |
+|---|---|
+| [sing-box](https://github.com/SagerNet/sing-box) | Reality, Trojan, AnyTLS, Hysteria2, Shadowsocks-2022, CDN VLESS+WS |
+| [Xray-core](https://github.com/XTLS/Xray-core) | XHTTP and XDNS |
+| [REALITY](https://github.com/XTLS/REALITY) | the TLS camouflage Reality and XHTTP are built on |
+| [AmneziaWG](https://github.com/amnezia-vpn/amneziawg-go) · [tools](https://github.com/amnezia-vpn/amneziawg-tools) | DPI-resistant WireGuard |
+| [WireGuard](https://www.wireguard.com/) | the direct UDP VPN |
+| [wstunnel](https://github.com/erebe/wstunnel) | WireGuard over `wss://` when UDP is blocked |
+| [TrustTunnel](https://github.com/TrustTunnel/TrustTunnel) · [client](https://github.com/TrustTunnel/TrustTunnelClient) | HTTP/2 + QUIC transport |
+| [telemt](https://github.com/telemt/telemt) | Telegram MTProxy (fake-TLS) |
+| [dnstt](https://www.bamsoftware.com/software/dnstt/) | the original DNS tunnel |
+| [Slipstream](https://github.com/net2share/slipstream-rust-build) | QUIC-over-DNS |
+| [MasterDNS](https://github.com/masterking32/MasterDnsVPN) | ARQ + resolver load-balancing DNS tunnel |
+| [GooseRelay](https://github.com/kianmhz/GooseRelayVPN) | SOCKS5 over Google Apps Script |
+
+**Networks you can donate capacity to**
+
+| Project | |
+|---|---|
+| [Psiphon Conduit](https://github.com/Psiphon-Inc/conduit) | relay for Psiphon users |
+| [Tor Snowflake](https://snowflake.torproject.org/) | relay for Tor users |
+| [MahsaNet](https://www.mahsaserver.com/) · [MahsaNG](https://github.com/GFW-knocker/MahsaNG) | config donation and the client most Iranian users have |
+
+**Monitoring** — [Prometheus](https://github.com/prometheus/prometheus), [Grafana](https://github.com/grafana/grafana),
+[node_exporter](https://github.com/prometheus/node_exporter), [cAdvisor](https://github.com/google/cadvisor),
+[clash-exporter](https://github.com/zxh326/clash-exporter).
+
+Pinned versions for all of these live in [`.env.example`](.env.example).
+
 ## License
 
 MIT
@@ -381,13 +455,6 @@ MIT
 See [CHANGELOG.md](CHANGELOG.md) for release notes and version history.
 
 
-
-## Community & support
-
-- **Telegram:** [t.me/motherofallvpns](https://t.me/motherofallvpns) — questions, help, and release announcements
-- **Twitter/X:** [@motherofallvpns](https://x.com/motherofallvpns)
-- **Issues:** [GitHub Issues](https://github.com/MotherofallVPNs/MoaV/issues) for bugs and feature requests
-- **Docs:** [moav.sh/docs](https://moav.sh/docs)
 
 ---
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ See the [Setup Guide](https://moav.sh/docs/SETUP) for complete instructions, the
 | Hysteria2 | 443/udp | ★★★★☆ | ★★★★★ | ✅ | Fast, works when TCP throttled |
 | Trojan | 8443/tcp | ★★★★☆ | ★★★★☆ | ✅ | Backup, uses your domain |
 | AnyTLS | 8445/tcp | ★★★★★ | ★★★★☆ | ⬜ | Defeats TLS-in-TLS fingerprinting, uses your domain |
-| Shadowsocks-2022 | 8388/tcp+udp | ★★★★☆ | ★★★★☆ | ⬜ | AEAD-2022 anti-probing; Outline-app compatible |
+| Shadowsocks-2022 | 8388/tcp+udp | ★★★★☆ | ★★★★☆ | ✅ | AEAD-2022 anti-probing; Outline-app compatible |
 | CDN (VLESS+WS) | 443 via Cloudflare | ★★★★★ | ★★★☆☆ | ✅ | When server IP is blocked |
 | TrustTunnel | 4443/tcp+udp | ★★★★★ | ★★★★☆ | ✅ | HTTP/2 & QUIC, looks like HTTPS |
 | WireGuard (Direct) | 51820/udp | ★★★☆☆ | ★★★★★ | ✅ | Full VPN, simple setup |
@@ -194,9 +194,13 @@ See the [Setup Guide](https://moav.sh/docs/SETUP) for complete instructions, the
 | GooseRelay | 8444/tcp | ★★★★★ | ★★☆☆☆ | ⬜ | SOCKS5 via Google Apps Script, fronted as google.com, MahsaNG v16 |
 | Telegram MTProxy | 993/tcp | ★★★★☆ | ★★★☆☆ | ✅ | Fake-TLS V2, direct Telegram access |
 | XHTTP (VLESS+XHTTP+Reality) | 2096/tcp | ★★★★★ | ★★★★☆ | ✅ | Xray-core, no domain needed |
-| Psiphon Conduit | — | — | — | ⬜ | Donate bandwidth to Psiphon (2M+ users) |
-| Tor Snowflake | — | — | — | ⬜ | Donate bandwidth to Tor network |
+| Psiphon Conduit | — | — | — | ✅ | Donate bandwidth to Psiphon (2M+ users) |
+| Tor Snowflake | — | — | — | ✅ | Donate bandwidth to Tor network |
 | MahsaNet | — | — | — | ⬜ | Donate VPN configs to Mahsa VPN (2M+ users) |
+
+**Default** = enabled in `.env.example`. Services still only run under their
+profile, so `moav start conduit` is what actually starts Conduit. MahsaNet is an
+action (`moav donate`), not a service.
 
 ## Using MoaV
 
@@ -391,9 +395,12 @@ capacity. Not salaries.
 | Coin | Address |
 |---|---|
 | **Bitcoin (BTC)** | `bc1qkfq3hg5kpzgy7muc8m3pmh6zemhv820a0ndqgg` |
-| **Ethereum (ETH)**<br>same address on every EVM chain (Arbitrum, Optimism, Base, Polygon, Gnosis…) and any ERC-20 | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
+| **Ethereum (ETH)**¹ | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
 | **Zcash (ZEC)** | `u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587` |
-| **Tron**<br>TRX and TRC-20 only — not interchangeable with the EVM address | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+| **Tron**² | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+
+¹ **Ethereum (ETH)** — same address on every EVM chain (Arbitrum, Optimism, Base, Polygon, Gnosis…) and any ERC-20
+² **Tron** — TRX and TRC-20 only — not interchangeable with the EVM address
 <!-- FUNDING:END -->
 
 Addresses are generated from [`.github/FUNDING.yml`](.github/FUNDING.yml), the single

--- a/README.md
+++ b/README.md
@@ -395,11 +395,12 @@ capacity. Not salaries.
 | Coin | Address |
 |---|---|
 | **Bitcoin (BTC)** | `bc1qkfq3hg5kpzgy7muc8m3pmh6zemhv820a0ndqgg` |
-| **Ethereum (ETH)**¹ | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
+| **Ethereum (ETH)** ¹ | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
 | **Zcash (ZEC)** | `u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587` |
-| **Tron**² | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+| **Tron** ² | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
 
-¹ **Ethereum (ETH)** — same address on every EVM chain (Arbitrum, Optimism, Base, Polygon, Gnosis…) and any ERC-20
+¹ **Ethereum (ETH)** — same address on every EVM chain (Arbitrum, Optimism, Base, Gnosis…) and any ERC20 (USDC, USDT, DAI…)
+
 ² **Tron** — TRX and TRC-20 only — not interchangeable with the EVM address
 <!-- FUNDING:END -->
 

--- a/scripts/render-funding.sh
+++ b/scripts/render-funding.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Render the donation block in README.md (and README-fa.md) from
+# .github/FUNDING.yml, so the addresses live in exactly one place.
+#
+# FUNDING.yml is already the canonical list -- GitHub reads `github:` and
+# `buy_me_a_coffee:` for the Sponsor button and ignores the crypto keys, which
+# is fine because those are ours. Copying addresses into a README by hand is how
+# the sing-box version ended up pinned in nine places, and an address is the one
+# thing that must never be wrong.
+#
+#   scripts/render-funding.sh            # rewrite the block in place
+#   scripts/render-funding.sh --check    # CI: fail if the block is stale
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FUNDING="$ROOT/.github/FUNDING.yml"
+START="<!-- FUNDING:START -->"
+END="<!-- FUNDING:END -->"
+CHECK=0
+[[ "${1:-}" == "--check" ]] && CHECK=1
+
+[[ -f "$FUNDING" ]] || { echo "render-funding: $FUNDING not found" >&2; exit 1; }
+
+render() {
+    python3 - "$FUNDING" "$1" <<'PY'
+import re, sys
+
+funding, lang = sys.argv[1], sys.argv[2]
+
+# Deliberately not a YAML parser: this is a flat key/value list and depending on
+# PyYAML would add a build dependency for a dozen lines.
+platforms = {
+    "github":          ("GitHub Sponsors", "https://github.com/sponsors/{v}"),
+    "buy_me_a_coffee": ("Buy Me a Coffee", "https://buymeacoffee.com/{v}"),
+    "open_collective": ("Open Collective", "https://opencollective.com/{v}"),
+    "liberapay":       ("Liberapay",       "https://liberapay.com/{v}"),
+    "ko_fi":           ("Ko-fi",           "https://ko-fi.com/{v}"),
+}
+coins = {
+    "BTC": "Bitcoin", "ETH": "Ethereum", "ZEC": "Zcash", "XMR": "Monero",
+    "LTC": "Litecoin", "TRON": "Tron", "SOL": "Solana",
+    "LN": "Lightning", "LIGHTNING": "Lightning",
+}
+# ETH is one address across every EVM chain; Tron is NOT -- TRX/TRC-20 use a
+# base58 address and anything sent to the 0x one is unrecoverable.
+notes_en = {
+    "ETH": "same address on every EVM chain (Arbitrum, Optimism, Base, Polygon, Gnosis…) and any ERC-20",
+    "TRON": "TRX and TRC-20 only — not interchangeable with the EVM address",
+}
+notes_fa = {
+    "ETH": "همین نشانی روی همهٔ زنجیره‌های EVM کار می‌کند و برای هر توکن ERC-20",
+    "TRON": "فقط TRX و TRC-20 — با نشانی EVM بالا یکی نیست",
+}
+head = {"en": ("Platform", "Link", "Coin", "Address"),
+        "fa": ("پلتفرم", "لینک", "ارز", "نشانی")}[lang]
+notes = notes_en if lang == "en" else notes_fa
+
+plat, crypto = [], []
+for line in open(funding, encoding="utf-8"):
+    line = line.split("#", 1)[0].strip()
+    m = re.match(r"^([A-Za-z_]+)\s*:\s*(.+)$", line)
+    if not m:
+        continue
+    key, val = m.group(1), m.group(2).strip().strip("[]").strip().strip("'\"")
+    if not val:
+        continue
+    if key in platforms:
+        name, url = platforms[key]
+        full = url.format(v=val)
+        plat.append(f"| **{name}** | [{full.split('//')[1]}]({full}) |")
+    else:
+        nice = coins.get(key.upper(), key)
+        label = f"{nice} ({key.upper()})" if nice.upper() != key.upper() else nice
+        note = notes.get(key.upper())
+        cell = f"`{val}`"
+        crypto.append(f"| **{label}** | {cell} |" if not note
+                      else f"| **{label}**<br>{note} | {cell} |")
+
+out = []
+if plat:
+    out += [f"| {head[0]} | {head[1]} |", "|---|---|", *plat, ""]
+if crypto:
+    out += [f"| {head[2]} | {head[3]} |", "|---|---|", *crypto]
+print("\n".join(out).rstrip())
+PY
+}
+
+status=0
+for f in README.md README-fa.md; do
+    path="$ROOT/$f"
+    [[ -f "$path" ]] || continue
+    grep -q "$START" "$path" || continue    # file has no block yet; skip silently
+
+    lang=en
+    [[ "$f" == *-fa.md ]] && lang=fa
+    block=$(render "$lang")
+
+    new=$(python3 - "$path" "$START" "$END" "$block" <<'PY'
+import sys
+path, start, end, block = sys.argv[1:5]
+s = open(path, encoding="utf-8").read()
+a = s.index(start) + len(start)
+b = s.index(end)
+sys.stdout.write(s[:a] + "\n" + block + "\n" + s[b:])
+PY
+)
+    if [[ "$CHECK" == "1" ]]; then
+        if [[ "$new" != "$(cat "$path")" ]]; then
+            echo "render-funding: $f is out of date — run scripts/render-funding.sh" >&2
+            status=1
+        else
+            echo "render-funding: $f up to date"
+        fi
+    else
+        printf '%s' "$new" > "$path"
+        echo "render-funding: refreshed the donation block in $f"
+    fi
+done
+exit "$status"

--- a/scripts/render-funding.sh
+++ b/scripts/render-funding.sh
@@ -55,7 +55,7 @@ head = {"en": ("Platform", "Link", "Coin", "Address"),
         "fa": ("پلتفرم", "لینک", "ارز", "نشانی")}[lang]
 notes = notes_en if lang == "en" else notes_fa
 
-plat, crypto = [], []
+plat, crypto, footnotes = [], [], []
 for line in open(funding, encoding="utf-8"):
     line = line.split("#", 1)[0].strip()
     m = re.match(r"^([A-Za-z_]+)\s*:\s*(.+)$", line)
@@ -72,15 +72,24 @@ for line in open(funding, encoding="utf-8"):
         nice = coins.get(key.upper(), key)
         label = f"{nice} ({key.upper()})" if nice.upper() != key.upper() else nice
         note = notes.get(key.upper())
-        cell = f"`{val}`"
-        crypto.append(f"| **{label}** | {cell} |" if not note
-                      else f"| **{label}**<br>{note} | {cell} |")
+        marker = ""
+        if note:
+            # Superscript numerals, not asterisks: a line starting with "*"
+            # renders as a bullet and "**" as broken bold.
+            sup = "¹²³⁴⁵⁶⁷⁸⁹"[len(footnotes)]
+            marker = sup
+            footnotes.append(f"{sup} **{label}** — {note}")
+        crypto.append(f"| **{label}**{marker} | `{val}` |")
 
 out = []
 if plat:
     out += [f"| {head[0]} | {head[1]} |", "|---|---|", *plat, ""]
 if crypto:
     out += [f"| {head[2]} | {head[3]} |", "|---|---|", *crypto]
+    # Notes live under the table: inline they wrap inside a narrow first column
+    # and blow the row height up to a dozen lines on GitHub.
+    if footnotes:
+        out += [""] + footnotes
 print("\n".join(out).rstrip())
 PY
 }


### PR DESCRIPTION
English pass first, as agreed. **README-fa.md follows as a second commit on this branch**, rebuilt against the corrected English rather than patched in place.

Same treatment the docs got in moav-site#10, so the README and the docs site stop disagreeing.

## Facts that were wrong

| Claim | Reality |
|---|---|
| Ports table: Reality **requires a domain** | It does not — it borrows a public SNI via `REALITY_TARGET`. Same error the Setup Guide had. |
| "Username: `admin`" for both dashboards | Only **Grafana** requires `admin`. The MoaV dashboard checks the password and ignores the username (`verify_auth` never compares it). Now two separate lines. |
| Profiles list | Omitted `gooserelay`. |
| CDN WebSocket "Yes (Cloudflare)" | CloudFront needs no custom domain. |

## Claims softened

- "16+ protocols covering every censorship scenario" → names transports and fallback paths, and keeps the Psiphon/Tor/MahsaNet donation integrations separate from user transports
- Reality "most reliable" → "a strong first choice where it works"
- AmneziaWG "defeats DPI" → "resists common DPI signatures"

**Star ratings left alone.** A relative scale inside a comparison table isn't an absolute claim, and flattening it would lose real information — same call I made for the docs protocol table.

## Verified

- `scripts/gen-protocol-docs.py --check` (protocol-roster drift gate) passes
- all 23 CI suites pass
- no residual `defeats` / `unblockable` / `indistinguishable` / `most reliable`

## Next commit on this branch

`README-fa.md` is tracking an **older structure**, not just older wording — 22 headings against README.md's 24 — so it gets rebuilt from the corrected English rather than patched. It also predates the claims fixed above, so translating before this landed would have baked them in.