### PR TITLE
docs/cli: stop calling 'moav user base64' a subscription; add 'moav user sub'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         run: bash tests/cli-surface-test.sh
       - name: DNS-tunnel bundle completeness
         run: bash tests/dns-tunnel-bundle-test.sh
+      - name: user subscription vs bundle-blob distinction
+        run: bash tests/user-subscription-test.sh
       - name: admin TLS enforcement
         run: bash tests/admin-tls-test.sh
       - name: admin IP whitelist (CIDR) unit test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,8 @@ with none they act on the whole stack.
 | `moav user add <name> [--package]` | Create a user (keys, configs, QR). `--package` also builds the downloadable zip |
 | `moav user add --batch N [--prefix NAME] [--package]` | Bulk-create N users |
 | `moav user package <name>` | (Re)build one user's downloadable **zip bundle** in `outputs/` |
-| `moav user base64 <name>` | Print that user's base64 **subscription** string |
+| `moav user sub <name>` | Print that user's base64 **subscription** — the blob phone apps (Streisand, v2rayNG, NekoBox, Hiddify) import |
+| `moav user base64 <name>` | Print that user's text-only bundle **zipped, then base64** — input for moav-client's e2e `bundle_b64`. **Not** a subscription; client apps reject it |
 | `moav user revoke <name>` | **Destructive** — remove a user and their access. Confirm with the owner first |
 | `moav regenerate-users` | Rebuild every bundle from stored state (keys unchanged); users just re-download |
 | `moav logs [svc]` | Tail container logs — **first stop for debugging** |

--- a/lib/menu.sh
+++ b/lib/menu.sh
@@ -133,7 +133,8 @@ show_usage() {
     echo "  user add --batch N [--prefix P]    Batch create (user01, user02...)"
     echo "  user revoke NAME      Revoke a user"
     echo "  user package NAME     Create zip bundle for existing user"
-    echo "  user base64 NAME      Base64 text-only bundle (for e2e / quick import)"
+    echo "  user sub NAME         Base64 subscription for phone apps (Streisand, v2rayNG...)"
+    echo "  user base64 NAME      Base64 ZIPPED bundle for moav-client e2e (not a subscription)"
     echo "  admin password        Reset admin dashboard password"
     echo ""
     echo "Donate & Test:"
@@ -163,6 +164,7 @@ show_usage() {
     echo "  moav start proxy admin               # Start specific profiles"
     echo "  moav user add alice bob --package     # Add users with zip bundles"
     echo "  moav user add --batch 10 --prefix vip # Batch create vip01..vip10"
+    echo "  moav user sub alice                  # Subscription blob to paste into a phone app"
     echo "  moav donate                          # Donate configs to MahsaNet"
     echo "  moav doctor dns                      # Check DNS configuration"
     echo "  moav export                          # Backup to moav-backup-TIMESTAMP.tar.gz"
@@ -408,14 +410,50 @@ update_env_var() {
 # files + subscription.txt; excludes the QR PNGs and README.html, which are the
 # bulk). Paste it into moav-client's e2e `bundle_b64` input, or use it for a
 # quick client import:  moav user base64 alice | pbcopy
+# Base64 V2Ray subscription for a user. Hands over the bundle's subscription.txt
+# rather than re-encoding, so there is no second format to keep in sync.
+cmd_user_subscription() {
+    local user="${1:-}"
+    if [[ -z "$user" ]]; then
+        error "Usage: moav user sub USERNAME"
+        {
+            echo ""
+            echo "Prints the base64 V2Ray subscription for a user -- paste into Streisand,"
+            echo "v2rayNG, NekoBox, Hiddify, or any client that accepts a subscription blob."
+            echo "For the whole bundle as a zipped blob (moav-client e2e): moav user base64"
+            echo ""
+            echo "Available users:"
+            ls -1 outputs/bundles/ 2>/dev/null || echo "  No users found"
+        } >&2
+        exit 1
+    fi
+    local sub="outputs/bundles/$user/subscription.txt"
+    if [[ ! -d "outputs/bundles/$user" ]]; then
+        error "User bundle not found: outputs/bundles/$user"
+        exit 1
+    fi
+    if [[ ! -s "$sub" ]]; then
+        error "No subscription.txt in $user's bundle."
+        error "  Regenerate it with: moav user package $user   (or: moav regenerate-users)"
+        exit 1
+    fi
+    # strip the trailing newline; some importers choke on a blank line
+    printf '%s\n' "$(tr -d '\r\n' < "$sub")"
+}
+
 cmd_user_base64() {
     local user="${1:-}"
     if [[ -z "$user" ]]; then
         error "Usage: moav user base64 USERNAME"
         {
             echo ""
-            echo "Emits base64 of a text-only bundle (configs + subscription.txt; no QR PNGs / README)."
-            echo "Paste into moav-client's e2e 'bundle_b64' input, or:  moav user base64 alice | pbcopy"
+            echo "Emits base64 of a zipped, text-only bundle (configs + subscription.txt;"
+            echo "no QR PNGs / README) for moav-client's e2e 'bundle_b64' input:"
+            echo "  moav user base64 alice | pbcopy"
+            echo ""
+            echo "This is NOT a client subscription. Phone apps (Streisand, v2rayNG,"
+            echo "NekoBox, Hiddify) will reject it -- it is a zip, not a config list."
+            echo "For those, use:  moav user sub USERNAME"
             echo ""
             echo "Available users:"
             ls -1 outputs/bundles/ 2>/dev/null || echo "  No users found"
@@ -440,7 +478,8 @@ cmd_user_base64() {
     b64="$(base64 < "$zip" | tr -d '\n')"
     size="$(wc -c < "$zip" | tr -d ' ')"
     rm -rf "$tmp"
-    echo "[moav] text-only bundle for '$user': ${size}B zipped -> ${#b64} base64 chars" >&2
+    echo "[moav] zipped text-only bundle for '$user' (for moav-client, not a client subscription):" >&2
+    echo "[moav]   ${size}B zipped -> ${#b64} base64 chars. Phone apps want: moav user sub $user" >&2
     printf '%s\n' "$b64"
 }
 

--- a/lib/users.sh
+++ b/lib/users.sh
@@ -331,11 +331,15 @@ cmd_user() {
                 exit 1
             fi
             ;;
-        base64|b64)
+        sub|subscription)
+            cmd_user_subscription "$username"
+            ;;
+        # emits a zipped bundle for moav-client's e2e, not a client subscription
+        base64|b64|bundle-b64)
             cmd_user_base64 "$username"
             ;;
         *)
-            error "Usage: moav user [list|add|revoke|package|base64] [USERNAME]"
+            error "Usage: moav user [list|add|revoke|package|sub|base64] [USERNAME]"
             exit 1
             ;;
     esac

--- a/tests/user-subscription-test.sh
+++ b/tests/user-subscription-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# `moav user base64` vs `moav user sub` must stay distinguishable.
+#
+# A release tester pasted `moav user base64` output into Streisand and reported
+# it as an invalid config. It is not a bug in the encoding: that command emits a
+# zipped bundle for moav-client's e2e `bundle_b64` input. It was a naming and
+# documentation failure -- AGENTS.md described it as printing the user's "base64
+# subscription", the help called it a "quick import", and the ecosystem meaning
+# of "base64" for a VPN user is unambiguously a subscription blob.
+#
+# So: keep base64 emitting a zip, give the actual subscription its own command,
+# and never let the docs call base64 a subscription again.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "user subscription / bundle-blob distinction"
+
+menu="$ROOT/lib/menu.sh"
+users="$ROOT/lib/users.sh"
+
+# --- both commands must exist and route separately -------------------------
+grep -q 'cmd_user_subscription()' "$menu" \
+    && ok "cmd_user_subscription exists" || bad "no cmd_user_subscription"
+
+grep -qE '^\s+sub\|subscription\)' "$users" \
+    && ok "'user sub' is routed" || bad "'user sub' is not routed"
+
+grep -qE '^\s+base64\|b64' "$users" \
+    && ok "'user base64' still routed (moav-client e2e depends on the name)" \
+    || bad "'user base64' route disappeared — breaks moav-client's bundle_b64 flow"
+
+# --- the subscription command must read subscription.txt, not re-encode ----
+# Two encoders would drift; the bundle file is already the canonical format.
+# Match the assignment, not any mention: the not-found error message also says
+# "subscription.txt", so a looser grep passes even when the path is changed.
+if awk '/^cmd_user_subscription\(\)/,/^}/' "$menu" \
+     | grep -qE '(sub|local sub)=.*subscription\.txt'; then
+    ok "user sub reads the bundle's subscription.txt"
+else
+    bad "user sub does not read subscription.txt — second format to keep in sync"
+fi
+
+# base64 must still zip. If this ever starts emitting the subscription instead,
+# moav-client's e2e input silently breaks. Match the zip *invocation*: the local
+# variable is itself named `zip`, so a bare grep for "zip" always passes.
+if awk '/^cmd_user_base64\(\)/,/^}/' "$menu" | grep -qE '(^|[^a-z_])zip +-'; then
+    ok "user base64 still emits a zip"
+else
+    bad "user base64 no longer zips — moav-client e2e bundle_b64 would break"
+fi
+
+# --- nothing may describe base64 as a subscription -------------------------
+# This is the exact wording that caused the misreport.
+offenders=""
+while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    # Any line naming `user base64` and calling it a subscription, unless it is
+    # explicitly negating ("not a subscription", "NOT a client subscription").
+    # No [^|]* here: in a markdown table the two halves are separated by the very
+    # pipe such a class excludes, which silently exempted the AGENTS.md row that
+    # caused this bug in the first place.
+    # The negation match tolerates markdown emphasis: "**Not** a subscription"
+    # has no literal "not a" in it, so a plain filter flags the very line that
+    # states the distinction correctly.
+    if grep -inE 'user base64.*subscription' "$f" 2>/dev/null \
+         | grep -viE 'not[*_ ]+a |rather than|instead of|reject' | grep -q .; then
+        offenders="$offenders $f"
+    fi
+done <<EOF
+$ROOT/AGENTS.md
+$ROOT/README.md
+$ROOT/llms.txt
+$ROOT/lib/menu.sh
+$ROOT/lib/users.sh
+$ROOT/docs/devdocs/E2E-TESTING.md
+EOF
+if [ -z "$offenders" ]; then
+    ok "no doc or help calls 'user base64' a subscription"
+else
+    bad "these still describe 'user base64' as a subscription:$offenders"
+fi
+
+# --- the help must offer the subscription route ----------------------------
+grep -q 'user sub NAME' "$menu" \
+    && ok "'moav help' lists user sub" || bad "'moav help' does not list user sub"
+
+if awk '/^cmd_user_base64\(\)/,/^}/' "$menu" | grep -qi 'moav user sub'; then
+    ok "base64's own output points at the subscription command"
+else
+    bad "base64 never mentions 'moav user sub' — the mix-up stays uncaught"
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes the "base64 output rejected by Streisand" report. **It was a wrongly reported bug** — and the docs caused it.

## What was actually wrong

`moav user base64` emits a **zipped bundle** for moav-client's e2e `bundle_b64` input. Streisand rejected it correctly: it is a zip, not a config list. Nothing was wrong with the encoding.

What was wrong is that nothing said so, and two things said the opposite:

- **`AGENTS.md`** described it as printing the user's base64 **subscription** — the guide contributors and agents read.
- **`moav help`** called it a "quick import".

In this ecosystem, "base64" for a VPN user means one thing: the subscription blob. The name plus that wording invited exactly the misuse reported.

## What changed

**Behavior is unchanged.** `base64` stays the primary name and still emits the zip — moav-client's e2e input documents that name, and warning on every legitimate use would just be noise on the intended path. `bundle-b64` is accepted as a self-describing alias.

What changed is that it now says what it is:

```
[moav] zipped text-only bundle for 'alice' (for moav-client, not a client subscription):
[moav]   12004B zipped -> 16008 base64 chars. Phone apps want: moav user sub alice
```

…plus corrected `AGENTS.md` and `moav help` lines.

## New: `moav user sub NAME`

What people reaching for `base64` actually wanted — the base64 V2Ray subscription phone apps import (Streisand, v2rayNG, NekoBox, Hiddify). It hands over the bundle's existing `subscription.txt` rather than re-encoding, so there is no second format to drift.

Verified on a live server: decodes to 6 newline-separated `vless://` share links, no trailing blank line.

## Tests

`tests/user-subscription-test.sh`, 8 asserts, wired into `ci.yml`. Includes a guard that fails if any doc or help text calls `user base64` a subscription again — the actual root cause.

Three of my first five negative controls did not fail when they should have: the doc guard used `[^|]*`, which excludes the very pipe that separates markdown table cells, so it silently exempted the AGENTS.md row that caused this bug; another matched the not-found error string instead of the path assignment; a third matched a variable literally named `zip`. All three were rewritten and re-verified.