### PR TITLE
fix(llms): make llms.txt links absolute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         run: bash tests/bundle-guide-sections-test.sh
       - name: ENABLE_* gating in the user-add paths
         run: bash tests/enable-flag-gating-test.sh
+      - name: llms.txt link hygiene (structure)
+        run: bash tests/llms-links-test.sh
       - name: admin TLS enforcement
         run: bash tests/admin-tls-test.sh
       - name: admin IP whitelist (CIDR) unit test
@@ -95,6 +97,8 @@ jobs:
         run: bash tests/release-footer-test.sh
       - name: release footer links resolve (network)
         run: bash scripts/render-release-footer.sh --check
+      - name: llms.txt links resolve (network)
+        run: LLMS_CHECK_URLS=1 bash tests/llms-links-test.sh
 
   go-test:
     name: go test dns-router

--- a/llms.txt
+++ b/llms.txt
@@ -21,12 +21,12 @@ Enough to deploy and find your way around. Everything else is linked below.
 
 ## For agents working in this repo
 
-- [AGENTS.md](AGENTS.md): the deep guide — repo layout, build/run, testing, the conventions that bite (strict mode, get_env_val, bash 3.2, host-vs-container paths, uid 2000, secrets in state)
-- [CONTRIBUTING.md](CONTRIBUTING.md): contributor workflow
-- [CHANGELOG.md](CHANGELOG.md): behavior changes per version
-- [docs/devdocs/E2E-TESTING.md](docs/devdocs/E2E-TESTING.md): the end-to-end harness and what a passing run must prove
-- [docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md](docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md): adding a new protocol
-- [docs/devdocs/VERSION-BUMP-CHECKLIST.md](docs/devdocs/VERSION-BUMP-CHECKLIST.md): bumping a component version
+- [AGENTS.md](https://raw.githubusercontent.com/MotherofallVPNs/MoaV/main/AGENTS.md): the deep guide — repo layout, build/run, testing, the conventions that bite (strict mode, get_env_val, bash 3.2, host-vs-container paths, uid 2000, secrets in state)
+- [CONTRIBUTING.md](https://raw.githubusercontent.com/MotherofallVPNs/MoaV/main/CONTRIBUTING.md): contributor workflow
+- [CHANGELOG.md](https://raw.githubusercontent.com/MotherofallVPNs/MoaV/main/CHANGELOG.md): behavior changes per version
+- [docs/devdocs/E2E-TESTING.md](https://raw.githubusercontent.com/MotherofallVPNs/MoaV/main/docs/devdocs/E2E-TESTING.md): the end-to-end harness and what a passing run must prove
+- [docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md](https://raw.githubusercontent.com/MotherofallVPNs/MoaV/main/docs/devdocs/PROTOCOL-INTEGRATION-CHECKLIST.md): adding a new protocol
+- [docs/devdocs/VERSION-BUMP-CHECKLIST.md](https://raw.githubusercontent.com/MotherofallVPNs/MoaV/main/docs/devdocs/VERSION-BUMP-CHECKLIST.md): bumping a component version
 
 ## Why MoaV exists
 

--- a/tests/llms-links-test.sh
+++ b/tests/llms-links-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Regression test: every link in llms.txt must be absolute.
+#
+# llms.txt is served at https://moav.sh/llms.txt but written in the repo, so a
+# relative link like [AGENTS.md](AGENTS.md) resolves against the SITE --
+# https://moav.sh/AGENTS.md, which 404s. It only ever worked when read inside
+# the GitHub repo. An agent handed the URL follows the link and gets nothing,
+# with no error to notice; a community member spotted it before we did.
+#
+# Offline by default (structure only). LLMS_CHECK_URLS=1 also fetches each one;
+# CI runs that as a separate networked step.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+f="$ROOT/llms.txt"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "llms.txt link hygiene"
+
+[ -f "$f" ] || { echo "  llms.txt not found"; exit 1; }
+
+# --- no relative markdown links ---------------------------------------------
+# Anchors (#section) are fine — they stay within the served file.
+rel=$(grep -oE '\]\([^)]+\)' "$f" | sed 's/^](//; s/)$//' \
+        | grep -vE '^(https?://|#)' || true)
+if [ -z "$rel" ]; then
+    ok "no relative links (all absolute or in-page anchors)"
+else
+    bad "relative link(s) — these resolve against moav.sh and 404: $(printf '%s' "$rel" | tr '\n' ' ')"
+fi
+
+# --- repo files must point at GitHub, not the docs site ----------------------
+# AGENTS.md and friends are not published on moav.sh; linking them there is the
+# same bug in a different shape.
+for repo_file in AGENTS.md CONTRIBUTING.md CHANGELOG.md; do
+    line=$(grep -F "$repo_file]" "$f" | head -1 || true)
+    [ -n "$line" ] || continue
+    if printf '%s' "$line" | grep -q 'moav\.sh'; then
+        bad "$repo_file is linked on moav.sh, but it is only published in the repo"
+    else
+        ok "$repo_file points at the repo"
+    fi
+done
+
+# --- docs pages must point at the site, not at GitHub ------------------------
+# The inverse: a published docs page should link to its canonical URL.
+docs_on_gh=$(grep -oE 'https://[a-z.]*github[^)]*/docs/(quick-start|SETUP|CLI|protocols|architecture)\.md' "$f" || true)
+[ -z "$docs_on_gh" ] \
+    && ok "published docs pages link to moav.sh, not GitHub" \
+    || bad "docs page linked to GitHub instead of its moav.sh URL: $docs_on_gh"
+
+# --- optional network check --------------------------------------------------
+if [ "${LLMS_CHECK_URLS:-0}" = "1" ]; then
+    # Only markdown link TARGETS. A bare grep for https:// also picks up prose
+    # placeholders like `https://<server>:9443`, which are not links to fetch.
+    urls=()
+    while IFS= read -r u; do [ -n "$u" ] && urls+=("$u"); done < <(
+        grep -oE '\]\(https://[^)]+\)' "$f" | sed 's/^](//; s/)$//' | sed 's/[.,]$//' | sort -u)
+    for u in "${urls[@]}"; do
+        code=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 "$u" 2>/dev/null || echo 000)
+        [ "$code" = "200" ] || { sleep 2; code=$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 "$u" 2>/dev/null || echo 000); }
+        if [ "$code" = "200" ]; then ok "resolves: $u"; else bad "$u -> HTTP $code"; fi
+    done
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Caught by a community member in Telegram, not by us.

## The bug

`llms.txt` is served at **`https://moav.sh/llms.txt`** but written in the repo, so the six links under `## For agents working in this repo` were relative:

```markdown
- [AGENTS.md](AGENTS.md)
- [docs/devdocs/E2E-TESTING.md](docs/devdocs/E2E-TESTING.md)
```

Those resolve against the **site**, not the repo — `https://moav.sh/AGENTS.md`. I checked all three: **404**. They only ever worked when the file was read inside GitHub. An agent handed the URL follows them and gets nothing, with no error to notice.

His exact point was that the markdown gives no hint these live on GitHub, so it reads as if they were on the site. Correct.

## The fix

Absolute `raw.githubusercontent.com/…/main/…` URLs. All six verified **200**.

**Why raw rather than `/blob/`:** `llms.txt` exists to be consumed by agents, and raw returns the actual markdown instead of a GitHub HTML page wrapped around a 20KB file. It still displays fine in a browser. Swapping to `/blob/` is a one-line change if you would rather the links look conventional to a human reader — say so and I will.

I used `main` rather than a SHA permalink: these are living docs, and a pinned link would go stale on the next edit.

## Tests

`tests/llms-links-test.sh`, wired into CI as two steps — structure (offline) and resolution (networked, all 36 link targets fetched).

Beyond "no relative links" it asserts both directions of the underlying confusion: a repo-only file like `AGENTS.md` must **not** be linked on `moav.sh`, and a published docs page must **not** be linked on GitHub.

Negative controls verified: reintroducing a relative link, and pointing `AGENTS.md` at `moav.sh/docs/`, each fail the suite.

## Related

`llms-full.txt` has the same class of bug, 46 links, fixed in moav-site#12 — it is generated from the docs sources, so the fix belongs in that generator.