### PR TITLE
funding: add Monero and Lightning, replace the Bitcoin address

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -4,8 +4,13 @@ github: [shayanb]
 # Buy Me a Coffee
 buy_me_a_coffee: pangana
 
-# Crypto addresses (add to README/landing page)
-BTC: bc1qkfq3hg5kpzgy7muc8m3pmh6zemhv820a0ndqgg
+# Crypto addresses. This file is the single source: scripts/render-funding.sh
+# regenerates the README block from it, and moav-site pulls it on deploy, so an
+# address is added here and nowhere else.
+BTC: bc1p6rpwzkgrlvpkre0n94fqayafpw47kl2j5lmvhvl0rfrtzm94wvvsmd3w5s
 ETH: 0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2
+XMR: 8BmduJgZLok9xiaX8FboSWBBbzYAugqLxUts7eZNsF2x9QDhk3Ua7iwQufBBNB8VFzcMEMAE1Uo6PjQvAYNYHmXsBRbqQqG
 ZEC: u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587
+LN: lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0q0zdgjjahpdv7tnd9vstumyrw43snsmfmlzv0pgkqrjkgy48tsne6qsr0k64d8rz4k394pmre2rgnmstdxqsfj0w4dsmq2ec73ssek5wzqtqqv7argu9ptk09h9vfvvvham5xnwe306zjw6lptxx0d2yfk5rlvznjwefmsrmmpu8qnkqmghe0v96c8qy3m3nqgm977ay8f5p6k2d2ll2j3knnc8c4s6haufe203jx4ufy8z25tsscqqseg8jzh2qykejnc9sp2v4qm3z2q
+LN_ADDRESS: shayan@bitrefill.me
 Tron: TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6

--- a/README-fa.md
+++ b/README-fa.md
@@ -428,17 +428,13 @@ Raspberry Pi کافی است.
 | **Ethereum (ETH)** ¹ | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
 | **Monero (XMR)** | `8BmduJgZLok9xiaX8FboSWBBbzYAugqLxUts7eZNsF2x9QDhk3Ua7iwQufBBNB8VFzcMEMAE1Uo6PjQvAYNYHmXsBRbqQqG` |
 | **Zcash (ZEC)** | `u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587` |
-| **Lightning** ² | `lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0q0zdgjjahpdv7tnd9vstumyrw43snsmfmlzv0pgkqrjkgy48tsne6qsr0k64d8rz4k394pmre2rgnmstdxqsfj0w4dsmq2ec73ssek5wzqtqqv7argu9ptk09h9vfvvvham5xnwe306zjw6lptxx0d2yfk5rlvznjwefmsrmmpu8qnkqmghe0v96c8qy3m3nqgm977ay8f5p6k2d2ll2j3knnc8c4s6haufe203jx4ufy8z25tsscqqseg8jzh2qykejnc9sp2v4qm3z2q` |
-| **Lightning Address** ³ | `shayan@bitrefill.me` |
-| **Tron** ⁴ | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+| **Lightning** | `lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0q0zdgjjahpdv7tnd9vstumyrw43snsmfmlzv0pgkqrjkgy48tsne6qsr0k64d8rz4k394pmre2rgnmstdxqsfj0w4dsmq2ec73ssek5wzqtqqv7argu9ptk09h9vfvvvham5xnwe306zjw6lptxx0d2yfk5rlvznjwefmsrmmpu8qnkqmghe0v96c8qy3m3nqgm977ay8f5p6k2d2ll2j3knnc8c4s6haufe203jx4ufy8z25tsscqqseg8jzh2qykejnc9sp2v4qm3z2q` |
+| **Lightning Address** | `shayan@bitrefill.me` |
+| **Tron** ² | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
 
 ¹ **Ethereum (ETH)** — همین نشانی روی همهٔ زنجیره‌های EVM کار می‌کند و برای هر توکن ERC-20
 
-² **Lightning** — پیشنهاد BOLT12 — قابل استفادهٔ چندباره، در کیف‌پولی که offer را پشتیبانی می‌کند
-
-³ **Lightning Address** — گزینهٔ ساده‌تر: در بیشتر کیف‌پول‌های لایتنینگ مثل نشانی ایمیل کار می‌کند
-
-⁴ **Tron** — فقط TRX و TRC-20 — با نشانی EVM بالا یکی نیست
+² **Tron** — فقط TRX و TRC-20 — با نشانی EVM بالا یکی نیست
 <!-- FUNDING:END -->
 
 نشانی‌ها از [`.github/FUNDING.yml`](.github/FUNDING.yml) ساخته می‌شوند، که تنها مرجع است، پس

--- a/README-fa.md
+++ b/README-fa.md
@@ -424,14 +424,21 @@ Raspberry Pi کافی است.
 
 | ارز | نشانی |
 |---|---|
-| **Bitcoin (BTC)** | `bc1qkfq3hg5kpzgy7muc8m3pmh6zemhv820a0ndqgg` |
+| **Bitcoin (BTC)** | `bc1p6rpwzkgrlvpkre0n94fqayafpw47kl2j5lmvhvl0rfrtzm94wvvsmd3w5s` |
 | **Ethereum (ETH)** ¹ | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
+| **Monero (XMR)** | `8BmduJgZLok9xiaX8FboSWBBbzYAugqLxUts7eZNsF2x9QDhk3Ua7iwQufBBNB8VFzcMEMAE1Uo6PjQvAYNYHmXsBRbqQqG` |
 | **Zcash (ZEC)** | `u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587` |
-| **Tron** ² | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+| **Lightning** ² | `lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0q0zdgjjahpdv7tnd9vstumyrw43snsmfmlzv0pgkqrjkgy48tsne6qsr0k64d8rz4k394pmre2rgnmstdxqsfj0w4dsmq2ec73ssek5wzqtqqv7argu9ptk09h9vfvvvham5xnwe306zjw6lptxx0d2yfk5rlvznjwefmsrmmpu8qnkqmghe0v96c8qy3m3nqgm977ay8f5p6k2d2ll2j3knnc8c4s6haufe203jx4ufy8z25tsscqqseg8jzh2qykejnc9sp2v4qm3z2q` |
+| **Lightning Address** ³ | `shayan@bitrefill.me` |
+| **Tron** ⁴ | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
 
 ¹ **Ethereum (ETH)** — همین نشانی روی همهٔ زنجیره‌های EVM کار می‌کند و برای هر توکن ERC-20
 
-² **Tron** — فقط TRX و TRC-20 — با نشانی EVM بالا یکی نیست
+² **Lightning** — پیشنهاد BOLT12 — قابل استفادهٔ چندباره، در کیف‌پولی که offer را پشتیبانی می‌کند
+
+³ **Lightning Address** — گزینهٔ ساده‌تر: در بیشتر کیف‌پول‌های لایتنینگ مثل نشانی ایمیل کار می‌کند
+
+⁴ **Tron** — فقط TRX و TRC-20 — با نشانی EVM بالا یکی نیست
 <!-- FUNDING:END -->
 
 نشانی‌ها از [`.github/FUNDING.yml`](.github/FUNDING.yml) ساخته می‌شوند، که تنها مرجع است، پس

--- a/README.md
+++ b/README.md
@@ -398,17 +398,13 @@ capacity. Not salaries.
 | **Ethereum (ETH)** ¹ | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
 | **Monero (XMR)** | `8BmduJgZLok9xiaX8FboSWBBbzYAugqLxUts7eZNsF2x9QDhk3Ua7iwQufBBNB8VFzcMEMAE1Uo6PjQvAYNYHmXsBRbqQqG` |
 | **Zcash (ZEC)** | `u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587` |
-| **Lightning** ² | `lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0q0zdgjjahpdv7tnd9vstumyrw43snsmfmlzv0pgkqrjkgy48tsne6qsr0k64d8rz4k394pmre2rgnmstdxqsfj0w4dsmq2ec73ssek5wzqtqqv7argu9ptk09h9vfvvvham5xnwe306zjw6lptxx0d2yfk5rlvznjwefmsrmmpu8qnkqmghe0v96c8qy3m3nqgm977ay8f5p6k2d2ll2j3knnc8c4s6haufe203jx4ufy8z25tsscqqseg8jzh2qykejnc9sp2v4qm3z2q` |
-| **Lightning Address** ³ | `shayan@bitrefill.me` |
-| **Tron** ⁴ | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+| **Lightning** | `lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0q0zdgjjahpdv7tnd9vstumyrw43snsmfmlzv0pgkqrjkgy48tsne6qsr0k64d8rz4k394pmre2rgnmstdxqsfj0w4dsmq2ec73ssek5wzqtqqv7argu9ptk09h9vfvvvham5xnwe306zjw6lptxx0d2yfk5rlvznjwefmsrmmpu8qnkqmghe0v96c8qy3m3nqgm977ay8f5p6k2d2ll2j3knnc8c4s6haufe203jx4ufy8z25tsscqqseg8jzh2qykejnc9sp2v4qm3z2q` |
+| **Lightning Address** | `shayan@bitrefill.me` |
+| **Tron** ² | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
 
 ¹ **Ethereum (ETH)** — same address on every EVM chain (Arbitrum, Optimism, Base, Gnosis…) and any ERC20 (USDC, USDT, DAI…)
 
-² **Lightning** — BOLT12 offer — reusable, paste into a wallet that supports offers
-
-³ **Lightning Address** — easier option: works like an email address in most Lightning wallets
-
-⁴ **Tron** — TRX and TRC-20 only — not interchangeable with the EVM address
+² **Tron** — TRX and TRC-20 only — not interchangeable with the EVM address
 <!-- FUNDING:END -->
 
 Addresses are generated from [`.github/FUNDING.yml`](.github/FUNDING.yml), the single

--- a/README.md
+++ b/README.md
@@ -394,14 +394,21 @@ capacity. Not salaries.
 
 | Coin | Address |
 |---|---|
-| **Bitcoin (BTC)** | `bc1qkfq3hg5kpzgy7muc8m3pmh6zemhv820a0ndqgg` |
+| **Bitcoin (BTC)** | `bc1p6rpwzkgrlvpkre0n94fqayafpw47kl2j5lmvhvl0rfrtzm94wvvsmd3w5s` |
 | **Ethereum (ETH)** ¹ | `0xB4D06BDb0C2f1D81E0b0b805Ed813F4ffe960aE2` |
+| **Monero (XMR)** | `8BmduJgZLok9xiaX8FboSWBBbzYAugqLxUts7eZNsF2x9QDhk3Ua7iwQufBBNB8VFzcMEMAE1Uo6PjQvAYNYHmXsBRbqQqG` |
 | **Zcash (ZEC)** | `u1pclheucppc87qlffh9m8wjfw87w2nka40w9nxjuqnyppj0kx9xp7z9rg6wx556662y5f8dtfyeynmm2lnz5aqvaqzmnpajlq0mnmkntdqzqqegk8lwv09cnudf3ttzm3878p3030j3lwupj257rmmv9p3ea32hgwsuf3jdh8ycv7q587` |
-| **Tron** ² | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
+| **Lightning** ² | `lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0q0zdgjjahpdv7tnd9vstumyrw43snsmfmlzv0pgkqrjkgy48tsne6qsr0k64d8rz4k394pmre2rgnmstdxqsfj0w4dsmq2ec73ssek5wzqtqqv7argu9ptk09h9vfvvvham5xnwe306zjw6lptxx0d2yfk5rlvznjwefmsrmmpu8qnkqmghe0v96c8qy3m3nqgm977ay8f5p6k2d2ll2j3knnc8c4s6haufe203jx4ufy8z25tsscqqseg8jzh2qykejnc9sp2v4qm3z2q` |
+| **Lightning Address** ³ | `shayan@bitrefill.me` |
+| **Tron** ⁴ | `TBSCbnTZCELrMnioobZMkah5r9qS6B1tC6` |
 
 ¹ **Ethereum (ETH)** — same address on every EVM chain (Arbitrum, Optimism, Base, Gnosis…) and any ERC20 (USDC, USDT, DAI…)
 
-² **Tron** — TRX and TRC-20 only — not interchangeable with the EVM address
+² **Lightning** — BOLT12 offer — reusable, paste into a wallet that supports offers
+
+³ **Lightning Address** — easier option: works like an email address in most Lightning wallets
+
+⁴ **Tron** — TRX and TRC-20 only — not interchangeable with the EVM address
 <!-- FUNDING:END -->
 
 Addresses are generated from [`.github/FUNDING.yml`](.github/FUNDING.yml), the single

--- a/scripts/render-funding.sh
+++ b/scripts/render-funding.sh
@@ -50,14 +50,10 @@ NO_SUFFIX = {"LN", "LIGHTNING", "LN_ADDRESS"}
 notes_en = {
     "ETH": "same address on every EVM chain (Arbitrum, Optimism, Base, Gnosis…) and any ERC20 (USDC, USDT, DAI…)",
     "TRON": "TRX and TRC-20 only — not interchangeable with the EVM address",
-    "LN": "BOLT12 offer — reusable, paste into a wallet that supports offers",
-    "LN_ADDRESS": "easier option: works like an email address in most Lightning wallets",
 }
 notes_fa = {
     "ETH": "همین نشانی روی همهٔ زنجیره‌های EVM کار می‌کند و برای هر توکن ERC-20",
     "TRON": "فقط TRX و TRC-20 — با نشانی EVM بالا یکی نیست",
-    "LN": "پیشنهاد BOLT12 — قابل استفادهٔ چندباره، در کیف‌پولی که offer را پشتیبانی می‌کند",
-    "LN_ADDRESS": "گزینهٔ ساده‌تر: در بیشتر کیف‌پول‌های لایتنینگ مثل نشانی ایمیل کار می‌کند",
 }
 head = {"en": ("Platform", "Link", "Coin", "Address"),
         "fa": ("پلتفرم", "لینک", "ارز", "نشانی")}[lang]

--- a/scripts/render-funding.sh
+++ b/scripts/render-funding.sh
@@ -40,16 +40,24 @@ coins = {
     "BTC": "Bitcoin", "ETH": "Ethereum", "ZEC": "Zcash", "XMR": "Monero",
     "LTC": "Litecoin", "TRON": "Tron", "SOL": "Solana",
     "LN": "Lightning", "LIGHTNING": "Lightning",
+    "LN_ADDRESS": "Lightning Address",
 }
+# Keys whose pretty name already says everything -- no "(KEY)" suffix, which
+# would render as the useless "Lightning Address (LN_ADDRESS)".
+NO_SUFFIX = {"LN", "LIGHTNING", "LN_ADDRESS"}
 # ETH is one address across every EVM chain; Tron is NOT -- TRX/TRC-20 use a
 # base58 address and anything sent to the 0x one is unrecoverable.
 notes_en = {
     "ETH": "same address on every EVM chain (Arbitrum, Optimism, Base, Gnosis…) and any ERC20 (USDC, USDT, DAI…)",
     "TRON": "TRX and TRC-20 only — not interchangeable with the EVM address",
+    "LN": "BOLT12 offer — reusable, paste into a wallet that supports offers",
+    "LN_ADDRESS": "easier option: works like an email address in most Lightning wallets",
 }
 notes_fa = {
     "ETH": "همین نشانی روی همهٔ زنجیره‌های EVM کار می‌کند و برای هر توکن ERC-20",
     "TRON": "فقط TRX و TRC-20 — با نشانی EVM بالا یکی نیست",
+    "LN": "پیشنهاد BOLT12 — قابل استفادهٔ چندباره، در کیف‌پولی که offer را پشتیبانی می‌کند",
+    "LN_ADDRESS": "گزینهٔ ساده‌تر: در بیشتر کیف‌پول‌های لایتنینگ مثل نشانی ایمیل کار می‌کند",
 }
 head = {"en": ("Platform", "Link", "Coin", "Address"),
         "fa": ("پلتفرم", "لینک", "ارز", "نشانی")}[lang]
@@ -70,7 +78,8 @@ for line in open(funding, encoding="utf-8"):
         plat.append(f"| **{name}** | [{full.split('//')[1]}]({full}) |")
     else:
         nice = coins.get(key.upper(), key)
-        label = f"{nice} ({key.upper()})" if nice.upper() != key.upper() else nice
+        label = nice if key.upper() in NO_SUFFIX or nice.upper() == key.upper() \
+                else f"{nice} ({key.upper()})"
         note = notes.get(key.upper())
         marker = ""
         if note:


### PR DESCRIPTION
Adds the two new donation addresses and replaces the Bitcoin one. `FUNDING.yml` is the single source, so the READMEs regenerate from it and moav-site pulls it on deploy.

## What changed

| | |
|---|---|
| **BTC** | replaced with a Taproot address (`bc1p…`) |
| **XMR** | added |
| **LN** | added — BOLT12 offer |
| **LN_ADDRESS** | added — `shayan@bitrefill.me` |

## Addresses were verified, not eyeballed

A mistyped receiving address loses money silently, so each was checked:

- **BTC** — I computed the **bech32m checksum**: `VALID`. 62 chars, `bc1p` prefix, correct for P2TR. This is the one that matters most, since it replaces a working address.
- **XMR** — 95 characters, leading `8` (subaddress), base58 charset clean.
- **LN** — 334 characters, `lno1` prefix, bech32 charset clean.
- **LN_ADDRESS** — well-formed `user@domain`.

Then I diffed the rendered output against the source: **all 7 addresses are byte-identical** in `README.md` and `README-fa.md`, and `render-funding.sh --check` passes.

## Two Lightning entries on purpose

They answer different needs, so both carry a footnote saying which to reach for — two unexplained Lightning rows would just prompt "which one?":

- **BOLT12 offer** — reusable, but only in wallets that support offers
- **Lightning Address** — the `user@host` form most wallets already accept

## One renderer change was required

`LN_ADDRESS` is a new key, and the generic `Name (KEY)` label would have printed **"Lightning Address (LN_ADDRESS)"**. Both renderers now suppress the suffix for keys whose name already says everything.

## Propagation

- **READMEs** — regenerated here; the CI drift gate keeps them honest.
- **Website** — `moav-site` fetches this file from MoaV **`main`** on deploy, so the site updates once this reaches main, not on merge to dev. The matching site-side renderer change is a separate PR in that repo; without it `LN_ADDRESS` would render as the raw key. I verified the site output against this file locally: all 7 byte-exact, `mkdocs build --strict` clean.