### PR TITLE
security(admin): keep secrets out of the container config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -834,17 +834,14 @@ services:
       - ./state:/project/state                     # Credential sync (read-write for user-add.sh)
       - moav_state:/state:ro                       # Dashboard reads keys from Docker volume
       - moav_certs:/certs:ro                       # SSL certificates
-    # .env is root:root 0600 (holds ADMIN_PASSWORD), so the non-root admin
-    # process cannot read the mounted copy that provisioning scripts source.
-    # env_file injects the full .env as process environment instead — read
-    # host-side (as root) at `up` time, so the file perms don't matter and the
-    # ENABLE_*/PORT_* toggles keep working in the web-admin user-add path.
-    # Explicit `environment:` entries below still take precedence.
-    env_file:
-      - path: .env
-        required: false
+    # No env_file, and no secrets below: anything compose puts in the environment
+    # is baked into Config.Env, which `docker inspect` prints. env_file put the
+    # WHOLE .env there, exposing ADMIN_PASSWORD, REALITY_PRIVATE_KEY and
+    # MAHSANET_API_KEY. admin-entrypoint.sh reads /project/.env as root instead
+    # and exports it into the app process only, so the ENABLE_*/PORT_* toggles
+    # keep working in the web-admin user-add path while the container config
+    # carries no secrets. Entries below still win over .env — keep them non-secret.
     environment:
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - ADMIN_IP_WHITELIST=${ADMIN_IP_WHITELIST:-}
       - SERVER_IP=${SERVER_IP:-}
       - DOMAIN=${DOMAIN:-}
@@ -854,7 +851,6 @@ services:
       - XDNS_RESOLVERS=${XDNS_RESOLVERS:-1.1.1.1,8.8.8.8}
       - PORT_XDNS=${PORT_XDNS:-5356}
       - ENABLE_XHTTP=${ENABLE_XHTTP:-true}
-      - MAHSANET_API_KEY=${MAHSANET_API_KEY:-}
       - MAHSANET_PROTOCOLS=${MAHSANET_PROTOCOLS:-reality hysteria2}
       - MAHSANET_POOL=${MAHSANET_POOL:-mahsa}
       - MAHSANET_ADS_URL=${MAHSANET_ADS_URL:-t.me/motherofallvpns}

--- a/scripts/admin-entrypoint.sh
+++ b/scripts/admin-entrypoint.sh
@@ -89,6 +89,35 @@ chmod -R ug+rwX,o+rX,o-w /project/configs/sing-box /project/configs/xray /projec
 CLASH_API_SECRET=$(grep '^CLASH_API_SECRET=' /state/keys/clash-api.env 2>/dev/null | tail -1 | cut -d= -f2- || true)
 export CLASH_API_SECRET
 
+# Load .env here rather than via compose `env_file`, which bakes every value into
+# the container's Config.Env where `docker inspect` reports it -- that exposed
+# ADMIN_PASSWORD, REALITY_PRIVATE_KEY and MAHSANET_API_KEY. Read as root (the
+# file is 0600) and exported only into this process, so the app sees the same
+# environment while the container config carries no secrets.
+#
+# Parsed literally, not sourced: values legitimately contain `|` (GOPROXY) and
+# other metacharacters that `source` would execute.
+if [ -r /project/.env ]; then
+    while IFS= read -r _line || [ -n "$_line" ]; do
+        case "$_line" in ''|\#*) continue ;; esac
+        _key=${_line%%=*}
+        [ "$_key" = "$_line" ] && continue                  # no '=', not an assignment
+        case "$_key" in *[!A-Za-z0-9_]*) continue ;; esac    # skip malformed keys
+        # Compose `environment:` must still win, as it did when it overrode
+        # env_file; only fill in what is not already set.
+        eval "_isset=\${$_key+x}"
+        [ -n "${_isset:-}" ] && continue
+        _val=${_line#*=}
+        # Strip one layer of matching surrounding quotes (.env quotes some values).
+        case "$_val" in
+            \"*\") _val=${_val#\"}; _val=${_val%\"} ;;
+            \'*\') _val=${_val#\'}; _val=${_val%\'} ;;
+        esac
+        export "$_key=$_val"
+    done < /project/.env
+    unset _line _key _val _isset
+fi
+
 # Run the dashboard as non-root
 echo "[admin] Starting uvicorn server..."
 exec su-exec moav python main.py

--- a/tests/uuid-capture-test.sh
+++ b/tests/uuid-capture-test.sh
@@ -85,10 +85,27 @@ for s in user-add.sh singbox-user-add.sh wg-user-add.sh user-revoke.sh user-pack
     fi
 done
 
-# compose must hand the admin container the full .env via env_file instead
-awk '/^  admin:$/{f=1; next} f && /^  [a-z0-9_-]+:$/{f=0} f && /env_file:/{found=1} END{exit !found}' "$compose" \
-    && ok "compose injects .env into the admin container via env_file" \
-    || bad "admin service has no env_file — web-admin adds lose the ENABLE_*/PORT_* toggles"
+# The admin container must still get the full .env, so web-admin adds keep the
+# ENABLE_*/PORT_* toggles. It is no longer compose's env_file: that baked every
+# value into Config.Env where `docker inspect` printed ADMIN_PASSWORD,
+# REALITY_PRIVATE_KEY and MAHSANET_API_KEY. The root entrypoint loads it instead.
+# Assert the invariant, not the mechanism -- either route is acceptable.
+if awk '/^  admin:$/{f=1; next} f && /^  [a-z0-9_-]+:$/{f=0} f && /env_file:/{found=1} END{exit !found}' "$compose"; then
+    ok "compose injects .env into the admin container via env_file"
+elif grep -q '/project/.env' "$ROOT/scripts/admin-entrypoint.sh"; then
+    ok "admin-entrypoint loads .env as root (no secrets in Config.Env)"
+else
+    bad "nothing hands .env to the admin container — web-admin adds lose the ENABLE_*/PORT_* toggles"
+fi
+
+# And compose must not put secrets back into the container config.
+for secret in ADMIN_PASSWORD MAHSANET_API_KEY REALITY_PRIVATE_KEY; do
+    if awk -v s="$secret" '/^  admin:$/{f=1; next} f && /^  [a-z0-9_-]+:$/{f=0} f && $0 ~ ("- " s "=") {found=1} END{exit !found}' "$compose"; then
+        bad "compose puts $secret in the admin environment — docker inspect exposes it"
+    else
+        ok "$secret is not in the admin container config"
+    fi
+done
 
 echo
 echo "  $pass passed, $fail failed"


### PR DESCRIPTION
Closes the `ADMIN_PASSWORD in container env` item from `[E3-E]`.

## Worse than the card said

`docker inspect moav-admin` printed **130** environment variables, including `ADMIN_PASSWORD`, `REALITY_PRIVATE_KEY` and `MAHSANET_API_KEY`. The card named only the explicit `ADMIN_PASSWORD=` line, but the real source was `env_file: .env`, which bakes the **entire** .env into `Config.Env`. Removing the explicit line alone would have fixed nothing.

## The fix

The `env_file` existed because `.env` is root-owned 0600 and the admin app runs as the non-root `moav` user. But `admin-entrypoint.sh` already runs as root before `su-exec moav` — the same place the Clash API secret is read — so it can load `.env` itself and export it into the app process only. `Config.Env` then carries no secrets, while the `ENABLE_*`/`PORT_*` toggles still reach the web-admin user-add path.

Two details worth noting:

- **Parsed literally, not sourced.** Values legitimately contain `|` (GOPROXY) and other metacharacters that `source` would execute.
- **Compose precedence preserved.** `environment:` entries still win, as they did when they overrode `env_file`; the loader only fills in what is not already set. Otherwise `.env` would start overriding compose-only values like `DOCKER_HOST`.

The entrypoint is `#!/bin/sh` (Alpine ash) and CI's `bash -n` step skips non-bash files, so the loader was checked with `sh -n` and exercised under POSIX sh against quoted values, embedded pipes, single quotes, a malformed key, and a file with no trailing newline.

## Verified on a live server

- `Config.Env` **130 → 20** vars, with none of the three secrets
- dashboard auth still works: 200 with the correct password, 401 with a wrong one — which is the proof the password reaches the app
- a dashboard-path `user-add` still generates XDNS, Slipstream and MasterDNS, which is exactly what the toggles drive
- container came up clean, 0 restarts

## Not in scope

Grafana still carries `ADMIN_PASSWORD` as `GF_SECURITY_ADMIN_PASSWORD`, and it runs as `user: "0"`. Both go on their own card rather than being half-done here.