### PR TITLE
feat(cdn): make CDN opt-in via ENABLE_CDN, and check the orange cloud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ ENABLE_TRUSTTUNNEL=true
 ENABLE_TELEMT=true
 # GooseRelay (SOCKS5 over Google Apps Script): opt-in, needs client-side setup.
 ENABLE_GOOSERELAY=false
+# CDN VLESS+WS: opt-in — needs the subdomain proxied through Cloudflare and an
+# Origin Rule to PORT_CDN first. Check with `moav doctor dns`.
+ENABLE_CDN=false
 ENABLE_ADMIN_UI=true
 ENABLE_CONDUIT=true
 ENABLE_SNOWFLAKE=true
@@ -286,12 +289,7 @@ GRAFANA_APP_TITLE=
 # CDN (Cloudflare-fronted VLESS+WebSocket)
 # =============================================================================
 
-# CDN links are OFF by default: they only work once the subdomain below is
-# actually proxied through Cloudflare (orange cloud), and an unconfigured one
-# hands users a config that cannot connect. Set true after the DNS is in place
-# and verify with `moav doctor cdn`.
-ENABLE_CDN=false
-# CDN subdomain (Cloudflare-proxied).
+# CDN subdomain (Cloudflare-proxied). Needs ENABLE_CDN=true above.
 CDN_SUBDOMAIN=cdn
 # Transport: ws (default, universal) or httpupgrade (lighter, but newer-client-only).
 CDN_TRANSPORT=ws

--- a/.env.example
+++ b/.env.example
@@ -286,7 +286,12 @@ GRAFANA_APP_TITLE=
 # CDN (Cloudflare-fronted VLESS+WebSocket)
 # =============================================================================
 
-# CDN subdomain (Cloudflare-proxied). Leave empty to disable CDN links.
+# CDN links are OFF by default: they only work once the subdomain below is
+# actually proxied through Cloudflare (orange cloud), and an unconfigured one
+# hands users a config that cannot connect. Set true after the DNS is in place
+# and verify with `moav doctor cdn`.
+ENABLE_CDN=false
+# CDN subdomain (Cloudflare-proxied).
 CDN_SUBDOMAIN=cdn
 # Transport: ws (default, universal) or httpupgrade (lighter, but newer-client-only).
 CDN_TRANSPORT=ws

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         run: bash tests/bundle-guide-sections-test.sh
       - name: ENABLE_* gating in the user-add paths
         run: bash tests/enable-flag-gating-test.sh
+      - name: ENABLE_CDN opt-in flag
+        run: bash tests/cdn-flag-test.sh
       - name: llms.txt link hygiene (structure)
         run: bash tests/llms-links-test.sh
       - name: admin TLS enforcement

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -380,6 +380,70 @@ jobs:
           done
           [ "$fails" -eq 0 ]
 
+      - name: CDN toggle — off then on, same server (ENABLE_CDN)
+        run: |
+          # The flip both ways on one server, which the static truth table cannot
+          # prove: CDN used to be implied by CDN_SUBDOMAIN being non-empty, so a
+          # fresh install generated CDN links whether or not Cloudflare was set
+          # up. The disabled->ENABLED direction matters as much as the reverse --
+          # an over-eager gate would pass a test that only checks "absent".
+          set -u
+          fails=0
+          cp .env /tmp/e2e-cdn-env.bak
+          trap 'cp /tmp/e2e-cdn-env.bak .env' EXIT
+          own() { sudo chown -R "$USER" configs state outputs 2>/dev/null || true; }
+
+          setflag() {  # <true|false>
+            if grep -q '^ENABLE_CDN=' .env; then
+              sed -i "s/^ENABLE_CDN=.*/ENABLE_CDN=$1/" .env
+            else
+              echo "ENABLE_CDN=$1" >> .env
+            fi
+          }
+
+          # --- OFF: no CDN artifacts, and nothing else lost --------------------
+          setflag false
+          ./moav.sh user add cdn-off; own
+          for f in cdn-vless.txt cdn-vless-qr.png; do
+            if [ -e "outputs/bundles/cdn-off/$f" ]; then
+              echo "::error::cdn-off: $f present with ENABLE_CDN=false"; fails=$((fails+1))
+            fi
+          done
+          if base64 -d outputs/bundles/cdn-off/subscription.txt 2>/dev/null | grep -q 'type=ws'; then
+            echo "::error::cdn-off: subscription still carries the CDN entry"; fails=$((fails+1))
+          fi
+          # The gate must not take anything else with it.
+          for f in reality.txt subscription.txt README.html; do
+            [ -s "outputs/bundles/cdn-off/$f" ] || { echo "::error::cdn-off: $f missing — the CDN gate broke an unrelated protocol"; fails=$((fails+1)); }
+          done
+          # The guide must hide the CDN section rather than show an empty one.
+          if grep -q 'id="cdn-en" style=""' outputs/bundles/cdn-off/README.html; then
+            echo "::error::cdn-off: guide shows the CDN section with no CDN config"; fails=$((fails+1))
+          fi
+
+          # --- ON: the same server now produces them ---------------------------
+          setflag true
+          ./moav.sh user add cdn-on; own
+          for f in cdn-vless.txt; do
+            [ -s "outputs/bundles/cdn-on/$f" ] || { echo "::error::cdn-on: $f missing with ENABLE_CDN=true"; fails=$((fails+1)); }
+          done
+          grep -q '^vless://' outputs/bundles/cdn-on/cdn-vless.txt \
+            || { echo "::error::cdn-on: cdn-vless.txt is not a vless link"; fails=$((fails+1)); }
+          if ! grep -q 'id="cdn-en" style=""' outputs/bundles/cdn-on/README.html; then
+            echo "::error::cdn-on: guide hides the CDN section although the config is present"; fails=$((fails+1))
+          fi
+
+          # --- doctor must follow the flag, not the subdomain -------------------
+          setflag false
+          ./moav.sh doctor dns 2>&1 | grep -q 'CDN check skipped' \
+            || { echo "::error::doctor still checks CDN with ENABLE_CDN=false"; fails=$((fails+1)); }
+
+          for u in cdn-off cdn-on; do
+            ./moav.sh user revoke "$u" >/dev/null 2>&1 || true
+            rm -rf "outputs/bundles/$u" "state/users/$u"
+          done
+          [ "$fails" -eq 0 ]
+
       - name: Run connectivity tests
         run: |
           set -o pipefail

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -444,6 +444,66 @@ jobs:
           done
           [ "$fails" -eq 0 ]
 
+      - name: Toggle flip across the three generation code paths
+        run: |
+          # CDN and the sing-box protocols are flipped elsewhere. These three each
+          # go through DIFFERENT code, which is why they are worth their own pass:
+          #   xhttp        -> scripts/lib/xray.sh   (via singbox-user-add.sh)
+          #   MasterDNS    -> user-add.sh's own DNS-family blocks
+          #   WireGuard    -> wg-user-add.sh
+          # Two adds, not six: one with all three off, one with all three on. That
+          # still exercises both directions per protocol at a third of the cost,
+          # and each assertion names its own file so a failure is unambiguous.
+          set -u
+          fails=0
+          own() { sudo chown -R "$USER" configs state outputs 2>/dev/null || true; }
+          setflag() {  # <NAME> <true|false>
+            if grep -q "^ENABLE_$1=" .env; then sed -i "s/^ENABLE_$1=.*/ENABLE_$1=$2/" .env
+            else echo "ENABLE_$1=$2" >> .env; fi
+          }
+          # present <user> <glob>  /  absent <user> <glob>
+          present() { if ! compgen -G "outputs/bundles/$1/$2" >/dev/null; then echo "::error::$1: $2 missing (protocol is enabled)"; fails=$((fails+1)); fi; }
+          absent()  { if   compgen -G "outputs/bundles/$1/$2" >/dev/null; then echo "::error::$1: $2 present (protocol is disabled)"; fails=$((fails+1)); fi; }
+
+          cp .env /tmp/e2e-flip-env.bak
+          trap 'cp /tmp/e2e-flip-env.bak .env' EXIT
+
+          # --- all three OFF ----------------------------------------------------
+          for p in XHTTP MASTERDNS WIREGUARD; do setflag "$p" false; done
+          ./moav.sh user add flip-off; own
+          absent flip-off 'xhttp-vless.txt'
+          absent flip-off 'xhttp-qr.png'
+          absent flip-off 'masterdns-client_config.toml'
+          absent flip-off 'moav-*-wg.conf'
+          absent flip-off 'wireguard-qr.png'
+          # An over-broad gate must not take the rest of the bundle with it.
+          present flip-off 'reality.txt'
+          present flip-off 'README.html'
+          present flip-off 'subscription.txt'
+
+          # --- all three ON, same server ---------------------------------------
+          for p in XHTTP MASTERDNS WIREGUARD; do setflag "$p" true; done
+          ./moav.sh user add flip-on; own
+          present flip-on 'xhttp-vless.txt'
+          present flip-on 'masterdns-client_config.toml'
+          present flip-on 'moav-*-wg.conf'
+          # The guide must follow the artifacts in both directions.
+          for pair in "xhttp:flip-on::flip-off" "wireguard:flip-on::flip-off"; do
+            sec="${pair%%:*}"
+            if ! grep -q "id=\"${sec}-en\" style=\"\"" "outputs/bundles/flip-on/README.html"; then
+              echo "::error::flip-on: guide hides the $sec section although its config is present"; fails=$((fails+1))
+            fi
+            if ! grep -q "id=\"${sec}-en\" style=\"display:none\"" "outputs/bundles/flip-off/README.html"; then
+              echo "::error::flip-off: guide shows the $sec section with no config"; fails=$((fails+1))
+            fi
+          done
+
+          for u in flip-off flip-on; do
+            ./moav.sh user revoke "$u" >/dev/null 2>&1 || true
+            rm -rf "outputs/bundles/$u" "state/users/$u"
+          done
+          [ "$fails" -eq 0 ]
+
       - name: Run connectivity tests
         run: |
           set -o pipefail

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -649,9 +649,15 @@ doctor_check_dns() {
                 warn "CDN endpoint ${cdn_host} resolves but did not answer over HTTPS — cannot confirm it is proxied"
                 echo "        If this is a fresh record, give Cloudflare a minute and re-run 'moav doctor dns'."
             else
+                local cdn_port
+                cdn_port=$(get_env_val "PORT_CDN" "$env_file" "2082")
                 warn "CDN endpoint ${cdn_host} resolves but is NOT proxied through Cloudflare (no cf-ray header)"
-                echo "        Turn the proxy on (orange cloud) for the '${cdn_subdomain:-cdn}' record in your Cloudflare DNS."
-                echo "        Grey-cloud points straight at the origin, so the CDN link gives no CDN and no extra resistance."
+                echo "        1. Turn the proxy on (orange cloud) for the '${cdn_subdomain:-cdn}' record in your Cloudflare DNS."
+                echo "           Grey-cloud points straight at the origin, so the CDN link gives no CDN and no extra resistance."
+                echo "        2. Send ${cdn_host} to port ${cdn_port}: Cloudflare only proxies its standard ports, so"
+                echo "           without an Origin Rule rewriting the destination port to ${cdn_port} the WebSocket never"
+                echo "           reaches sing-box and the client fails with no useful error."
+                echo "        See https://moav.sh/docs/TROUBLESHOOTING/#cdn-vlessws-not-working"
                 failures=$((failures + 1))
             fi
         fi

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -608,6 +608,8 @@ doctor_check_dns() {
         info "DNS tunnel checks skipped: dnstt, Slipstream, MasterDNS, and XDNS are all disabled."
     fi
 
+    local cdn_flag
+    cdn_flag=$(get_env_val "ENABLE_CDN" "$env_file" "")
     cdn_subdomain=$(get_env_val "CDN_SUBDOMAIN" "$env_file" "")
     cdn_domain=$(get_env_val "CDN_DOMAIN" "$env_file" "")
     if [[ -n "$cdn_subdomain" ]]; then
@@ -616,12 +618,43 @@ doctor_check_dns() {
         cdn_host="$cdn_domain"
     fi
 
-    if [[ -n "$cdn_host" ]]; then
+    # Absent flag = the pre-ENABLE_CDN rule (on if a subdomain is set), matching
+    # cdn_enabled() in scripts/lib/common.sh.
+    local cdn_on=false
+    if [[ -n "$cdn_flag" ]]; then
+        [[ "$cdn_flag" == "true" ]] && cdn_on=true
+    elif [[ -n "$cdn_host" ]]; then
+        cdn_on=true
+    fi
+
+    if [[ "$cdn_on" != "true" ]]; then
+        info "CDN check skipped: ENABLE_CDN is not true."
+    elif [[ -z "$cdn_host" ]]; then
+        warn "ENABLE_CDN=true but neither CDN_SUBDOMAIN nor CDN_DOMAIN is set — no CDN links will be generated."
+        failures=$((failures + 1))
+    else
         if ! doctor_check_resolves "CDN endpoint" "$cdn_host" "create or fix the CDN DNS entry for ${cdn_host}"; then
             failures=$((failures + 1))
+        else
+            # Resolving is not enough: the record must be PROXIED (orange cloud).
+            # A grey-cloud record resolves to the origin and the CDN link then
+            # behaves like plain VLESS+WS on a second hostname -- no CDN in front,
+            # and none of the censorship resistance the CDN path exists for.
+            # cf-ray is served by Cloudflare's edge and by nothing else.
+            local cdn_hdrs
+            cdn_hdrs=$(curl -sS -I --max-time 10 "https://${cdn_host}" 2>/dev/null | tr 'A-Z' 'a-z' || true)
+            if printf '%s' "$cdn_hdrs" | grep -qE '^(cf-ray|server: *cloudflare)'; then
+                success "CDN endpoint ${cdn_host} is proxied through Cloudflare"
+            elif [[ -z "$cdn_hdrs" ]]; then
+                warn "CDN endpoint ${cdn_host} resolves but did not answer over HTTPS — cannot confirm it is proxied"
+                echo "        If this is a fresh record, give Cloudflare a minute and re-run 'moav doctor dns'."
+            else
+                warn "CDN endpoint ${cdn_host} resolves but is NOT proxied through Cloudflare (no cf-ray header)"
+                echo "        Turn the proxy on (orange cloud) for the '${cdn_subdomain:-cdn}' record in your Cloudflare DNS."
+                echo "        Grey-cloud points straight at the origin, so the CDN link gives no CDN and no extra resistance."
+                failures=$((failures + 1))
+            fi
         fi
-    else
-        info "CDN check skipped: CDN_SUBDOMAIN/CDN_DOMAIN is not configured."
     fi
 
     if [[ $failures -gt 0 ]]; then

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -381,7 +381,9 @@ export TELEMT_STUN_TCP_FALLBACK="${TELEMT_STUN_TCP_FALLBACK:-true}"
 export TELEMT_API_ENABLED="${TELEMT_API_ENABLED:-true}"
 export TELEMT_API_PORT="${TELEMT_API_PORT:-9091}"
 # Construct CDN_DOMAIN from CDN_SUBDOMAIN + DOMAIN if not explicitly set
-if [[ -z "${CDN_DOMAIN:-}" && -n "${CDN_SUBDOMAIN:-}" && -n "${DOMAIN:-}" ]]; then
+if ! cdn_enabled; then
+    CDN_DOMAIN=""
+elif [[ -z "${CDN_DOMAIN:-}" && -n "${CDN_SUBDOMAIN:-}" && -n "${DOMAIN:-}" ]]; then
     export CDN_DOMAIN="${CDN_SUBDOMAIN}.${DOMAIN}"
 else
     export CDN_DOMAIN="${CDN_DOMAIN:-}"

--- a/scripts/generate-user.sh
+++ b/scripts/generate-user.sh
@@ -405,7 +405,9 @@ fi
 # Generate CDN VLESS+WS client config (if CDN_DOMAIN is set)
 # -----------------------------------------------------------------------------
 # Construct CDN_DOMAIN from CDN_SUBDOMAIN + DOMAIN if not explicitly set
-if [[ -z "${CDN_DOMAIN:-}" ]]; then
+if ! cdn_enabled; then
+    CDN_DOMAIN=""
+elif [[ -z "${CDN_DOMAIN:-}" ]]; then
     if [[ -n "${CDN_SUBDOMAIN:-}" && -n "${DOMAIN:-}" ]]; then
         CDN_DOMAIN="${CDN_SUBDOMAIN}.${DOMAIN}"
     fi

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -330,3 +330,24 @@ donate_allows() {
     [[ -z "${DONATE_ONLY_PROTOCOLS:-}" ]] && return 0
     [[ " ${DONATE_ONLY_PROTOCOLS} " == *" $1 "* ]]
 }
+
+# Is the Cloudflare-fronted CDN inbound in use?
+#
+# ENABLE_CDN is the flag; .env.example ships it false, because a CDN link only
+# works once the subdomain is proxied through Cloudflare, and an unconfigured
+# one hands users a config that cannot connect.
+#
+# When the flag is ABSENT the legacy rule applies -- CDN is on if CDN_SUBDOMAIN
+# is set. Servers built before the flag existed keep their working CDN instead
+# of silently losing it on upgrade.
+cdn_enabled() {
+    local flag="${ENABLE_CDN:-}"
+    [[ -z "$flag" && -f .env ]] && flag="$(get_env_val "ENABLE_CDN" ".env" "")"
+    if [[ -n "$flag" ]]; then
+        [[ "$flag" == "true" ]]
+        return
+    fi
+    local sub="${CDN_SUBDOMAIN:-}"
+    [[ -z "$sub" && -f .env ]] && sub="$(get_env_val "CDN_SUBDOMAIN" ".env" "")"
+    [[ -n "$sub" || -n "${CDN_DOMAIN:-}" ]]
+}

--- a/scripts/singbox-user-add.sh
+++ b/scripts/singbox-user-add.sh
@@ -303,7 +303,7 @@ fi
 # Generate CDN VLESS+WS link (if CDN configured and, in donate mode, requested)
 # Construct CDN_DOMAIN from CDN_SUBDOMAIN + DOMAIN if not explicitly set
 CDN_DOMAIN=""
-if donate_allows cdn; then
+if donate_allows cdn && cdn_enabled; then
     CDN_DOMAIN="${CDN_DOMAIN:-$(get_env_val "CDN_DOMAIN" ".env" "")}"
     if [[ -z "$CDN_DOMAIN" ]]; then
         CDN_SUBDOMAIN="${CDN_SUBDOMAIN:-$(get_env_val "CDN_SUBDOMAIN" ".env" "")}"

--- a/scripts/user-add.sh
+++ b/scripts/user-add.sh
@@ -446,7 +446,9 @@ if [[ -f "$TEMPLATE_FILE" ]]; then
     SERVER_IP="${SERVER_IP:-$(curl -s --max-time 5 https://api.ipify.org 2>/dev/null || echo "YOUR_SERVER_IP")}"
     # Context-specific inputs the shared renderer reads from the environment.
     DNSTT_PUBKEY=$(cat "outputs/dnstt/server.pub" 2>/dev/null || echo "")
-    if [[ -z "${CDN_DOMAIN:-}" && -n "${CDN_SUBDOMAIN:-}" && -n "${DOMAIN:-}" ]]; then
+    if ! cdn_enabled; then
+        CDN_DOMAIN=""
+    elif [[ -z "${CDN_DOMAIN:-}" && -n "${CDN_SUBDOMAIN:-}" && -n "${DOMAIN:-}" ]]; then
         CDN_DOMAIN="${CDN_SUBDOMAIN}.${DOMAIN}"
     fi
     if [[ -f "$OUTPUT_DIR/trusttunnel.json" ]]; then

--- a/tests/cdn-flag-test.sh
+++ b/tests/cdn-flag-test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Regression test: CDN is opt-in via ENABLE_CDN, without breaking servers that
+# predate the flag.
+#
+# CDN links only work once the subdomain is actually proxied through Cloudflare.
+# .env.example used to ship CDN_SUBDOMAIN=cdn with no flag, so every new server
+# generated CDN links by default and handed users a config that could not
+# connect unless they had separately set up Cloudflare.
+#
+# The flag defaults to false for new servers. When it is ABSENT the legacy rule
+# applies (on if CDN_SUBDOMAIN is set), so an existing server with a working
+# Cloudflare setup does not silently lose its CDN on upgrade.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "ENABLE_CDN flag"
+
+# --- the flag ships, and ships off -------------------------------------------
+val=$(grep -E '^ENABLE_CDN=' "$ROOT/.env.example" | cut -d= -f2)
+[ "$val" = "false" ] && ok "'.env.example' ships ENABLE_CDN=false" \
+                     || bad "ENABLE_CDN in .env.example is '${val:-missing}', expected false"
+
+# --- cdn_enabled() truth table ----------------------------------------------
+# Run from a directory with no .env so only the environment decides.
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+probe() {  # <env-assignments> -> prints on|off
+    (
+        cd "$ROOT" || exit
+        # shellcheck disable=SC1091
+        source scripts/lib/common.sh >/dev/null 2>&1
+        cd "$tmp" || exit          # no .env here: environment only
+        eval "$1"
+        if cdn_enabled; then echo on; else echo off; fi
+    )
+}
+check() { # <label> <env> <expected>
+    local got; got=$(probe "$2")
+    [ "$got" = "$3" ] && ok "$1 -> $3" || bad "$1 -> $got (expected $3)"
+}
+check "flag true, no subdomain"          'ENABLE_CDN=true;  CDN_SUBDOMAIN=' on
+check "flag false, subdomain set"        'ENABLE_CDN=false; CDN_SUBDOMAIN=cdn' off
+check "no flag, subdomain set (upgrade)" 'unset ENABLE_CDN; CDN_SUBDOMAIN=cdn' on
+check "no flag, no subdomain"            'unset ENABLE_CDN; CDN_SUBDOMAIN=' off
+check "flag false wins over CDN_DOMAIN"  'ENABLE_CDN=false; CDN_DOMAIN=cdn.example.com' off
+
+# --- every CDN_DOMAIN derivation must be gated -------------------------------
+# Downstream code all tests `-n "$CDN_DOMAIN"`, so gating the derivation is what
+# turns CDN off everywhere. A new derivation site added ungated would leak.
+for f in scripts/generate-user.sh scripts/bootstrap.sh scripts/user-add.sh scripts/singbox-user-add.sh; do
+    if grep -q 'cdn_enabled' "$ROOT/$f"; then
+        ok "$(basename "$f") gates CDN on cdn_enabled"
+    else
+        bad "$(basename "$f") derives CDN_DOMAIN without cdn_enabled — CDN leaks when disabled"
+    fi
+done
+
+# --- doctor must respect the flag and check for the orange cloud -------------
+grep -q 'ENABLE_CDN' "$ROOT/lib/doctor.sh" \
+    && ok "doctor respects ENABLE_CDN" \
+    || bad "doctor still checks CDN regardless of the flag"
+# Match the actual test, not the prose: "cf-ray" also appears in the warning
+# text, so a looser grep passes even after the check itself is removed.
+if grep -qE 'grep -q[A-Za-z]* .\^\(cf-ray' "$ROOT/lib/doctor.sh"; then
+    ok "doctor verifies the record is Cloudflare-PROXIED, not just resolving"
+else
+    bad "doctor only checks resolution — a grey-cloud record would pass"
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Stacks on #286 (shares the CDN block in `singbox-user-add.sh`) — merge that first.

## Why

A CDN link only works once the subdomain is actually **proxied** through Cloudflare. `.env.example` shipped `CDN_SUBDOMAIN=cdn` with no flag, so **every new server generated CDN links by default** and handed users a config that could not connect unless they had separately set up Cloudflare.

## The flag

`ENABLE_CDN` gates it and ships `false`.

Per your call on the upgrade path: when the flag is **absent**, the previous rule still applies — CDN is on if `CDN_SUBDOMAIN` is set. A server built before the flag existed keeps its working CDN instead of silently losing it. Two ways to express "on" until old `.env` files age out, which is the price of not breaking anyone.

| state | result |
|---|---|
| `ENABLE_CDN=true` | on |
| `ENABLE_CDN=false` | off, even with `CDN_SUBDOMAIN=cdn` |
| flag absent, `CDN_SUBDOMAIN` set | **on** (upgrade path) |
| flag absent, no subdomain | off |

Every consumer derives `CDN_DOMAIN` then tests it, so gating the **four derivation sites** turns CDN off everywhere downstream — no need to touch the other seven files that read it.

## The doctor check

`moav doctor dns` skips the CDN section when the flag is off. When it is on, it now checks the record is **proxied**, not merely resolving:

```
✓ CDN endpoint: cdn.yorkschool.xyz resolves (188.114.96.0, 188.114.97.0)
✓ CDN endpoint cdn.yorkschool.xyz is proxied through Cloudflare
```

This matters because a grey-cloud record resolves to the origin, so the CDN link becomes plain VLESS+WS on a second hostname — no CDN in front and none of the resistance the path exists for. `cf-ray` is served by Cloudflares edge and nothing else; verified it identifies a real proxied host and correctly rejects a non-Cloudflare one.

I did **not** add a bootstrap warning or block `user add`, per your answer — doctor only.

## Verified live

All three flag states on a real server, plus doctor in both the on and off cases.

## Tests

`tests/cdn-flag-test.sh` (12 asserts, CI): the truth table including the upgrade case, that every derivation site is gated, and that doctor checks for the orange cloud rather than just resolution.

Negative controls verified: shipping `ENABLE_CDN=true`, breaking the upgrade fallback, and removing the proxied check each fail the suite. The third initially passed for the wrong reason — my assert matched the word `cf-ray` in the warning *message* rather than the check — so it now matches the grep invocation itself.