### PR TITLE
fix(bundles): ship Slipstream + MasterDNS configs in host-generated bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         run: bash tests/singbox-user-metrics-test.sh
       - name: CLI surface consistency (help/links/table/pins)
         run: bash tests/cli-surface-test.sh
+      - name: DNS-tunnel bundle completeness
+        run: bash tests/dns-tunnel-bundle-test.sh
       - name: admin TLS enforcement
         run: bash tests/admin-tls-test.sh
       - name: admin IP whitelist (CIDR) unit test

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -263,6 +263,23 @@ STATE_DIR="${STATE_DIR:-state}"
 AWG_CONFIG_DIR="configs/amneziawg"
 GOOSERELAY_CONFIG_DIR="configs/gooserelay"
 
+# $STATE_DIR/keys exists in the containers but not on the host, so hydrate it
+# from the client-facing copies bootstrap publishes; keeps the shared generators
+# in scripts/lib/*.sh reading one location on both paths.
+publish_to_state_keys() {   # <published-host-file> <state-key-filename>
+    local src="$1" dst="$STATE_DIR/keys/$2"
+    [[ -s "$dst" ]] && return 0        # already there (container-style layout)
+    [[ -s "$src" ]] || return 1
+    mkdir -p "$STATE_DIR/keys" 2>/dev/null || return 1
+    cp "$src" "$dst" 2>/dev/null || return 1
+}
+_hydrated=0
+publish_to_state_keys "outputs/slipstream/cert.pem"       "slipstream-cert.pem"   && _hydrated=1
+publish_to_state_keys "outputs/masterdns/encrypt_key.txt" "masterdns-encrypt.key" && _hydrated=1
+# a root cp leaves 640 root:root; uid 2000 must be able to read these
+[[ "$_hydrated" == "1" ]] && secure_state_keys "$STATE_DIR/keys"
+unset _hydrated
+
 for USERNAME in "${USERNAMES[@]}"; do
     OUTPUT_DIR="outputs/bundles/$USERNAME"
     mkdir -p "$OUTPUT_DIR"
@@ -402,15 +419,25 @@ echo ""
 # is enabled and its key/config is present. ($STATE_DIR + the host lib config
 # dirs are set above, before the per-user loop.)
 
-if [[ "${ENABLE_SLIPSTREAM:-true}" == "true" ]] && [[ -f "$STATE_DIR/keys/slipstream-cert.pem" ]]; then
-    if slipstream_generate_client_instructions "$USERNAME" "$OUTPUT_DIR"; then
-        log_info "✓ Slipstream instructions generated"
+if [[ "${ENABLE_SLIPSTREAM:-true}" == "true" ]]; then
+    if [[ -f "$STATE_DIR/keys/slipstream-cert.pem" ]]; then
+        if slipstream_generate_client_instructions "$USERNAME" "$OUTPUT_DIR"; then
+            log_info "✓ Slipstream instructions generated"
+        fi
+    else
+        log_warn "Slipstream is enabled but its certificate was not found — bundle will not include it"
+        log_warn "  looked in $STATE_DIR/keys/slipstream-cert.pem and outputs/slipstream/cert.pem; run 'moav bootstrap' to publish it"
     fi
 fi
 
-if [[ "${ENABLE_MASTERDNS:-true}" == "true" ]] && [[ -s "$STATE_DIR/keys/masterdns-encrypt.key" ]]; then
-    if masterdns_generate_client_instructions "$USERNAME" "$OUTPUT_DIR"; then
-        log_info "✓ MasterDNS instructions generated"
+if [[ "${ENABLE_MASTERDNS:-true}" == "true" ]]; then
+    if [[ -s "$STATE_DIR/keys/masterdns-encrypt.key" ]]; then
+        if masterdns_generate_client_instructions "$USERNAME" "$OUTPUT_DIR"; then
+            log_info "✓ MasterDNS instructions generated"
+        fi
+    else
+        log_warn "MasterDNS is enabled but its encryption key was not found — bundle will not include it"
+        log_warn "  looked in $STATE_DIR/keys/masterdns-encrypt.key and outputs/masterdns/encrypt_key.txt; run 'moav bootstrap' to publish it"
     fi
 fi
 

--- a/tests/dns-tunnel-bundle-test.sh
+++ b/tests/dns-tunnel-bundle-test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Regression test: every enabled DNS tunnel must reach the user bundle, and a
+# missing key must be loud.
+#
+# Bug: on a real server NO user bundle contained Slipstream or MasterDNS configs
+# -- not just later users, every user including the bootstrap-created ones --
+# while both services were enabled and had been running for a day. The server was
+# serving two last-resort transports to nobody.
+#
+# Cause: `moav user add` runs on the HOST and gated each one on
+# $STATE_DIR/keys/<key>, but those keys live in the moav_state volume and there is
+# no keys/ directory on the host at all. Both guards were bare `if [[ -f ]]` with
+# no else, so the configs were skipped silently and the command still exited 0.
+#
+# dnstt was unaffected because it reads outputs/dnstt/server.pub, which bootstrap
+# publishes to the host bind mount. bootstrap publishes the other two the same way
+# (outputs/slipstream/cert.pem, outputs/masterdns/encrypt_key.txt, both verified
+# byte-identical to the volume originals) -- the host path just never looked there.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ua="$ROOT/scripts/user-add.sh"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "DNS-tunnel bundle completeness tests"
+
+# --- the host path must consult the published copies ------------------------
+# Comments are stripped first: an earlier version of this test grepped the whole
+# file and passed on the explanatory comment alone, so deleting the actual
+# hydration calls still showed green.
+code=$(sed 's/[[:space:]]*#.*$//' "$ua")
+
+grep -q 'publish_to_state_keys "outputs/slipstream/cert.pem"' <<<"$code" \
+    && ok "user-add hydrates from the published Slipstream cert" \
+    || bad "no publish_to_state_keys call for outputs/slipstream/cert.pem — host bundles will omit Slipstream"
+
+grep -q 'publish_to_state_keys "outputs/masterdns/encrypt_key.txt"' <<<"$code" \
+    && ok "user-add hydrates from the published MasterDNS key" \
+    || bad "no publish_to_state_keys call for outputs/masterdns/encrypt_key.txt — host bundles will omit MasterDNS"
+
+grep -q 'secure_state_keys' <<<"$code" \
+    && ok "hydrated keys get their modes normalized" \
+    || bad "secure_state_keys not called — a root cp leaves 640 root:root, unreadable by uid 2000"
+
+grep -q 'outputs/dnstt/server.pub' <<<"$code" \
+    && ok "dnstt still reads its published pubkey (unchanged)" \
+    || bad "dnstt's published pubkey read disappeared"
+
+# --- a missing key must warn, not skip in silence ---------------------------
+for proto in Slipstream MasterDNS; do
+    if awk -v p="$proto" '
+        $0 ~ ("ENABLE_" toupper(p)) {inblock=1}
+        inblock && /log_warn/ {found=1}
+        inblock && /^fi$/ {inblock=0}
+        END {exit !found}' "$ua"; then
+        ok "$proto logs a warning when enabled but keyless"
+    else
+        bad "$proto still skips silently when its key is missing"
+    fi
+done
+
+# --- exercise the hydration for real ----------------------------------------
+# Simulate a host layout: published files present, state/keys absent.
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/outputs/slipstream" "$tmp/outputs/masterdns" "$tmp/state"
+printf 'CERTDATA\n' > "$tmp/outputs/slipstream/cert.pem"
+printf 'KEYDATA\n'  > "$tmp/outputs/masterdns/encrypt_key.txt"
+
+# Extract the helper and run it in isolation, against the simulated tree.
+helper=$(sed -n '/^publish_to_state_keys()/,/^}/p' "$ua")
+if [ -z "$helper" ]; then
+    bad "publish_to_state_keys() not found — cannot test the hydration"
+else
+    out=$(
+        cd "$tmp" || exit 1
+        STATE_DIR="state"
+        eval "$helper"
+        publish_to_state_keys "outputs/slipstream/cert.pem"       "slipstream-cert.pem"   && echo "slip-ok"
+        publish_to_state_keys "outputs/masterdns/encrypt_key.txt" "masterdns-encrypt.key" && echo "md-ok"
+    )
+    [[ "$out" == *slip-ok* && "$out" == *md-ok* ]] \
+        && ok "helper reports success for both protocols" \
+        || bad "helper failed: $out"
+
+    [[ -s "$tmp/state/keys/slipstream-cert.pem" ]] \
+        && ok "Slipstream cert landed in state/keys/" \
+        || bad "Slipstream cert was not hydrated"
+    [[ -s "$tmp/state/keys/masterdns-encrypt.key" ]] \
+        && ok "MasterDNS key landed in state/keys/" \
+        || bad "MasterDNS key was not hydrated"
+
+    # Content must survive intact -- these keys go straight into client configs.
+    [[ "$(cat "$tmp/state/keys/slipstream-cert.pem")" == "CERTDATA" ]] \
+        && ok "cert content copied verbatim" || bad "cert content altered"
+    [[ "$(cat "$tmp/state/keys/masterdns-encrypt.key")" == "KEYDATA" ]] \
+        && ok "key content copied verbatim" || bad "key content altered"
+
+    # An existing container-style key must win: the volume copy is canonical, and
+    # clobbering it from outputs/ would let a stale publish overwrite live material.
+    printf 'CANONICAL\n' > "$tmp/state/keys/slipstream-cert.pem"
+    (
+        cd "$tmp" || exit 1
+        STATE_DIR="state"; eval "$helper"
+        publish_to_state_keys "outputs/slipstream/cert.pem" "slipstream-cert.pem"
+    ) >/dev/null 2>&1
+    [[ "$(cat "$tmp/state/keys/slipstream-cert.pem")" == "CANONICAL" ]] \
+        && ok "an existing key is not overwritten by the published copy" \
+        || bad "hydration clobbered an existing key"
+
+    # The whole hydration block must survive `set -euo pipefail` in both states:
+    # nothing to do (container layout, keys already present) and a missing source.
+    # Run the real block from the script rather than a paraphrase of it.
+    block=$(sed -n '/^_hydrated=0/,/^unset _hydrated/p' "$ua")
+    for state in already-present missing-source; do
+        [[ "$state" == "missing-source" ]] && rm -f "$tmp/state/keys/"* "$tmp/outputs/slipstream/cert.pem"
+        got=$(
+            cd "$tmp" || exit 1
+            set -euo pipefail
+            STATE_DIR="state"
+            secure_state_keys() { :; }
+            eval "$helper"
+            eval "$block"
+            echo "survived"
+        ) 2>&1
+        [[ "$got" == *survived* ]] \
+            && ok "hydration block survives strict mode ($state)" \
+            || bad "hydration block aborts under set -e ($state): $got"
+    done
+    # Restore for the checks below.
+    printf 'CERTDATA\n' > "$tmp/outputs/slipstream/cert.pem"
+
+    # Nothing to publish must fail cleanly rather than creating an empty key,
+    # which would pass the -s guard downstream and emit a broken config.
+    rm -f "$tmp/state/keys/masterdns-encrypt.key" "$tmp/outputs/masterdns/encrypt_key.txt"
+    (
+        cd "$tmp" || exit 1
+        STATE_DIR="state"; eval "$helper"
+        publish_to_state_keys "outputs/masterdns/encrypt_key.txt" "masterdns-encrypt.key"
+    ) >/dev/null 2>&1
+    [[ ! -e "$tmp/state/keys/masterdns-encrypt.key" ]] \
+        && ok "a missing source creates no empty key file" \
+        || bad "hydration created an empty/placeholder key"
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Two of the four DNS tunnels never reached a single user bundle. Both services ran fine — they just had no clients.

## What was wrong

`scripts/user-add.sh` runs on the **host** and gated each generator on `$STATE_DIR/keys/<key>`. Those keys live in the `moav_state` volume; the host `state/` tree has no `keys/` directory at all. Both guards were bare `if [[ -f ]]` with **no else**, so the configs were skipped in silence and the command still exited 0.

Verified on a live server: no user had either config — including bootstrap-created ones, so this was broader than "only users added later".

The same gap hit the **dashboard**: `admin/main.py` runs the script with `cwd=/project` and no `STATE_DIR`, which resolves to the same empty host `state/`.

**dnstt and XDNS were never affected.** dnstt reads `outputs/dnstt/server.pub`, and its per-user delivery is the pubkey embedded in `README.html`, not a config file — there is deliberately no per-user dnstt file.

## The fix

`bootstrap` already publishes the client-facing material to host-visible paths for exactly this reason. Mirror those two published copies into `$STATE_DIR/keys/` so the shared generators in `scripts/lib/*.sh` keep serving the host and container paths from one code path, rather than teaching the libs a second location.

Then hand off to the existing `secure_state_keys()` — it already names both files explicitly (644, root-owned). Without it a root `cp` leaves `640 root:root`, which the uid-2000 admin user cannot read; the admin container runs as root today, but `Dockerfile.admin` builds a uid-2000 user, and the day it drops to it these configs would start silently missing again.

Both guards now **warn** when a protocol is enabled but its key is absent, naming both locations checked, instead of skipping quietly.

## Verified on a live server

From a clean slate (`state/keys` deleted entirely):

- both configs land in the bundle and the zip
- Slipstream cert **byte-identical** to the published one; MasterDNS key matches `encrypt_key.txt`; domains correct (`s.`/`m.` subdomains)
- hydrated keys come out `644 root:root`, matching the volume copies
- dnstt pubkey still present in `README.html`; no placeholders left
- warning path fires correctly and still generates the other protocols
- dashboard path verified by running the script inside the admin container

## Note for existing users

This only affects newly generated bundles. Existing users still have incomplete ones — `moav regenerate-users` rebuilds them.

## Tests

`tests/dns-tunnel-bundle-test.sh`, 15 asserts, wired into `ci.yml`. Each assert was checked to fail when its bug is reintroduced (hydration call removed, `secure_state_keys` dropped, clobber guard removed, warning removed).

Worth noting: the first version of this test grepped the whole script and passed on my own explanatory comment, so deleting the real hydration calls still showed green. It now strips comments and asserts the actual call sites. One assert (no empty key file on a missing source) holds via `cp` failing rather than the explicit guard, so that guard is belt-and-braces.