### PR TITLE
fix(bundle): stop hiding TrustTunnel and dnstt in the client guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: bash tests/dns-tunnel-bundle-test.sh
       - name: user subscription vs bundle-blob distinction
         run: bash tests/user-subscription-test.sh
+      - name: bundle guide section visibility (all protocols)
+        run: bash tests/bundle-guide-sections-test.sh
       - name: admin TLS enforcement
         run: bash tests/admin-tls-test.sh
       - name: admin IP whitelist (CIDR) unit test

--- a/lib/migrate.sh
+++ b/lib/migrate.sh
@@ -565,11 +565,15 @@ cmd_migrate_ip() {
                     rm -f "$user_dir/cdn-vless.txt.bak"
                 fi
 
-                # Update TrustTunnel config
-                if [[ -f "$user_dir/trusttunnel.txt" ]]; then
-                    sed -i.bak "s/$old_ip/$new_ip/g" "$user_dir/trusttunnel.txt"
-                    rm -f "$user_dir/trusttunnel.txt.bak"
-                fi
+                # Update TrustTunnel config. .toml and .json are the files that
+                # actually ship and that carry the IP; trusttunnel.txt never
+                # existed, so a move used to strand TrustTunnel on the old server.
+                for _tt in trusttunnel.toml trusttunnel.json trusttunnel.txt; do
+                    if [[ -f "$user_dir/$_tt" ]]; then
+                        sed -i.bak "s/$old_ip/$new_ip/g" "$user_dir/$_tt"
+                        rm -f "$user_dir/$_tt.bak"
+                    fi
+                done
 
                 # Update XDNS configs
                 if [[ -f "$user_dir/xdns-direct-config.json" ]]; then

--- a/scripts/lib/bundle_readme.py
+++ b/scripts/lib/bundle_readme.py
@@ -141,6 +141,12 @@ cdn = link("cdn-vless.txt")
 # guide lives in this README, not a separate instructions .txt).
 md = instr("masterdns-client_config.toml")
 gr = instr("gooserelay-client_config.json")
+# TrustTunnel ships .toml (client config) + .json (credentials); either proves it.
+tt_present = any(os.path.isfile(os.path.join(OUT, n))
+                 for n in ("trusttunnel.toml", "trusttunnel.json"))
+# dnstt is server-wide: there is no per-user artifact, so presence is the server
+# pubkey this guide embeds.
+dnstt_present = bool(os.environ.get("RB_DNSTT_PUBKEY", "").strip())
 
 repl = {
     "USERNAME": os.environ.get("RB_USERNAME", ""),
@@ -191,8 +197,10 @@ repl = {
     "XHTTP_DISPLAY":       _hide("xhttp-vless.txt"),
     "AMNEZIAWG_DISPLAY":   _hide("amneziawg.conf"),
     "WIREGUARD_DISPLAY":   _hide("wireguard.conf"),
-    "TRUSTTUNNEL_DISPLAY": _hide("trusttunnel.txt"),
-    "DNSTT_DISPLAY":       _hide("dnstt-instructions.txt"),
+    # Keyed on artifacts that are actually written. trusttunnel.txt and
+    # dnstt-instructions.txt never existed, so both sections were always hidden.
+    "TRUSTTUNNEL_DISPLAY": "" if tt_present else "display:none",
+    "DNSTT_DISPLAY":       "" if dnstt_present else "display:none",
     "TELEMT_DISPLAY":      _hide("telegram-proxy-link.txt"),
 
     "TRUSTTUNNEL_PASSWORD": val_or(os.environ.get("RB_USER_PASSWORD", ""), "See trusttunnel.json"),

--- a/tests/bundle-guide-sections-test.sh
+++ b/tests/bundle-guide-sections-test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Regression test: a protocol whose config is in the bundle must be VISIBLE in
+# README.html, and one that is absent must be hidden.
+#
+# Reported by a user: TrustTunnel was generated, and the admin dashboard listed
+# it, but its section was missing from the guide. Cause: the section was keyed on
+# `trusttunnel.txt`, a filename nothing has ever written -- the real artifacts are
+# trusttunnel.toml and trusttunnel.json -- so `_hide()` hid it in EVERY bundle
+# ever produced. The same phantom-filename bug hid the whole dnstt section, keyed
+# on `dnstt-instructions.txt`, which also never existed. dnstt is server-wide and
+# has no per-user file at all, so its signal is the server pubkey the guide embeds.
+#
+# The class of bug is "section keyed on a file that is never generated", which is
+# invisible from the outside: the guide just quietly omits a protocol. So this
+# asserts the round trip -- render with the artifact, render without it -- rather
+# than checking the mapping by eye.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "bundle guide section visibility"
+
+command -v python3 >/dev/null || { echo "  python3 required"; exit 1; }
+tpl="$ROOT/templates/client-guide-template.html"
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+
+# Render the guide for a bundle containing exactly $1.. files, then report the
+# style attribute of section $SECTION.
+render() {   # <outdir>
+    local out="$1"
+    RB_OUTPUT_DIR="$out" \
+    RB_TEMPLATE="$tpl" \
+    RB_OUTPUT_HTML="$out/README.html" \
+    RB_CONTEXT="host" \
+    RB_USERNAME="t" RB_SERVER_IP="203.0.113.9" RB_DOMAIN="example.com" \
+    RB_DNSTT_PUBKEY="${RB_DNSTT_PUBKEY:-}" \
+    RB_USER_PASSWORD="pw" \
+    python3 "$ROOT/scripts/lib/bundle_readme.py" >/dev/null 2>&1
+}
+
+section_style() {  # <html> <section-id>
+    grep -oE "id=\"$2-en\" style=\"[^\"]*\"" "$1" | head -1 | sed 's/.*style="//; s/"$//'
+}
+
+# section-id : the artifact file(s) that should make it appear
+# Empty artifact means "driven by an env var, not a file" (dnstt).
+run_case() {  # <label> <section> <artifact...>
+    local label="$1" section="$2"; shift 2
+    local d="$tmp/$section"; rm -rf "$d"; mkdir -p "$d"
+    local f
+    for f in "$@"; do
+        case "$f" in
+            *.json) printf '{"server":"203.0.113.9"}\n' > "$d/$f" ;;
+            *.png)  printf 'x' > "$d/$f" ;;
+            *)      printf 'server=203.0.113.9\n' > "$d/$f" ;;
+        esac
+    done
+    render "$d"
+    local st; st=$(section_style "$d/README.html" "$section")
+    if [ -z "$st" ]; then
+        ok "$label: visible"
+    else
+        bad "$label: HIDDEN ($st) although its artifact is in the bundle"
+    fi
+
+    # And the converse: with the artifacts gone it must hide.
+    rm -f "$d"/*
+    ( unset RB_DNSTT_PUBKEY; render "$d" )
+    st=$(section_style "$d/README.html" "$section")
+    if [ "$st" = "display:none" ]; then
+        ok "$label: hidden when absent"
+    else
+        bad "$label: still shown with no artifact (style='$st')"
+    fi
+}
+
+run_case "reality"     reality      reality.txt
+run_case "hysteria2"   hysteria2    hysteria2.txt
+run_case "trojan"      trojan       trojan.txt
+run_case "anytls"      anytls       anytls.txt
+run_case "shadowsocks" shadowsocks  shadowsocks.txt
+run_case "xhttp"       xhttp        xhttp-vless.txt
+run_case "telegram"    telemt       telegram-proxy-link.txt
+run_case "wireguard"   wireguard    moav-srv-wg.conf
+run_case "amneziawg"   amneziawg    moav-srv-awg.conf
+run_case "masterdns"   masterdns    masterdns-client_config.toml
+run_case "xdns"        xdns         xdns-config.json
+run_case "slipstream"  slipstream   slipstream-cert.pem
+run_case "gooserelay"  gooserelay   gooserelay-client_config.json
+# The reported bug: .toml and .json are what actually ship.
+run_case "trusttunnel" trusttunnel  trusttunnel.toml trusttunnel.json
+
+# dnstt has no per-user artifact — presence is the server pubkey.
+d="$tmp/dnstt"; mkdir -p "$d"
+RB_DNSTT_PUBKEY="deadbeefdeadbeefdeadbeefdeadbeef" render "$d"
+st=$(section_style "$d/README.html" "dns-tunnel")
+[ -z "$st" ] && ok "dnstt: visible when the server pubkey is set" \
+             || bad "dnstt: HIDDEN with a pubkey set ($st)"
+( unset RB_DNSTT_PUBKEY; render "$d" )
+st=$(section_style "$d/README.html" "dns-tunnel")
+[ "$st" = "display:none" ] && ok "dnstt: hidden with no pubkey" \
+                           || bad "dnstt: shown with no pubkey (style='$st')"
+
+# --- no section may key on a file nothing writes -----------------------------
+# The root cause. Any _hide()/isfile() target must be a name some generator
+# actually produces, or the section silently disappears from every bundle.
+for name in $(grep -oE '_hide\("[^"]+"\)|isfile\(os\.path\.join\(OUT, "[^"]+"\)' \
+                "$ROOT/scripts/lib/bundle_readme.py" | grep -oE '"[^"]+"' | tr -d '"' | sort -u); do
+    case "$name" in
+        # resolved through _candidates() globs to the moav-<server>-* names
+        wireguard.conf|amneziawg.conf|wireguard-wstunnel.conf|wireguard-ipv6.conf|amneziawg-ipv6.conf) continue ;;
+    esac
+    if grep -rqF "$name" "$ROOT/scripts" --include="*.sh" 2>/dev/null; then
+        ok "$name is written by a generator"
+    else
+        bad "$name is referenced by the guide but NO script writes it — section hides silently"
+    fi
+done
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
The reported bug is real (Noticed the bug in https://www.youtube.com/watch?v=UndaXuS9-Ws) , and the audit found two more instances of the same root cause.

## What the user saw

TrustTunnel generated, listed in the admin dashboard, **missing from README.html**.

## Root cause: sections keyed on filenames nothing writes

`bundle_readme.py` hides a protocol section when its artifact is absent. TrustTunnel was keyed on **`trusttunnel.txt`** — a filename no script has ever written. The real artifacts are `trusttunnel.toml` and `trusttunnel.json`. So the section was hidden in **every bundle ever produced**, not just this user's.

Same bug hid the **dnstt** section, keyed on **`dnstt-instructions.txt`**, also never written. dnstt is server-wide and has no per-user artifact at all, so its signal is now the server pubkey the guide already embeds.

Confirmed live on a server where both are enabled and running:

```
id="trusttunnel-en" style="display:none"     <- configs present
id="dns-tunnel-en"  style="display:none"     <- enabled + container up
```

## Validated all the other protocols, as asked

Rendered the guide for each of the 14 protocols with and against its artifact. **No further cases.** Every other `_hide()` target is a file a generator actually writes, and `anytls`/`gooserelay` were hidden *correctly* — both are `false` on that server.

One thing that looks wrong but is not: `slipstream-en` uses `{{CONFIG_SLIPSTREAM}}` as its `style` attribute. The `CONFIG_` prefix is misleading — it is a display value and behaves correctly. Flagging rather than "fixing" it.

## A third instance, and this one is not cosmetic

`lib/migrate.sh` carries the same two phantom names. `trusttunnel.toml` and `.json` **do contain the server IP** (verified), so `moav migrate-ip` was rewriting a file that does not exist and leaving TrustTunnel users pointed at the **old server** after a move. Now covers the real files.

The DNS-family configs key off the domain rather than the IP, so they were genuinely unaffected — checked before claiming.

## Tests

`tests/bundle-guide-sections-test.sh` (39 asserts, in CI) drives the real renderer for all 14 protocols and asserts **both** directions — visible with the artifact, hidden without — plus a guard that every file the guide keys on is one a generator writes. That last one is what would have caught this class originally.

Negative controls verified: reintroducing the `trusttunnel.txt` key, reintroducing `dnstt-instructions.txt`, and the opposite failure (a section pinned always-visible) each fail the suite.

## Noted, not fixed here

`ENABLE_TRUSTTUNNEL=false` is set in `user-add.sh`'s donate-mode block but never checked, so donate-mode users still get TrustTunnel configs. Pre-existing and out of scope for this fix.