### PR TITLE
fix(user-add): do not generate configs for disabled protocols

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -236,7 +236,7 @@ MAHSANET_API_KEY=
 # WireGuard/AmneziaWG/TrustTunnel/GooseRelay and the DNS tunnels are never
 # donated -- each needs a client daemon, tunnel device or DNS delegation the
 # recipient does not have. See docs/devdocs/DONATE-MODE.md
-MAHSANET_PROTOCOLS="reality hysteria2"
+MAHSANET_PROTOCOLS="reality hysteria2 xhttp"
 MAHSANET_POOL=mahsa
 # Link shown next to every config you donate — point it at your own channel if
 # you prefer. No scheme and no "@" (MahsaNet's rule); both are stripped/refused.

--- a/.env.example
+++ b/.env.example
@@ -231,6 +231,11 @@ SNOWFLAKE_CAPACITY=50        # Max concurrent clients
 # -- Mahsanet config donation (mahsaserver.com) --
 # Register at https://www.mahsaserver.com/, verify, then generate an API key.
 MAHSANET_API_KEY=
+# Which protocols to donate. Space-separated, from the donatable set:
+# reality, trojan, anytls, hysteria2, shadowsocks, telegram, xhttp, cdn.
+# WireGuard/AmneziaWG/TrustTunnel/GooseRelay and the DNS tunnels are never
+# donated -- each needs a client daemon, tunnel device or DNS delegation the
+# recipient does not have. See docs/devdocs/DONATE-MODE.md
 MAHSANET_PROTOCOLS="reality hysteria2"
 MAHSANET_POOL=mahsa
 # Link shown next to every config you donate — point it at your own channel if

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         run: bash tests/user-subscription-test.sh
       - name: bundle guide section visibility (all protocols)
         run: bash tests/bundle-guide-sections-test.sh
+      - name: ENABLE_* gating in the user-add paths
+        run: bash tests/enable-flag-gating-test.sh
       - name: admin TLS enforcement
         run: bash tests/admin-tls-test.sh
       - name: admin IP whitelist (CIDR) unit test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -313,44 +313,72 @@ jobs:
           done
           [ "$bad" -eq 0 ]
 
-      - name: A disabled protocol must not reach the bundle
+      - name: Protocol gating — normal add, disabled protocols, donate mode (CLI + dashboard)
         run: |
-          # A user reported bundles containing protocols they never enabled. The
-          # host add path (singbox-user-add.sh) gated only SS/AnyTLS/XHTTP, so
-          # Reality, Trojan, Hysteria2 and TrustTunnel shipped regardless of
-          # their ENABLE_* flags. Static gating is covered by
-          # tests/enable-flag-gating-test.sh; this is the live both-directions
-          # check, on a real bootstrapped server.
+          # Two user reports live here: bundles carrying protocols the operator
+          # disabled, and donate mode handing recipients the operator's full
+          # protocol set. Donate mode was silently a no-op for everything the
+          # sub-scripts generate, so this asserts the DASHBOARD path too --
+          # admin/main.py runs the same script with DONATE_ONLY_PROTOCOLS in the
+          # environment, and that is the path the MahsaNet donation actually uses.
+          set -u
+          fails=0
+          have() { [ -e "outputs/bundles/$1/$2" ]; }
+          # want <user> <file>...  — every file must be present
+          want() { u=$1; shift; for f in "$@"; do have "$u" "$f" || { echo "::error::$u: $f missing (should be present)"; fails=$((fails+1)); }; done; }
+          # deny <user> <file>...  — none may be present
+          deny() { u=$1; shift; for f in "$@"; do ! have "$u" "$f" || { echo "::error::$u: $f present (should be absent)"; fails=$((fails+1)); }; done; }
+          own() { sudo chown -R "$USER" configs state outputs 2>/dev/null || true; }
+
           cp .env /tmp/e2e-env.bak
           trap 'cp /tmp/e2e-env.bak .env' EXIT
+
+          # --- 1. normal add: everything enabled must be there -----------------
+          ./moav.sh user add gate-normal; own
+          want gate-normal reality.txt trojan.txt hysteria2.txt shadowsocks.txt \
+                           xhttp-vless.txt trusttunnel.toml telegram-proxy-link.txt
+
+          # --- 2. disabled protocols must not reach the bundle -----------------
           sed -i 's/^ENABLE_TROJAN=.*/ENABLE_TROJAN=false/;s/^ENABLE_HYSTERIA2=.*/ENABLE_HYSTERIA2=false/' .env
           grep -q '^ENABLE_TROJAN='    .env || echo 'ENABLE_TROJAN=false'    >> .env
           grep -q '^ENABLE_HYSTERIA2=' .env || echo 'ENABLE_HYSTERIA2=false' >> .env
-
-          ./moav.sh user add gatecheck            # must not die under set -u
-          sudo chown -R "$USER" configs state outputs 2>/dev/null || true
-
-          bad=0
-          for f in trojan.txt trojan-qr.png hysteria2.txt hysteria2-qr.png; do
-            if [ -e "outputs/bundles/gatecheck/$f" ]; then
-              echo "::error::$f is in the bundle although its protocol is disabled"; bad=1
-            fi
-          done
-          # ...and the converse: a still-enabled protocol must be present, or a
-          # gate that hides everything would pass the check above.
-          for f in reality.txt; do
-            if [ ! -s "outputs/bundles/gatecheck/$f" ]; then
-              echo "::error::$f missing although its protocol is enabled"; bad=1
-            fi
-          done
-          # The subscription is built from those links, so it must agree.
-          if base64 -d outputs/bundles/gatecheck/subscription.txt 2>/dev/null | grep -qE '^(trojan|hysteria2)://'; then
-            echo "::error::subscription.txt advertises a disabled protocol"; bad=1
+          ./moav.sh user add gate-off; own
+          deny gate-off trojan.txt trojan-qr.png hysteria2.txt hysteria2-qr.png
+          want gate-off reality.txt          # converse: a gate that hid everything must fail
+          if base64 -d outputs/bundles/gate-off/subscription.txt 2>/dev/null | grep -qE '^(trojan|hysteria2)://'; then
+            echo "::error::subscription.txt advertises a disabled protocol"; fails=$((fails+1))
           fi
+          cp /tmp/e2e-env.bak .env
 
-          ./moav.sh user revoke gatecheck >/dev/null 2>&1 || true
-          rm -rf outputs/bundles/gatecheck state/users/gatecheck
-          [ "$bad" -eq 0 ]
+          # --- 3. donate mode via the CLI --------------------------------------
+          DONATE_ONLY_PROTOCOLS="reality hysteria2" ./moav.sh user add gate-donate; own
+          want gate-donate reality.txt hysteria2.txt
+          deny gate-donate trojan.txt shadowsocks.txt xhttp-vless.txt cdn-vless.txt \
+                           trusttunnel.toml trusttunnel.json masterdns-client_config.toml \
+                           xdns-config.json slipstream-client.conf telegram-proxy-link.txt
+          for w in moav-*-wg.conf moav-*-awg.conf; do
+            if compgen -G "outputs/bundles/gate-donate/$w" >/dev/null; then
+              echo "::error::gate-donate: $w present (WireGuard family is never donated)"; fails=$((fails+1))
+            fi
+          done
+          n=$(base64 -d outputs/bundles/gate-donate/subscription.txt 2>/dev/null | grep -c '://' || true)
+          [ "$n" -eq 2 ] || { echo "::error::donated subscription has $n entries, expected 2"; fails=$((fails+1)); }
+
+          # --- 4. donate mode via the DASHBOARD path ---------------------------
+          # admin/main.py: subprocess.run(["bash", user-add.sh, ...], cwd=/project,
+          # env={... DONATE_ONLY_PROTOCOLS}). Same shape, inside the container.
+          docker compose exec -T -w /project \
+            -e DONATE_ONLY_PROTOCOLS="reality hysteria2" \
+            admin bash scripts/user-add.sh gate-dash; own
+          want gate-dash reality.txt hysteria2.txt
+          deny gate-dash trojan.txt shadowsocks.txt xhttp-vless.txt trusttunnel.toml \
+                         masterdns-client_config.toml xdns-config.json
+
+          for u in gate-normal gate-off gate-donate gate-dash; do
+            ./moav.sh user revoke "$u" >/dev/null 2>&1 || true
+            rm -rf "outputs/bundles/$u" "state/users/$u"
+          done
+          [ "$fails" -eq 0 ]
 
       - name: Run connectivity tests
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -313,6 +313,45 @@ jobs:
           done
           [ "$bad" -eq 0 ]
 
+      - name: A disabled protocol must not reach the bundle
+        run: |
+          # A user reported bundles containing protocols they never enabled. The
+          # host add path (singbox-user-add.sh) gated only SS/AnyTLS/XHTTP, so
+          # Reality, Trojan, Hysteria2 and TrustTunnel shipped regardless of
+          # their ENABLE_* flags. Static gating is covered by
+          # tests/enable-flag-gating-test.sh; this is the live both-directions
+          # check, on a real bootstrapped server.
+          cp .env /tmp/e2e-env.bak
+          trap 'cp /tmp/e2e-env.bak .env' EXIT
+          sed -i 's/^ENABLE_TROJAN=.*/ENABLE_TROJAN=false/;s/^ENABLE_HYSTERIA2=.*/ENABLE_HYSTERIA2=false/' .env
+          grep -q '^ENABLE_TROJAN='    .env || echo 'ENABLE_TROJAN=false'    >> .env
+          grep -q '^ENABLE_HYSTERIA2=' .env || echo 'ENABLE_HYSTERIA2=false' >> .env
+
+          ./moav.sh user add gatecheck            # must not die under set -u
+          sudo chown -R "$USER" configs state outputs 2>/dev/null || true
+
+          bad=0
+          for f in trojan.txt trojan-qr.png hysteria2.txt hysteria2-qr.png; do
+            if [ -e "outputs/bundles/gatecheck/$f" ]; then
+              echo "::error::$f is in the bundle although its protocol is disabled"; bad=1
+            fi
+          done
+          # ...and the converse: a still-enabled protocol must be present, or a
+          # gate that hides everything would pass the check above.
+          for f in reality.txt; do
+            if [ ! -s "outputs/bundles/gatecheck/$f" ]; then
+              echo "::error::$f missing although its protocol is enabled"; bad=1
+            fi
+          done
+          # The subscription is built from those links, so it must agree.
+          if base64 -d outputs/bundles/gatecheck/subscription.txt 2>/dev/null | grep -qE '^(trojan|hysteria2)://'; then
+            echo "::error::subscription.txt advertises a disabled protocol"; bad=1
+          fi
+
+          ./moav.sh user revoke gatecheck >/dev/null 2>&1 || true
+          rm -rf outputs/bundles/gatecheck state/users/gatecheck
+          [ "$bad" -eq 0 ]
+
       - name: Run connectivity tests
         run: |
           set -o pipefail

--- a/docs/devdocs/DONATE-MODE.md
+++ b/docs/devdocs/DONATE-MODE.md
@@ -1,0 +1,75 @@
+# Donate mode
+
+Donate mode creates **lightweight users whose configs are handed to another
+network** (MahsaNet today) instead of to one of your own users. Those recipients
+import a share link into a phone app — they never run a client daemon, never get
+a tunnel device, and never control a DNS resolver.
+
+That single fact decides what is donatable.
+
+## What it is
+
+Setting `DONATE_ONLY_PROTOCOLS` on a `user add` switches it into donate mode:
+
+```bash
+DONATE_ONLY_PROTOCOLS="reality hysteria2" ./scripts/user-add.sh alice
+```
+
+The value is a **space-separated list of protocol tokens**. Everything not in
+that list is disabled for that user, so the bundle carries only what was asked
+for.
+
+## Who sets it
+
+| Caller | Where | Source of the list |
+|---|---|---|
+| CLI | `lib/donate.sh` (`export DONATE_ONLY_PROTOCOLS`) | `MAHSANET_PROTOCOLS` in `.env`, default `"reality hysteria2"` |
+| Admin dashboard | `admin/main.py`, MahsaNet batch endpoint | request body `protocols`, defaulting to `MAHSANET_PROTOCOLS` |
+
+Both end at the same place: `scripts/user-add.sh`, the `DONATE_ONLY` block.
+
+## Donatable vs not
+
+**Donatable** — sing-box / xray protocols that travel as a single share link or
+subscription entry:
+
+`reality` · `trojan` · `anytls` · `hysteria2` · `shadowsocks` · `telegram` ·
+`xhttp` · `cdn`
+
+**Never donated**, forced off regardless of `.env`:
+
+WireGuard · AmneziaWG · TrustTunnel · GooseRelay · dnstt · Slipstream ·
+MasterDNS · XDNS
+
+The reason is the same for all of them: each needs something the recipient
+cannot get from a pasted link — a client-side daemon, a `wg`/`awg` tunnel
+device, or an NS delegation pointed at your server. Donating one would produce a
+config that looks valid and cannot connect.
+
+`cdn` is the odd one out: it has no `ENABLE_` flag and is switched by clearing
+`CDN_SUBDOMAIN`.
+
+## Adding a protocol to donate mode
+
+1. Confirm it is actually donatable by the test above: can a recipient use it
+   with **only** a share link or subscription entry, no daemon and no DNS
+   control? If not, stop — it belongs in the forced-off list.
+2. Add a `_donated <token> && ENABLE_X=true || ENABLE_X=false` line to the
+   donatable block in `scripts/user-add.sh`.
+3. Make sure the generator honours `ENABLE_X` on **both** add paths —
+   `scripts/singbox-user-add.sh` (host, what `moav user add` runs) and
+   `scripts/generate-user.sh` (container/bootstrap). They drifted apart once and
+   shipped protocols that were switched off;
+   `tests/enable-flag-gating-test.sh` guards that now.
+4. Add the token to `MAHSANET_PROTOCOLS` in `.env.example` only if it should be
+   donated **by default**.
+5. If the dashboard should offer it, it is already list-driven — the endpoint
+   validates against the same set.
+
+## Gotcha
+
+Donate mode only sets the `ENABLE_*` variables. It relies on each generator
+actually checking its flag. A generator that keys on "does this config file
+exist" instead of its flag will keep producing configs in donate mode, because
+those files are server-wide and survive the toggle. TrustTunnel had exactly that
+bug: it was gated on `configs/trusttunnel/credentials.toml` existing.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -294,3 +294,39 @@ get_env_val() {
     val=$(grep "^${key}=" "$file" 2>/dev/null | tail -1 | cut -d'=' -f2- | sed 's/#.*//' | tr -d '"' | tr -d "'" | xargs) || true
     echo "${val:-$default}"
 }
+
+# Donate mode: restrict a user to the protocols in DONATE_ONLY_PROTOCOLS.
+# Reference, including how to add a protocol: docs/devdocs/DONATE-MODE.md
+#
+# Call this AFTER sourcing .env, in every script that generates per-user configs.
+# It used to live only in user-add.sh, un-exported, and each sub-script then
+# re-sourced .env — so the overrides never reached singbox-user-add.sh or
+# wg-user-add.sh, and donated users got the operator's full protocol set.
+apply_donate_mode() {
+    local list=" ${DONATE_ONLY_PROTOCOLS:-} "
+    [[ -n "${DONATE_ONLY_PROTOCOLS:-}" ]] || return 0
+
+    # Not donatable: each needs a client-side daemon, a tunnel device or a DNS
+    # delegation, which a recipient pasting a share link does not have.
+    export ENABLE_WIREGUARD=false ENABLE_AMNEZIAWG=false ENABLE_TRUSTTUNNEL=false \
+           ENABLE_GOOSERELAY=false ENABLE_DNSTT=false ENABLE_SLIPSTREAM=false \
+           ENABLE_MASTERDNS=false ENABLE_XDNS=false
+
+    _dm() { [[ "$list" == *" $1 "* ]]; }
+    _dm reality     && export ENABLE_REALITY=true   || export ENABLE_REALITY=false
+    _dm trojan      && export ENABLE_TROJAN=true    || export ENABLE_TROJAN=false
+    _dm anytls      && export ENABLE_ANYTLS=true    || export ENABLE_ANYTLS=false
+    _dm hysteria2   && export ENABLE_HYSTERIA2=true || export ENABLE_HYSTERIA2=false
+    _dm shadowsocks && export ENABLE_SS=true        || export ENABLE_SS=false
+    _dm telegram    && export ENABLE_TELEMT=true    || export ENABLE_TELEMT=false
+    _dm xhttp       && export ENABLE_XHTTP=true     || export ENABLE_XHTTP=false
+    unset -f _dm
+}
+
+# True when donate mode is off, or when $1 is in the donated list. For protocols
+# with no ENABLE_ flag to switch (CDN keys off CDN_SUBDOMAIN, and clearing that
+# does not stick because the generator re-reads .env when it is empty).
+donate_allows() {
+    [[ -z "${DONATE_ONLY_PROTOCOLS:-}" ]] && return 0
+    [[ " ${DONATE_ONLY_PROTOCOLS} " == *" $1 "* ]]
+}

--- a/scripts/singbox-user-add.sh
+++ b/scripts/singbox-user-add.sh
@@ -227,11 +227,16 @@ REALITY_TARGET_HOST=$(echo "$REALITY_TARGET" | cut -d: -f1)
 # -----------------------------------------------------------------------------
 
 # Reality link (IPv4)
-REALITY_LINK=$(singbox_reality_link "$USERNAME" "$SERVER_IP")
-echo "$REALITY_LINK" > "$OUTPUT_DIR/reality.txt"
+# Gated like every other protocol: without this the host add path shipped
+# Reality/Trojan/Hysteria2 links even with their ENABLE_* set to false, so a
+# bundle advertised inbounds the operator had turned off.
+if [[ "${ENABLE_REALITY:-true}" == "true" ]]; then
+    REALITY_LINK=$(singbox_reality_link "$USERNAME" "$SERVER_IP")
+    echo "$REALITY_LINK" > "$OUTPUT_DIR/reality.txt"
+fi
 
-# Trojan link (IPv4) — only if domain is set (requires TLS cert)
-if [[ -n "${DOMAIN:-}" ]]; then
+# Trojan link (IPv4) — only if enabled and domain is set (requires TLS cert)
+if [[ "${ENABLE_TROJAN:-true}" == "true" ]] && [[ -n "${DOMAIN:-}" ]]; then
     TROJAN_LINK=$(singbox_trojan_link "$USERNAME" "$SERVER_IP")
     echo "$TROJAN_LINK" > "$OUTPUT_DIR/trojan.txt"
 fi
@@ -242,28 +247,34 @@ if [[ "${ENABLE_ANYTLS:-false}" == "true" ]] && [[ -n "${DOMAIN:-}" ]]; then
     echo "$ANYTLS_LINK" > "$OUTPUT_DIR/anytls.txt"
 fi
 
-# Hysteria2 link (IPv4) — only if domain is set (requires TLS cert)
-if [[ -n "${DOMAIN:-}" ]]; then
+# Hysteria2 link (IPv4) — only if enabled and domain is set (requires TLS cert)
+if [[ "${ENABLE_HYSTERIA2:-true}" == "true" ]] && [[ -n "${DOMAIN:-}" ]]; then
     HY2_LINK=$(singbox_hysteria2_link "$USERNAME" "$SERVER_IP")
     echo "$HY2_LINK" > "$OUTPUT_DIR/hysteria2.txt"
 fi
 
 # Generate IPv6 links if available
 if [[ -n "$SERVER_IPV6" ]]; then
-    REALITY_LINK_V6=$(singbox_reality_link "IPv6-${USERNAME}" "[${SERVER_IPV6}]")
-    echo "$REALITY_LINK_V6" > "$OUTPUT_DIR/reality-ipv6.txt"
+    if [[ "${ENABLE_REALITY:-true}" == "true" ]]; then
+        REALITY_LINK_V6=$(singbox_reality_link "IPv6-${USERNAME}" "[${SERVER_IPV6}]")
+        echo "$REALITY_LINK_V6" > "$OUTPUT_DIR/reality-ipv6.txt"
+    fi
 
     if [[ -n "${DOMAIN:-}" ]]; then
-        TROJAN_LINK_V6=$(singbox_trojan_link "IPv6-${USERNAME}" "[${SERVER_IPV6}]")
-        echo "$TROJAN_LINK_V6" > "$OUTPUT_DIR/trojan-ipv6.txt"
+        if [[ "${ENABLE_TROJAN:-true}" == "true" ]]; then
+            TROJAN_LINK_V6=$(singbox_trojan_link "IPv6-${USERNAME}" "[${SERVER_IPV6}]")
+            echo "$TROJAN_LINK_V6" > "$OUTPUT_DIR/trojan-ipv6.txt"
+        fi
 
         if [[ "${ENABLE_ANYTLS:-false}" == "true" ]]; then
             ANYTLS_LINK_V6=$(singbox_anytls_link "IPv6-${USERNAME}" "[${SERVER_IPV6}]")
             echo "$ANYTLS_LINK_V6" > "$OUTPUT_DIR/anytls-ipv6.txt"
         fi
 
-        HY2_LINK_V6=$(singbox_hysteria2_link "IPv6-${USERNAME}" "[${SERVER_IPV6}]")
-        echo "$HY2_LINK_V6" > "$OUTPUT_DIR/hysteria2-ipv6.txt"
+        if [[ "${ENABLE_HYSTERIA2:-true}" == "true" ]]; then
+            HY2_LINK_V6=$(singbox_hysteria2_link "IPv6-${USERNAME}" "[${SERVER_IPV6}]")
+            echo "$HY2_LINK_V6" > "$OUTPUT_DIR/hysteria2-ipv6.txt"
+        fi
     fi
 
     log_info "Generated IPv6 links (server: $SERVER_IPV6)"
@@ -271,14 +282,14 @@ fi
 
 # Generate QR codes
 if command -v qrencode &>/dev/null; then
-    qrencode -o "$OUTPUT_DIR/reality-qr.png" -s 6 "$REALITY_LINK" 2>/dev/null || true
+    [[ -n "${REALITY_LINK:-}" ]] && qrencode -o "$OUTPUT_DIR/reality-qr.png" -s 6 "$REALITY_LINK" 2>/dev/null || true
     [[ -n "${TROJAN_LINK:-}" ]] && qrencode -o "$OUTPUT_DIR/trojan-qr.png" -s 6 "$TROJAN_LINK" 2>/dev/null || true
     [[ -n "${ANYTLS_LINK:-}" ]] && qrencode -o "$OUTPUT_DIR/anytls-qr.png" -s 6 "$ANYTLS_LINK" 2>/dev/null || true
     [[ -n "${HY2_LINK:-}" ]] && qrencode -o "$OUTPUT_DIR/hysteria2-qr.png" -s 6 "$HY2_LINK" 2>/dev/null || true
 
     # IPv6 QR codes
     if [[ -n "$SERVER_IPV6" ]]; then
-        qrencode -o "$OUTPUT_DIR/reality-ipv6-qr.png" -s 6 "$REALITY_LINK_V6" 2>/dev/null || true
+        [[ -n "${REALITY_LINK_V6:-}" ]] && qrencode -o "$OUTPUT_DIR/reality-ipv6-qr.png" -s 6 "$REALITY_LINK_V6" 2>/dev/null || true
         [[ -n "${TROJAN_LINK_V6:-}" ]] && qrencode -o "$OUTPUT_DIR/trojan-ipv6-qr.png" -s 6 "$TROJAN_LINK_V6" 2>/dev/null || true
         [[ -n "${ANYTLS_LINK_V6:-}" ]] && qrencode -o "$OUTPUT_DIR/anytls-ipv6-qr.png" -s 6 "$ANYTLS_LINK_V6" 2>/dev/null || true
         [[ -n "${HY2_LINK_V6:-}" ]] && qrencode -o "$OUTPUT_DIR/hysteria2-ipv6-qr.png" -s 6 "$HY2_LINK_V6" 2>/dev/null || true
@@ -377,9 +388,11 @@ EOF
     fi
 fi
 
-# Add user to TrustTunnel (if config exists)
+# Add user to TrustTunnel (if enabled and its config exists). The file-exists
+# check alone was not enough: credentials.toml survives disabling the protocol,
+# so bundles kept shipping TrustTunnel configs after ENABLE_TRUSTTUNNEL=false.
 TRUSTTUNNEL_CREDS="configs/trusttunnel/credentials.toml"
-if [[ -f "$TRUSTTUNNEL_CREDS" ]]; then
+if [[ "${ENABLE_TRUSTTUNNEL:-true}" == "true" ]] && [[ -f "$TRUSTTUNNEL_CREDS" ]]; then
     log_info "Adding $USERNAME to TrustTunnel..."
 
     # Check if user already exists in TrustTunnel
@@ -513,8 +526,10 @@ fi
 echo ""
 log_info "=== User '$USERNAME' created ==="
 echo ""
-echo "Reality Link:"
-echo "$REALITY_LINK"
+if [[ -n "${REALITY_LINK:-}" ]]; then
+    echo "Reality Link:"
+    echo "$REALITY_LINK"
+fi
 if [[ -n "${TROJAN_LINK:-}" ]]; then
     echo ""
     echo "Trojan Link:"
@@ -535,8 +550,10 @@ echo ""
 if [[ -n "${SERVER_IPV6:-}" ]]; then
     echo "=== IPv6 Links ==="
     echo ""
-    echo "Reality (IPv6):"
-    echo "$REALITY_LINK_V6"
+    if [[ -n "${REALITY_LINK_V6:-}" ]]; then
+        echo "Reality (IPv6):"
+        echo "$REALITY_LINK_V6"
+    fi
     if [[ -n "${TROJAN_LINK_V6:-}" ]]; then
         echo ""
         echo "Trojan (IPv6):"

--- a/scripts/singbox-user-add.sh
+++ b/scripts/singbox-user-add.sh
@@ -58,6 +58,10 @@ if [[ -f .env && -r .env ]]; then
     set +a
 fi
 
+# Donate mode must be re-applied: the source above just reset every ENABLE_*
+# to the operator's .env values. See docs/devdocs/DONATE-MODE.md
+apply_donate_mode
+
 CONFIG_FILE="configs/sing-box/config.json"
 STATE_DIR="${STATE_DIR:-./state}"
 OUTPUT_DIR="outputs/bundles/$USERNAME"
@@ -296,14 +300,17 @@ if command -v qrencode &>/dev/null; then
     fi
 fi
 
-# Generate CDN VLESS+WS link (if CDN configured)
+# Generate CDN VLESS+WS link (if CDN configured and, in donate mode, requested)
 # Construct CDN_DOMAIN from CDN_SUBDOMAIN + DOMAIN if not explicitly set
-CDN_DOMAIN="${CDN_DOMAIN:-$(get_env_val "CDN_DOMAIN" ".env" "")}"
-if [[ -z "$CDN_DOMAIN" ]]; then
-    CDN_SUBDOMAIN="${CDN_SUBDOMAIN:-$(get_env_val "CDN_SUBDOMAIN" ".env" "")}"
-    DOMAIN_FROM_ENV="${DOMAIN:-$(get_env_val "DOMAIN" ".env" "")}"
-    if [[ -n "$CDN_SUBDOMAIN" && -n "$DOMAIN_FROM_ENV" ]]; then
-        CDN_DOMAIN="${CDN_SUBDOMAIN}.${DOMAIN_FROM_ENV}"
+CDN_DOMAIN=""
+if donate_allows cdn; then
+    CDN_DOMAIN="${CDN_DOMAIN:-$(get_env_val "CDN_DOMAIN" ".env" "")}"
+    if [[ -z "$CDN_DOMAIN" ]]; then
+        CDN_SUBDOMAIN="${CDN_SUBDOMAIN:-$(get_env_val "CDN_SUBDOMAIN" ".env" "")}"
+        DOMAIN_FROM_ENV="${DOMAIN:-$(get_env_val "DOMAIN" ".env" "")}"
+        if [[ -n "$CDN_SUBDOMAIN" && -n "$DOMAIN_FROM_ENV" ]]; then
+            CDN_DOMAIN="${CDN_SUBDOMAIN}.${DOMAIN_FROM_ENV}"
+        fi
     fi
 fi
 # Load CDN WS path: .env → state file (bootstrap-generated) → fallback

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -168,29 +168,11 @@ if [[ -f .env && -r .env ]]; then
     rm -f "$_ENV_TMP"
 fi
 
-# DONATE_ONLY_PROTOCOLS: lightweight user creation for config donation
-# When set, only provision the listed protocols (skip WireGuard, AmneziaWG, etc.)
+# Donate mode (docs/devdocs/DONATE-MODE.md). Applied after .env is sourced, and
+# again inside each sub-script, since they re-source .env themselves.
 DONATE_ONLY="${DONATE_ONLY_PROTOCOLS:-}"
-if [[ -n "$DONATE_ONLY" ]]; then
-    log_info "Donate mode: only provisioning protocols: $DONATE_ONLY"
-    # Disable heavy services unconditionally
-    ENABLE_WIREGUARD=false
-    ENABLE_AMNEZIAWG=false
-    ENABLE_DNSTT=false
-    ENABLE_SLIPSTREAM=false
-    ENABLE_TRUSTTUNNEL=false
-    # Enable/disable based on donate list
-    echo " $DONATE_ONLY " | grep -q " reality "   && ENABLE_REALITY=true   || ENABLE_REALITY=false
-    echo " $DONATE_ONLY " | grep -q " trojan "    && ENABLE_TROJAN=true    || ENABLE_TROJAN=false
-    echo " $DONATE_ONLY " | grep -q " anytls "    && ENABLE_ANYTLS=true    || ENABLE_ANYTLS=false
-    echo " $DONATE_ONLY " | grep -q " hysteria2 " && ENABLE_HYSTERIA2=true || ENABLE_HYSTERIA2=false
-    echo " $DONATE_ONLY " | grep -q " telegram "  && ENABLE_TELEMT=true    || ENABLE_TELEMT=false
-    echo " $DONATE_ONLY " | grep -q " xhttp "     && ENABLE_XHTTP=true    || ENABLE_XHTTP=false
-    # CDN: clear CDN_DOMAIN if not in donate list
-    if ! echo " $DONATE_ONLY " | grep -q " cdn "; then
-        CDN_SUBDOMAIN=""
-    fi
-fi
+[[ -n "$DONATE_ONLY" ]] && log_info "Donate mode: only provisioning protocols: $DONATE_ONLY"
+apply_donate_mode
 
 # Display batch info
 if [[ "$BATCH_MODE" == "true" ]]; then

--- a/scripts/wg-user-add.sh
+++ b/scripts/wg-user-add.sh
@@ -56,6 +56,10 @@ if [[ -f .env && -r .env ]]; then
     set +a
 fi
 
+# Donate mode must be re-applied: the source above just reset every ENABLE_*
+# to the operator's .env values. See docs/devdocs/DONATE-MODE.md
+apply_donate_mode
+
 WG_CONFIG_DIR="configs/wireguard"
 STATE_DIR="${STATE_DIR:-./state}"
 OUTPUT_DIR="outputs/bundles/$USERNAME"

--- a/tests/enable-flag-gating-test.sh
+++ b/tests/enable-flag-gating-test.sh
@@ -96,6 +96,70 @@ else
     bad "TrustTunnel gated on credentials.toml alone — that file survives disabling it"
 fi
 
+# --- donate mode ------------------------------------------------------------
+# Donate mode hands configs to another network (MahsaNet); recipients paste a
+# share link into a phone app. Anything needing a client daemon, a tunnel device
+# or a DNS delegation cannot be donated. Reference: docs/devdocs/DONATE-MODE.md
+#
+# The overrides used to live inline in user-add.sh, un-exported, and every
+# sub-script then re-sourced .env -- so they never reached singbox-user-add.sh
+# or wg-user-add.sh and donated users got the operator's full protocol set.
+common="$ROOT/scripts/lib/common.sh"
+
+grep -q '^apply_donate_mode()' "$common" \
+    && ok "apply_donate_mode is shared in lib/common.sh" \
+    || bad "apply_donate_mode is not in lib/common.sh — each path would drift"
+
+for s in user-add.sh singbox-user-add.sh wg-user-add.sh; do
+    if grep -q '^apply_donate_mode' "$ROOT/scripts/$s"; then
+        ok "$s applies donate mode"
+    else
+        bad "$s never applies donate mode — it re-sources .env and loses the overrides"
+    fi
+done
+
+# Every override must be EXPORTED, or the sub-scripts cannot see it. Checked by
+# running the function and reading the environment it leaves behind -- a textual
+# check misreads a multi-line `export a=1 \\\n b=2` as unexported continuations.
+donate_env=$(
+    set +u
+    # shellcheck disable=SC1090
+    source "$common" >/dev/null 2>&1
+    DONATE_ONLY_PROTOCOLS="reality hysteria2"
+    apply_donate_mode
+    env | grep -E '^(ENABLE_|CDN_SUBDOMAIN)' | sort
+)
+for want in ENABLE_WIREGUARD=false ENABLE_AMNEZIAWG=false ENABLE_TRUSTTUNNEL=false \
+            ENABLE_GOOSERELAY=false ENABLE_DNSTT=false ENABLE_SLIPSTREAM=false \
+            ENABLE_MASTERDNS=false ENABLE_XDNS=false \
+            ENABLE_REALITY=true ENABLE_HYSTERIA2=true \
+            ENABLE_TROJAN=false ENABLE_SS=false ENABLE_XHTTP=false ENABLE_TELEMT=false; do
+    if printf '%s\n' "$donate_env" | grep -qx "$want"; then
+        ok "donate mode exports $want"
+    else
+        got=$(printf '%s\n' "$donate_env" | grep "^${want%%=*}=" || echo "<unset>")
+        bad "donate mode: expected $want, got $got"
+    fi
+done
+
+# The non-donatable set must stay forced off.
+for p in WIREGUARD AMNEZIAWG TRUSTTUNNEL GOOSERELAY DNSTT SLIPSTREAM MASTERDNS XDNS; do
+    if awk '/^apply_donate_mode\(\)/,/^}/' "$common" | grep -q "ENABLE_$p=false"; then
+        ok "donate mode forces ENABLE_$p off"
+    else
+        bad "donate mode does not disable $p — not donatable, needs a daemon/tunnel/DNS"
+    fi
+done
+
+# CDN has no ENABLE_ flag; clearing CDN_SUBDOMAIN does not stick because the
+# generator re-reads .env when it is empty, so it needs the predicate.
+grep -q '^donate_allows()' "$common" \
+    && ok "donate_allows() exists for flagless protocols" \
+    || bad "no donate_allows() — CDN cannot be excluded from a donation"
+grep -q 'donate_allows cdn' "$ROOT/scripts/singbox-user-add.sh" \
+    && ok "CDN generation is gated by donate_allows" \
+    || bad "CDN is not gated — donated users get a CDN link they did not ask for"
+
 echo ""
 echo "  passed: $pass   failed: $fail"
 [ "$fail" -eq 0 ] || exit 1

--- a/tests/enable-flag-gating-test.sh
+++ b/tests/enable-flag-gating-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Regression test: `moav user add` must not generate configs for a protocol the
+# operator disabled.
+#
+# Reported by a user: bundles contained protocols they never enabled. Cause was
+# an asymmetry between the two add paths. generate-user.sh (the container /
+# bootstrap path) gated Reality, Trojan, Hysteria2 and TrustTunnel on their
+# ENABLE_* flags; singbox-user-add.sh (the HOST path, what `moav user add` runs)
+# gated only SS, AnyTLS and XHTTP. So bootstrap-created users were correct while
+# every later user got share links for inbounds the operator had turned off.
+#
+# TrustTunnel had a second cause: it was gated on configs/trusttunnel/
+# credentials.toml existing, and that file survives disabling the protocol.
+#
+# Static test -- it asserts each generation site sits behind its flag. The live
+# both-directions check runs in e2e (disabled protocols absent, enabled present).
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+host="$ROOT/scripts/singbox-user-add.sh"
+cont="$ROOT/scripts/generate-user.sh"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "ENABLE_* gating in the user-add paths"
+
+# Does $2 (an artifact write) sit inside a block guarded by $1 (its flag)?
+# Walks the file tracking the nearest enclosing `if` that mentions the flag.
+gated() {  # <flag> <artifact-write-substring> <file>
+    python3 - "$1" "$2" "$3" <<'PY'
+import sys, re
+flag, needle, path = sys.argv[1], sys.argv[2], sys.argv[3]
+depth, guard = 0, []          # guard[i] = True if the if at depth i tests flag
+for line in open(path):
+    s = line.strip()
+    if re.match(r'^(if|elif)\b', s):
+        if re.match(r'^if\b', s):
+            guard.append(flag in s)
+            depth += 1
+        elif guard:
+            guard[-1] = guard[-1] or (flag in s)
+    elif s.startswith('fi') and guard:
+        guard.pop(); depth -= 1
+    if needle in s and not s.startswith('#'):
+        sys.exit(0 if any(guard) else 1)
+sys.exit(2)   # needle not found
+PY
+}
+
+check() {  # <label> <flag> <needle> <file>
+    local label="$1" flag="$2" needle="$3" file="$4"
+    gated "$flag" "$needle" "$file"
+    case "$?" in
+        0) ok   "$label gated on $flag" ;;
+        1) bad  "$label is NOT gated on $flag — a disabled protocol still ships configs" ;;
+        2) bad  "$label: could not find '$needle' in $(basename "$file") — test is stale" ;;
+    esac
+}
+
+# --- the host path (what `moav user add` actually runs) ----------------------
+check "reality.txt"    ENABLE_REALITY    'reality.txt"'    "$host"
+check "trojan.txt"     ENABLE_TROJAN     'trojan.txt"'     "$host"
+check "hysteria2.txt"  ENABLE_HYSTERIA2  'hysteria2.txt"'  "$host"
+check "anytls.txt"     ENABLE_ANYTLS     'anytls.txt"'     "$host"
+check "trusttunnel"    ENABLE_TRUSTTUNNEL 'trusttunnel_write_client_bundle' "$host"
+
+# --- the container path must stay gated too ---------------------------------
+check "reality (container)"   ENABLE_REALITY   'reality.txt"'   "$cont"
+check "trojan (container)"    ENABLE_TROJAN    'trojan.txt"'    "$cont"
+check "hysteria2 (container)" ENABLE_HYSTERIA2 'hysteria2.txt"' "$cont"
+
+# --- a disabled protocol must not break the summary/QR under set -u ---------
+# Once the link vars are conditional, every later use has to tolerate them being
+# unset, or `moav user add` dies with "unbound variable" instead of skipping.
+# Every later use of a now-conditional link var must tolerate it being unset, or
+# `moav user add` dies with "unbound variable" instead of skipping the protocol.
+# Checked by shape, not by an enclosing-block walk: the QR sites are `[[ -n ...
+# ]] && qrencode` AND-lists rather than if-blocks, and a needle like
+# 'echo "$REALITY_LINK"' also matches the redirect that writes reality.txt.
+# e2e covers the runtime side by adding a user with the protocol disabled.
+for site in 'qrencode -o "$OUTPUT_DIR/reality-qr.png"' 'qrencode -o "$OUTPUT_DIR/reality-ipv6-qr.png"'; do
+    line=$(grep -F "$site" "$host" | head -1)
+    if printf '%s' "$line" | grep -q '\-n "${REALITY_LINK'; then
+        ok "$(printf '%s' "$site" | grep -oE '[a-z0-9-]+\.png') is guarded against an unset link"
+    else
+        bad "unguarded QR site (set -u aborts when the protocol is off): $line"
+    fi
+done
+
+# --- TrustTunnel must not key on a file that outlives the toggle ------------
+if grep -q 'ENABLE_TRUSTTUNNEL.*==.*"true".*&&.*-f "$TRUSTTUNNEL_CREDS"' "$host" \
+   || grep -B1 '\-f "$TRUSTTUNNEL_CREDS"' "$host" | grep -q 'ENABLE_TRUSTTUNNEL'; then
+    ok "TrustTunnel checks the flag, not just credentials.toml"
+else
+    bad "TrustTunnel gated on credentials.toml alone — that file survives disabling it"
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/tests/enable-flag-gating-test.sh
+++ b/tests/enable-flag-gating-test.sh
@@ -160,6 +160,19 @@ grep -q 'donate_allows cdn' "$ROOT/scripts/singbox-user-add.sh" \
     && ok "CDN generation is gated by donate_allows" \
     || bad "CDN is not gated — donated users get a CDN link they did not ask for"
 
+# The shipped donation default must be a subset of what donate mode can actually
+# grant. A typo ("shadowsock") or a tunnel protocol here would silently donate
+# nothing for that entry, since apply_donate_mode only matches known tokens.
+donatable="reality trojan anytls hysteria2 shadowsocks telegram xhttp cdn"
+defaults=$(grep -E '^MAHSANET_PROTOCOLS=' "$ROOT/.env.example" | cut -d= -f2- | tr -d '"')
+for tok in $defaults; do
+    case " $donatable " in
+        *" $tok "*) ok "MAHSANET_PROTOCOLS default '$tok' is donatable" ;;
+        *)          bad "MAHSANET_PROTOCOLS default '$tok' is not in the donatable set — it would donate nothing" ;;
+    esac
+done
+
+
 echo ""
 echo "  passed: $pass   failed: $fail"
 [ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
The reported bug is real and reproducible.

## What happens

With `ENABLE_TROJAN=false` and `ENABLE_HYSTERIA2=false` on a live server, `moav user add` still produced:

```
trojan.txt  trojan-qr.png  hysteria2.txt  hysteria2-qr.png
```

So a bundle advertises inbounds the operator turned off, and the user gets links that cannot work.

## Cause: the two add paths had drifted

| path | gates |
|---|---|
| `generate-user.sh` (container / bootstrap) | Reality, Trojan, Hysteria2, TrustTunnel, + SS/AnyTLS/XHTTP |
| `singbox-user-add.sh` (**host** — what `moav user add` runs) | **only** SS, AnyTLS, XHTTP |

Bootstrap-created users were correct, which is why this survived: the demo user looked fine and every user added afterwards did not.

**TrustTunnel had a second cause** — it was gated on `configs/trusttunnel/credentials.toml` existing, and that file survives disabling the protocol, so the check never went false.

## The fix

Each generation site now sits behind its `ENABLE_*` flag on the host path, matching the container path's existing pattern.

One consequence worth calling out: once the link variables are conditional, every later use has to tolerate them being unset, or `set -u` kills the whole add instead of skipping one protocol. The QR and summary sites are guarded accordingly, and I verified it live with `ENABLE_REALITY=false` — exits 0, no reality artifacts, other protocols intact.

## Verified live, both directions

- disabled → `reality-qr.png`, `reality.txt` only (the one still enabled)
- all enabled → every protocol present, `subscription.txt` carrying 3 vless + trojan + hysteria2 + ss

## Tests, including e2e as requested

- `tests/enable-flag-gating-test.sh` (11 asserts, CI) — asserts each generation site is inside its flag's guard, on **both** paths, so they cannot drift apart again.
- **e2e gains a live check**: adds a user with two protocols disabled and asserts they are absent, that a still-enabled one is **present**, and that `subscription.txt` agrees. The converse assertion matters — a gate that hid everything would pass a one-sided check.

Negative controls verified: ungating Trojan, ungating Reality, and reverting TrustTunnel to the `credentials.toml`-only check each fail the suite.

## Related

Same bundle area as #285 (TrustTunnel/dnstt hidden in README.html). They are independent bugs — that one was the guide hiding a config that existed, this one is generating a config that should not.