### PR TITLE
release: generate the release footer; drop the wstunnel QR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
         run: python3 scripts/gen-protocol-docs.py --check
       - name: funding block drift gate (README from FUNDING.yml)
         run: bash scripts/render-funding.sh --check
+      - name: release footer generator
+        run: bash tests/release-footer-test.sh
+      - name: release footer links resolve (network)
+        run: bash scripts/render-release-footer.sh --check
 
   go-test:
     name: go test dns-router

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,52 +61,16 @@ jobs:
       - name: Build release body
         id: body
         run: |
-          # Define the install guide section
+          # Footer is generated, not written here: it drifted twice while it was a
+          # heredoc, and the community URLs must agree with lib/common.sh.
           # A prerelease page must not imply the one-liner installs it: install.sh
           # serves the latest STABLE release, so on an rc that command gives the
           # reader something other than what they are reading about.
-          #
-          # NOTE ON INDENTATION: this is inside a YAML literal block (`run: |`)
-          # whose base indent is 10. Heredoc bodies and terminators must sit at
-          # exactly that indent so the shell receives them at column 0 -- at any
-          # other indent the terminator never matches, and a line at column 0
-          # ends the YAML block early (a bare `---` there is read as a YAML
-          # document separator, which invalidates the whole workflow file).
-          : > install_guide.txt
           if echo "${GITHUB_REF#refs/tags/}" | grep -qE "(alpha|beta|rc)"; then
-          cat >> install_guide.txt << 'PREGUIDE_EOF'
-
-          ---
-
-          > **Note:** the install command below fetches the latest **stable** release, not
-          > this candidate. To try this build specifically, use the `git checkout` steps in
-          > the notes above.
-          PREGUIDE_EOF
+            bash scripts/render-release-footer.sh --pre > install_guide.txt
+          else
+            bash scripts/render-release-footer.sh > install_guide.txt
           fi
-
-          cat >> install_guide.txt << 'GUIDE_EOF'
-
-          ---
-
-          ## Quick Install
-
-          ```bash
-          curl -fsSL moav.sh/install.sh | bash
-          ```
-
-          This will install MoaV to `/opt/moav` and guide you through setup.
-
-          ## Documentation
-
-          **[moav.sh/docs](https://moav.sh/docs)** — Full documentation
-
-          - [Setup Guide](https://moav.sh/docs/SETUP) — Complete installation instructions
-          - [Client Setup](https://moav.sh/docs/CLIENTS) — How to connect from devices
-          - [DNS Configuration](https://moav.sh/docs/DNS) — DNS records setup
-          - [CLI Reference](https://moav.sh/docs/CLI) — All commands and options
-          - [Monitoring](https://moav.sh/docs/MONITORING) — Grafana dashboards and metrics
-          - [Troubleshooting](https://moav.sh/docs/TROUBLESHOOTING) — Common issues and solutions
-          GUIDE_EOF
 
           if [ "${{ steps.existing.outputs.exists }}" = "true" ]; then
             # Check if install guide already present in existing body

--- a/scripts/generate-user.sh
+++ b/scripts/generate-user.sh
@@ -516,7 +516,6 @@ if [[ "${ENABLE_WIREGUARD:-true}" == "true" ]]; then
         BUNDLE_CHANGED=true
         wireguard_generate_client_config "$USER_ID" "$OUTPUT_DIR"
         qrencode -o "$OUTPUT_DIR/wireguard-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wg).conf" 2>/dev/null || true
-        qrencode -o "$OUTPUT_DIR/wireguard-wstunnel-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wgws).conf" 2>/dev/null || true
         if [[ -n "${SERVER_IPV6:-}" ]] && [[ -f "$OUTPUT_DIR/$(moav_wg_basename wg6).conf" ]]; then
             qrencode -o "$OUTPUT_DIR/wireguard-ipv6-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wg6).conf" 2>/dev/null || true
         fi

--- a/scripts/lib/bundle_readme.py
+++ b/scripts/lib/bundle_readme.py
@@ -208,7 +208,6 @@ repl = {
     "QR_ANYTLS": qr("anytls-qr.png"),
     "QR_CDN": qr("cdn-vless-qr.png"),
     "QR_WIREGUARD": qr("wireguard-qr.png"),
-    "QR_WIREGUARD_WSTUNNEL": qr("wireguard-wstunnel-qr.png"),
     "QR_AMNEZIAWG": qr("amneziawg-qr.png"),
     "QR_SHADOWSOCKS": qr("shadowsocks-qr.png"),
     "QR_XHTTP": qr("xhttp-qr.png"),

--- a/scripts/lib/wireguard.sh
+++ b/scripts/lib/wireguard.sh
@@ -233,5 +233,9 @@ EOF
     rm -f "$output_dir/wireguard.conf" "$output_dir/wireguard-wstunnel.conf" \
           "$output_dir/wireguard-ipv6.conf" 2>/dev/null || true
 
+    # The wstunnel QR is no longer generated: it points at localhost, so scanning
+    # it into a WireGuard app connects and carries nothing.
+    rm -f "$output_dir/wireguard-wstunnel-qr.png" 2>/dev/null || true
+
     log_info "Generated WireGuard client config for $user_id"
 }

--- a/scripts/render-release-footer.sh
+++ b/scripts/render-release-footer.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Render the footer that release.yml appends to every GitHub release body.
+#
+#   scripts/render-release-footer.sh            # print the footer
+#   scripts/render-release-footer.sh --pre      # prepend the pre-release note
+#   scripts/render-release-footer.sh --check    # verify every link resolves
+#
+# Community URLs come from lib/common.sh (MOAV_URL_*), the same single source the
+# CLI footer uses, so the release notes and `moav help` cannot disagree.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "$ROOT/lib/common.sh"
+
+MODE="${1:-}"
+
+# Docs pages, grouped for a reader of a release note rather than as a sitemap.
+# Order matters: Quick Start first, because that is where a new operator lands.
+docs_get_started=(
+    "quick-start|Quick Start|install to first user in ~10 minutes"
+    "CLIENTS|Client Setup|connect from phones and desktops"
+    "DNS|DNS Configuration|records, delegations, freeing port 53"
+)
+docs_reference=(
+    "CLI|CLI Reference|every command and flag"
+    "SETUP|Setup Guide|every option, in depth"
+    "MONITORING|Monitoring|Grafana dashboards and metrics"
+    "TROUBLESHOOTING|Troubleshooting|symptom-first fixes"
+)
+docs_understand=(
+    "protocols|Supported Protocols|per-protocol ports, ciphers, stealth"
+    "architecture|Architecture|container topology and bundle flow"
+    "threat-model|Threat Model|what is and is not protected"
+    "OPSEC|OPSEC Guide|operator-side hardening"
+)
+docs_help=(
+    "support|Support MoaV|run a server, contribute, translate, donate"
+    "TRANSLATING|Translating the Docs|one page is a complete contribution"
+)
+
+emit_group() {   # <heading> <array-name>
+    local heading="$1" name="$2" entry slug label blurb
+    printf '**%s**\n\n' "$heading"
+    eval "local items=(\"\${${name}[@]}\")"
+    for entry in "${items[@]}"; do
+        IFS='|' read -r slug label blurb <<<"$entry"
+        printf -- '- [%s](%s/%s) — %s\n' "$label" "$MOAV_URL_DOCS" "$slug" "$blurb"
+    done
+    printf '\n'
+}
+
+render_pre() {
+    cat <<PRE
+
+---
+
+> **Note:** the install command below fetches the latest **stable** release, not
+> this candidate. To try this build specifically, use the \`git checkout\` steps in
+> the notes above.
+PRE
+}
+
+render() {
+    cat <<HEAD
+
+---
+
+## Quick Install
+
+\`\`\`bash
+curl -fsSL $MOAV_URL_SITE/install.sh | bash
+\`\`\`
+
+This will install MoaV to \`/opt/moav\` and guide you through setup.
+
+## Documentation
+
+**[${MOAV_URL_DOCS#https://}]($MOAV_URL_DOCS)** — full documentation
+
+HEAD
+    emit_group "Get started"   docs_get_started
+    emit_group "Reference"     docs_reference
+    emit_group "Understand it" docs_understand
+    emit_group "Help out"      docs_help
+    cat <<TAIL
+**Running it with an AI agent?** [llms.txt]($MOAV_URL_SITE/llms.txt) is a compact
+orientation for coding agents; [llms-full.txt]($MOAV_URL_SITE/llms-full.txt) is the
+whole corpus. Both ship as release assets.
+
+## Community
+
+[Telegram]($MOAV_URL_TG) · [X]($MOAV_URL_X) · [Issues]($MOAV_URL_GH/issues) · [${MOAV_URL_SITE#https://}]($MOAV_URL_SITE)
+TAIL
+}
+
+# --check: every link in the rendered footer must resolve. The list used to live
+# in a workflow heredoc where a renamed docs page would ship a 404 in every
+# release from then on with nothing noticing.
+if [[ "$MODE" == "--check" ]]; then
+    status=0
+    # while-read, not mapfile: mapfile is bash 4+ and macOS ships bash 3.2.
+    urls=()
+    while IFS= read -r u; do
+        [[ -n "$u" ]] && urls+=("$u")
+    done < <(render | grep -oE 'https://[^)[:space:]]+' | sed 's/[.,]$//' | sort -u)
+    echo "render-release-footer: checking ${#urls[@]} links"
+    for u in "${urls[@]}"; do
+        code=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 "$u" 2>/dev/null || echo 000)
+        # One retry: a single flaky fetch should not fail a release.
+        if [[ "$code" != "200" ]]; then
+            sleep 2
+            code=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 "$u" 2>/dev/null || echo 000)
+        fi
+        if [[ "$code" == "200" ]]; then
+            printf '  ok    %s\n' "$u"
+        else
+            printf '  FAIL  %s (HTTP %s)\n' "$u" "$code"
+            status=1
+        fi
+    done
+    [[ "$status" == "0" ]] || echo "render-release-footer: fix the URLs above or update this script" >&2
+    exit "$status"
+fi
+
+[[ "$MODE" == "--pre" ]] && render_pre
+render

--- a/scripts/wg-user-add.sh
+++ b/scripts/wg-user-add.sh
@@ -213,9 +213,6 @@ if command -v qrencode &>/dev/null; then
             log_info "IPv6 QR image saved to: $OUTPUT_DIR/wireguard-ipv6-qr.png"
     fi
 
-    # wstunnel QR code
-    qrencode -o "$OUTPUT_DIR/wireguard-wstunnel-qr.png" -s 6 -r "$OUTPUT_DIR/$(moav_wg_basename wgws).conf" 2>/dev/null && \
-        log_info "wstunnel QR image saved to: $OUTPUT_DIR/wireguard-wstunnel-qr.png"
 fi
 
 echo ""

--- a/templates/client-guide-template.html
+++ b/templates/client-guide-template.html
@@ -1025,17 +1025,9 @@
                         <p style="color: var(--text-muted); font-size: 12px;">Mobile requires running wstunnel in Termux (Android) or using an app that supports WireGuard-over-WebSocket. For most users, we recommend using Reality or Hysteria2 on mobile instead.</p>
                     </div>
 
-                    <div class="qr-section" style="margin-top: 16px;">
-                        <div class="qr-code">
-                            <img src="data:image/png;base64,{{QR_WIREGUARD_WSTUNNEL}}" alt="WireGuard wstunnel QR Code" onerror="this.parentElement.classList.add('qr-missing'); this.parentElement.innerHTML='QR not available<br>Use config below';">
-                        </div>
-                        <div class="qr-instructions">
-                            <h4>WireGuard-wstunnel Config</h4>
-                            <p style="font-size: 12px; color: var(--text-muted);">Use this config AFTER starting wstunnel client. Points to localhost instead of server.</p>
-                        </div>
-                    </div>
                     <div class="config-box">
                         <h4>WireGuard-wstunnel Config File (save as .conf)</h4>
+                        <p style="font-size: 12px; color: var(--text-muted);">Use this config AFTER starting the wstunnel client — it points at localhost, not the server, so on its own it will connect but carry no traffic. No QR: importing it straight into a WireGuard app is exactly the mistake it invites.</p>
                         <div class="config-value multiline">{{CONFIG_WIREGUARD_WSTUNNEL}}</div>
                     </div>
                 </details>
@@ -1963,17 +1955,9 @@
                         <p style="color: var(--text-muted); font-size: 12px;">برای موبایل نیاز به اجرای wstunnel در Termux (Android) است. برای اکثر کاربران، توصیه می‌کنیم در موبایل از Reality یا Hysteria2 استفاده کنید.</p>
                     </div>
 
-                    <div class="qr-section" style="margin-top: 16px;">
-                        <div class="qr-code">
-                            <img src="data:image/png;base64,{{QR_WIREGUARD_WSTUNNEL}}" alt="QR Code WireGuard wstunnel" onerror="this.parentElement.classList.add('qr-missing'); this.parentElement.innerHTML='QR در دسترس نیست<br>از کانفیگ زیر استفاده کنید';">
-                        </div>
-                        <div class="qr-instructions">
-                            <h4>کانفیگ WireGuard-wstunnel</h4>
-                            <p style="font-size: 12px; color: var(--text-muted);">این کانفیگ را بعد از اجرای wstunnel client استفاده کنید. به localhost اشاره می‌کند.</p>
-                        </div>
-                    </div>
                     <div class="config-box">
                         <h4>فایل کانفیگ WireGuard-wstunnel (ذخیره با پسوند .conf)</h4>
+                        <p style="font-size: 12px; color: var(--text-muted);">این کانفیگ را بعد از اجرای wstunnel client استفاده کنید — به localhost اشاره می‌کند نه به سرور، پس به‌تنهایی وصل می‌شود ولی ترافیکی عبور نمی‌دهد. QR ندارد: وارد کردن مستقیم آن در اپ WireGuard دقیقاً همان اشتباهی است که این QR باعثش می‌شد.</p>
                         <div class="config-value multiline">{{CONFIG_WIREGUARD_WSTUNNEL}}</div>
                     </div>
                 </details>

--- a/tests/config-naming-test.sh
+++ b/tests/config-naming-test.sh
@@ -162,6 +162,26 @@ grep -q 'rc -eq 127' "$ROOT/tests/cli-smoke-test.sh" \
     && ok "cli-smoke-test treats command-not-found as a failure, not 'ok'" \
     || bad "cli-smoke-test still reports 'ok' for exit 127"
 
+# No wstunnel QR. Its config points at 127.0.0.1, so scanning it into a WireGuard
+# app produces a tunnel that connects and carries nothing -- the shape of a bug
+# report we chased for a release. The .conf still ships; only the QR is gone.
+# Match generation/embedding only -- the cleanup `rm -f` below names the same
+# file, so a bare grep for the filename flags our own removal code.
+# -I skips binaries: a stale __pycache__/*.pyc compiled from the previous
+# bundle_readme.py still contains the old key and false-fails this otherwise.
+if grep -rnI 'wireguard-wstunnel-qr\|QR_WIREGUARD_WSTUNNEL' "$ROOT/scripts" "$ROOT/templates" 2>/dev/null \
+     | grep -vE 'rm -f' | grep -q .; then
+    bad "the wstunnel QR is being generated or embedded again"
+else
+    ok "no wstunnel QR is generated or embedded"
+fi
+grep -q 'rm -f "$output_dir/wireguard-wstunnel-qr.png"' "$ROOT/scripts/lib/wireguard.sh" \
+    && ok "stale wstunnel QRs are cleaned from regenerated bundles" \
+    || bad "regenerated bundles keep a stale wstunnel QR"
+grep -q 'moav_wg_basename wgws' "$ROOT/scripts/lib/wireguard.sh" \
+    && ok "the wstunnel .conf itself still ships" \
+    || bad "the wstunnel config was removed along with its QR"
+
 echo
 echo "  $pass passed, $fail failed"
 [[ $fail -eq 0 ]]

--- a/tests/release-footer-test.sh
+++ b/tests/release-footer-test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# The release footer is generated, and must stay generated.
+#
+# It lived in a heredoc inside release.yml and drifted twice: the community links
+# (Telegram, X, issues, website) existed only because someone pasted them into the
+# v2.0.0 body by hand, the donation/support page was never linked, and the docs
+# list still named six pages after the rewrite shipped fourteen more. Nothing
+# noticed, because a workflow heredoc has no reader.
+#
+# Offline structural checks only -- the live URL check is
+# `scripts/render-release-footer.sh --check`, a separate CI step, so this suite
+# stays runnable without network.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+gen="$ROOT/scripts/render-release-footer.sh"
+wf="$ROOT/.github/workflows/release.yml"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "release footer generator"
+
+[[ -x "$gen" ]] && ok "generator exists and is executable" || bad "generator missing or not executable"
+
+out="$(bash "$gen" 2>/dev/null)"
+[[ -n "$out" ]] && ok "generator produces output" || bad "generator produced nothing"
+
+# --- release.yml must call it, not inline the footer -----------------------
+grep -q 'render-release-footer.sh' "$wf" \
+    && ok "release.yml calls the generator" \
+    || bad "release.yml does not call the generator"
+
+if grep -qE "^\s+- \[Setup Guide\]\(https://moav.sh/docs/SETUP\)" "$wf"; then
+    bad "release.yml still inlines the docs list — the drift is back"
+else
+    ok "release.yml no longer inlines the docs list"
+fi
+
+# --- the append-guard sentinel must survive ---------------------------------
+# release.yml skips appending when the body already contains "## Quick Install",
+# so a hand-edited release body is not clobbered. Renaming that heading in the
+# generator would silently double-append the footer on every re-run.
+grep -q '## Quick Install' <<<"$out" \
+    && ok "footer keeps the '## Quick Install' append-guard sentinel" \
+    || bad "sentinel gone — release.yml would append the footer twice"
+
+# --- every category the card called out ------------------------------------
+for want in "Quick Start" "Client Setup" "CLI Reference" "Troubleshooting" \
+            "Supported Protocols" "Threat Model" "Support MoaV" "Translating the Docs"; do
+    grep -qF "$want" <<<"$out" && ok "links $want" || bad "missing docs link: $want"
+done
+
+for want in "t.me/motherofallvpns" "x.com/motherofallvpns" "/issues" "llms.txt"; do
+    grep -qF "$want" <<<"$out" && ok "links $want" || bad "missing link: $want"
+done
+
+# Quick Start must come before the Setup Guide: a release note is read by someone
+# deciding whether to install, not by someone looking up an option.
+qs=$(grep -n 'docs/quick-start' <<<"$out" | head -1 | cut -d: -f1)
+sg=$(grep -n 'docs/SETUP' <<<"$out" | head -1 | cut -d: -f1)
+if [[ -n "$qs" && -n "$sg" && "$qs" -lt "$sg" ]]; then
+    ok "Quick Start is listed before the Setup Guide"
+else
+    bad "Quick Start must precede the Setup Guide (got qs=$qs sg=$sg)"
+fi
+
+# --- community URLs must come from lib/common.sh ----------------------------
+# Same assertion tests/cli-surface-test.sh makes about the CLI footer: if the
+# generator hardcodes them, the release notes and `moav help` can disagree.
+body="$(sed 's/[[:space:]]*#.*$//' "$gen")"
+if grep -qE 'https://(t\.me|x\.com)/motherofallvpns' <<<"$body"; then
+    bad "generator hardcodes a community URL instead of using MOAV_URL_*"
+else
+    ok "community URLs come from the MOAV_URL_* variables"
+fi
+
+for v in MOAV_URL_SITE MOAV_URL_DOCS MOAV_URL_TG MOAV_URL_X MOAV_URL_GH; do
+    grep -q "$v" <<<"$body" && ok "uses \$$v" || bad "does not use \$$v"
+done
+
+# --- prerelease variant ------------------------------------------------------
+pre="$(bash "$gen" --pre 2>/dev/null)"
+grep -q 'latest \*\*stable\*\*' <<<"$pre" \
+    && ok "--pre emits the stable-install caveat" \
+    || bad "--pre lost the prerelease caveat"
+grep -q 'latest \*\*stable\*\*' <<<"$out" \
+    && bad "stable release wrongly carries the prerelease caveat" \
+    || ok "stable release has no prerelease caveat"
+
+# --- no unrendered placeholders ---------------------------------------------
+if grep -qE '\$\{?[A-Z_]+\}?' <<<"$out"; then
+    bad "footer contains an unexpanded variable: $(grep -oE '\$\{?[A-Z_]+\}?' <<<"$out" | head -1)"
+else
+    ok "no unexpanded variables in the rendered footer"
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Two things, both about artifacts that quietly said the wrong thing.

## 1. The release footer is now generated

The footer `release.yml` appends to every release body was a heredoc, and it drifted twice:

- **No community links at all.** Telegram, X, issues and the site existed in the v2.0.0 body only because they were pasted in by hand. Every future release would have lost them.
- **No donation/support link**, though `docs/support` is the page that asks people to run a server, contribute or donate.
- **The docs list predated the rewrite** — six pages listed, fourteen more shipped and unlinked.
- **Quick Start absent** while the long Setup reference was listed first, which is backwards for someone reading a release note.
- **`llms.txt` unmentioned**, though it ships as a release asset.

`scripts/render-release-footer.sh` renders it, taking community URLs from the same `MOAV_URL_*` variables in `lib/common.sh` that the CLI footer uses — so the release notes and `moav help` cannot disagree. Grouped (Get started / Reference / Understand it / Help out / Community) for someone deciding whether to install, not as a sitemap.

**`--check` curls every link and fails on non-200**, wired into CI as its own step. This is the part that keeps it honest: a renamed docs page would otherwise ship a 404 in the footer of every release from then on, with nothing noticing. All 21 links currently resolve.

Preserves the existing behavior the card called out: the footer still contains `## Quick Install`, which `release.yml` greps for so a hand-edited release body is never clobbered. There is a test asserting that sentinel survives — renaming it would silently double-append the footer.

## 2. `wireguard-wstunnel-qr.png` is gone

Its config points at `127.0.0.1`, so scanning it into a WireGuard app produces a tunnel that connects and carries no traffic — the exact shape of the QR bug report, and indistinguishable from the real QR as an image. The QR bug itself is confirmed not-a-bug (QR payload is byte-identical to the working `.conf`; retested on a phone).

The wstunnel `.conf` still ships, now with the caveat stated inline in the guide (EN + FA), and stale copies are removed from regenerated bundles — otherwise every regenerated bundle would keep shipping the old PNG.

## Tests

`tests/release-footer-test.sh` (27 asserts) + 3 in `tests/config-naming-test.sh`, both in CI. Negative controls verified: hardcoding a community URL, dropping the support link, renaming the append-guard heading, inverting Quick Start/Setup order, reverting `release.yml` to inlining, reintroducing the QR, and removing the stale-QR cleanup all fail the suite.

Two of my own bugs caught while writing them: `mapfile` is bash 4+ and would have passed CI on Linux while failing for anyone on macOS (repo targets bash 3.2); and the QR guard false-failed on a stale `__pycache__/*.pyc` compiled from the previous `bundle_readme.py`, so it now skips binaries.