### PR TITLE
fix(peers,net,compose): silent repair failure, hidden stale tuning file, zombie reapers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
         run: bash scripts/render-funding.sh --check
       - name: FUNDING.yml address values stay quoted
         run: bash tests/funding-yaml-test.sh
+      - name: doctor peers --fix (SIGPIPE + volume state)
+        run: bash tests/peers-repair-test.sh
       - name: release footer generator
         run: bash tests/release-footer-test.sh
       - name: release footer links resolve (network)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
         run: bash tests/funding-yaml-test.sh
       - name: doctor peers --fix (SIGPIPE + volume state)
         run: bash tests/peers-repair-test.sh
+      - name: net tuning stale-file + template drift
+        run: bash tests/nettune-template-test.sh
       - name: release footer generator
         run: bash tests/release-footer-test.sh
       - name: release footer links resolve (network)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
         run: bash tests/nettune-template-test.sh
       - name: PID-1 reaper on orphan-inheriting containers
         run: bash tests/zombie-reaper-test.sh
+      - name: doctor host (load/swap/zombies) + check wiring
+        run: bash tests/hostload-test.sh
       - name: release footer generator
         run: bash tests/release-footer-test.sh
       - name: release footer links resolve (network)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
         run: bash tests/peers-repair-test.sh
       - name: net tuning stale-file + template drift
         run: bash tests/nettune-template-test.sh
+      - name: PID-1 reaper on orphan-inheriting containers
+        run: bash tests/zombie-reaper-test.sh
       - name: release footer generator
         run: bash tests/release-footer-test.sh
       - name: release footer links resolve (network)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -821,6 +821,10 @@ services:
       dockerfile: dockerfiles/Dockerfile.admin
     container_name: moav-admin
     restart: unless-stopped
+    # PID 1 here is python (the entrypoint execs it), which never reaps orphans.
+    # When a user-add script is killed on timeout its children reparent to PID 1
+    # and stay zombies -- 28 of them on a live server. tini reaps them.
+    init: true
     logging: *default-logging
     networks:
       - moav_net
@@ -918,6 +922,9 @@ services:
     image: ${IMAGE_GRAFANA:-grafana/grafana:latest}
     container_name: moav-grafana
     restart: unless-stopped
+    # Same reason as admin: the entrypoint execs grafana, so PID 1 does not reap.
+    # 11 zombies on both live servers.
+    init: true
     logging: *default-logging
     user: "0"
     entrypoint: ["/bin/sh", "/scripts/grafana-entrypoint.sh"]

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -1128,6 +1128,7 @@ DOCTOR_CHECKS=(
     "conflicts:Check for conflicting services (e.g. DNS tunnels on port 53)"
     "reality:Check Reality fallback targets resolve and are reachable"
     "net:Check BBR/sysctl tuning + packet drops + PMTU + CGNAT + MTU"
+    "host:Check CPU load, swap pressure and zombie processes"
     "peers:Check for duplicate WireGuard/AmneziaWG peer addresses (--fix repairs)"
     "env:Compare .env with .env.example for missing vars"
     "updates:Check for MoaV updates"

--- a/lib/hostload.sh
+++ b/lib/hostload.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# lib/hostload.sh — host saturation: CPU load, swap pressure, zombies, and which
+# container is eating the box. Read-only.
+#
+# WHY THIS EXISTS. Diagnosing "REALITY feels slow" on two live servers took four
+# rounds of hand-run commands (uptime, top, docker stats, ps for zombie parents)
+# before the picture showed up: one box at load 1.00 on a single vCPU with 681 MiB
+# swapped, a bandwidth-donation container capped at half that machine, and 39
+# zombies. Every one of those is a one-line probe.
+#
+# The probes are separate functions so tests can drive the reporting logic with
+# fixed values instead of whatever the CI runner happens to be doing.
+
+# A probe like the others so tests can drive the reporting on a non-Linux box.
+host_metrics_available() { [[ -r /proc/loadavg && -r /proc/meminfo ]]; }
+
+host_ncpu()  { nproc 2>/dev/null || echo 1; }
+host_load1() { awk '{print $1+0}' /proc/loadavg 2>/dev/null || echo 0; }
+
+# Used swap in MiB. 0 when there is no swap device.
+host_swap_used_mib() {
+    awk '/^SwapTotal:/{t=$2} /^SwapFree:/{f=$2} END{printf "%d", (t>0 ? (t-f)/1024 : 0)}' \
+        /proc/meminfo 2>/dev/null || echo 0
+}
+host_swap_total_mib() {
+    awk '/^SwapTotal:/{printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo 0
+}
+host_mem_avail_mib() {
+    awk '/^MemAvailable:/{printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo 0
+}
+
+# PPIDs of every zombie, one per line.
+host_zombie_ppids() { ps -eo stat=,ppid= 2>/dev/null | awk '$1 ~ /^Z/ {print $2}'; }
+host_proc_name()    { ps -p "$1" -o comm= 2>/dev/null | tr -d ' '; }
+
+# "<name> <cpu%>" of the busiest container, empty if docker is unreachable.
+# Bounded: docker stats on a wedged daemon otherwise hangs the whole doctor run.
+host_top_container() {
+    local t=""
+    command -v timeout >/dev/null 2>&1 && t="timeout 8"
+    $t docker stats --no-stream --format '{{.Name}} {{.CPUPerc}}' 2>/dev/null \
+        | sort -k2 -hr | head -1
+}
+
+# Services that exist to donate bandwidth to other people. They compete with the
+# operator's own traffic, so naming them when the box is saturated is the point.
+HOSTLOAD_DONATION_CONTAINERS="moav-conduit moav-snowflake moav-tor"
+
+# Returns 0 = healthy, 1 = something to act on, 2 = not a Linux host.
+hostload_status() {
+    host_metrics_available || {
+        echo -e "    ${YELLOW}○${NC} Host metrics unavailable (no /proc) — skipped"
+        return 2
+    }
+
+    local pass=true ncpu load1 top_line top_name top_cpu
+    ncpu=$(host_ncpu); load1=$(host_load1)
+    top_line=$(host_top_container)
+    top_name="${top_line%% *}"; top_cpu="${top_line##* }"
+
+    # awk, not [[ ]]: load1 is a float and bash cannot compare those.
+    local verdict
+    verdict=$(awk -v l="$load1" -v n="$ncpu" 'BEGIN{ print (l >= n ? "over" : (l >= n*0.7 ? "near" : "ok")) }')
+    case "$verdict" in
+        over)
+            echo -e "    ${YELLOW}!${NC} load $load1 on $ncpu vCPU — the run queue is full"
+            [[ -n "$top_name" ]] && echo -e "      ${DIM}Busiest container: $top_name ($top_cpu)${NC}"
+            pass=false
+            ;;
+        near)
+            echo -e "    ${YELLOW}○${NC} load $load1 on $ncpu vCPU — little headroom"
+            [[ -n "$top_name" ]] && echo -e "      ${DIM}Busiest container: $top_name ($top_cpu)${NC}"
+            ;;
+        *)
+            echo -e "    ${GREEN}✓${NC} load $load1 on $ncpu vCPU"
+            ;;
+    esac
+
+    # A donation service on a small host is the operator paying for strangers'
+    # traffic with their own users' latency. Only worth saying when it is winning.
+    if [[ "$verdict" != "ok" && -n "$top_name" ]]; then
+        case " $HOSTLOAD_DONATION_CONTAINERS " in
+            *" $top_name "*)
+                echo -e "      ${DIM}$top_name donates bandwidth to other people and is capped at half a core.${NC}"
+                echo -e "      ${DIM}On a $ncpu-vCPU host, stop it and re-test before tuning anything else.${NC}"
+                ;;
+        esac
+    fi
+
+    local swap_used swap_total mem_avail
+    swap_used=$(host_swap_used_mib); swap_total=$(host_swap_total_mib)
+    mem_avail=$(host_mem_avail_mib)
+    if [[ "$swap_total" -eq 0 ]]; then
+        echo -e "    ${GREEN}✓${NC} no swap configured (${mem_avail} MiB RAM available)"
+    elif [[ "$swap_used" -gt 64 ]]; then
+        echo -e "    ${YELLOW}!${NC} ${swap_used} MiB swapped out (${mem_avail} MiB RAM available)"
+        echo -e "      ${DIM}Swap I/O shows up as latency on every connection. Drop a heavy${NC}"
+        echo -e "      ${DIM}optional profile — monitoring costs ~400 MiB of the three containers.${NC}"
+        pass=false
+    else
+        echo -e "    ${GREEN}✓${NC} ${swap_used} MiB swapped (${mem_avail} MiB RAM available)"
+    fi
+
+    local zppids zcount
+    zppids=$(host_zombie_ppids)
+    zcount=$(printf '%s' "$zppids" | grep -c . 2>/dev/null || true)
+    zcount="${zcount:-0}"
+    if [[ "$zcount" -gt 5 ]]; then
+        # Name the parent: a zombie is reaped by its parent, so the parent is the
+        # bug. "Restart the container" is only the fix once you know which one.
+        local worst
+        worst=$(printf '%s\n' "$zppids" | sort | uniq -c | sort -rn | head -1 | awk '{print $2}')
+        local wname; wname=$(host_proc_name "$worst")
+        echo -e "    ${YELLOW}!${NC} $zcount zombie process(es), most under PID $worst (${wname:-gone})"
+        echo -e "      ${DIM}That parent is not reaping. If it is a MoaV container, recreate it:${NC}"
+        echo -e "      ${DIM}moav start   # docker compose up -d; 'moav restart' keeps the old config${NC}"
+        pass=false
+    else
+        echo -e "    ${GREEN}✓${NC} $zcount zombie process(es)"
+    fi
+
+    $pass && return 0 || return 1
+}
+
+doctor_check_host() {
+    hostload_status
+}

--- a/lib/nettune.sh
+++ b/lib/nettune.sh
@@ -167,7 +167,22 @@ nt_status() {
     fi
 
     if [[ "$applied" == "true" ]]; then
-        echo -e "    ${GREEN}✓${NC} Tuning file present: $NT_CONF_PATH"
+        # Presence is not enough. `net apply` skips a host that already has the
+        # file, so a server tuned by an older MoaV keeps that version's key set
+        # forever -- and then a key added since reads as operator drift. A 2.1.0
+        # server was still running the v1.8.4 bundle, missing tcp_max_syn_backlog.
+        local stale
+        stale=$(comm -23 \
+            <(nt_render_config 0 | grep -oE '^net\.[a-z0-9_.]+' | sort -u) \
+            <(grep -oE '^net\.[a-z0-9_.]+' "$NT_CONF_PATH" 2>/dev/null | sort -u) \
+            | tr '\n' ' ')
+        if [[ -n "${stale// /}" ]]; then
+            echo -e "    ${YELLOW}!${NC} Tuning file is from an older MoaV — missing: ${stale% }"
+            echo -e "      ${DIM}Re-run 'moav net apply' to refresh it (it rewrites the file).${NC}"
+            pass=false
+        else
+            echo -e "    ${GREEN}✓${NC} Tuning file present: $NT_CONF_PATH"
+        fi
     else
         echo -e "    ${YELLOW}○${NC} Tuning file not present (run: moav net apply)"
     fi
@@ -299,9 +314,12 @@ nt_check_drops() {
     else
         local line
         for line in "${report[@]}"; do
-            echo -e "    ${YELLOW}!${NC} $line"
+            echo -e "    ${YELLOW}!${NC} $line since boot"
             pass=false
         done
+        # A since-boot total says nothing about now: a bad hour last week and an
+        # ongoing overflow print the same number.
+        echo -e "      ${DIM}Still happening? 'nstat -az | grep -E \"SndbufErrors|RcvbufErrors|ListenDrops\"' twice, 10s apart.${NC}"
     fi
     $pass && return 0 || return 1
 }

--- a/lib/peers.sh
+++ b/lib/peers.sh
@@ -49,10 +49,18 @@ peers_users_for_octet() {
 # peers_live_owner <container> <bin> <iface> <prefix> <octet>
 # Which public key currently OWNS the address in the running interface (that is
 # the peer whose tunnel actually works). Empty if the service is not running.
+#
+# The docker output is captured before awk sees it, NOT piped into it. Piping and
+# then `exit`ing on the first match closes the pipe while `wg show` is still
+# writing its other peers, so docker dies of SIGPIPE; under `set -o pipefail`
+# that makes this assignment fail and `set -e` kills the caller mid-repair with
+# no message at all. It is a race, so it only shows up on servers with enough
+# peers for the match to land before the writer finishes -- which is exactly the
+# servers that need the repair.
 peers_live_owner() {
-    local cont="$1" bin="$2" iface="$3" prefix="$4" octet="$5"
-    docker exec "$cont" "$bin" show "$iface" allowed-ips 2>/dev/null \
-        | awk -v pat="${prefix//./[.]}[.]${octet}(/|,|$)" '$0 ~ pat {print $1; exit}'
+    local cont="$1" bin="$2" iface="$3" prefix="$4" octet="$5" out
+    out=$(docker exec "$cont" "$bin" show "$iface" allowed-ips 2>/dev/null) || return 0
+    awk -v pat="${prefix//./[.]}[.]${octet}(/|,|$)" '$0 ~ pat {print $1; exit}' <<<"$out"
 }
 
 # peers_pubkey_for_user <conf> <user>
@@ -140,6 +148,28 @@ peers_drop_block() {
     rm -f "$tmp"
 }
 
+# peers_clear_state_env <svc> <user> — drop the stored keypair+IP so the next
+# provisioning run reallocates. Returns 0 if a copy was actually removed.
+#
+# There are TWO state trees and the generators read different ones: the host CLI
+# path uses ./state, while the container path (scripts/generate-user.sh, and so
+# `moav regenerate-users`) reads /state from the moav_state docker volume, which
+# is NOT the host directory. Clearing only the host copy leaves the volume copy
+# authoritative, the stored address comes straight back, and the duplicate the
+# repair just reported reappears on the next regenerate.
+peers_clear_state_env() {
+    local svc="$1" user="$2" gone=1
+    local envf="${STATE_DIR:-state}/users/$user/${svc}.env"
+    [[ -f "$envf" ]] && { rm -f "$envf" 2>/dev/null && gone=0; }
+    # Same volume name and image as scripts/user-revoke.sh uses for its cleanup.
+    if docker run --rm -v moav_moav_state:/state alpine \
+        sh -c "[ -f /state/users/$user/${svc}.env ] && rm -f /state/users/$user/${svc}.env" 2>/dev/null
+    then
+        gone=0
+    fi
+    return $gone
+}
+
 # peers_repair [--yes] — for every duplicated address, keep the peer that owns it
 # on the live interface (or the last one in the config, which is who WireGuard
 # would pick on load) and reset the rest: drop their [Peer] block and their
@@ -147,7 +177,6 @@ peers_drop_block() {
 # `moav regenerate-users`.
 peers_repair() {
     local assume_yes="${1:-}" spec name conf prefix svc bin iface
-    local state_dir="${STATE_DIR:-state}"
     local -a resets=()
 
     for spec in "${PEERS_SPECS[@]}"; do
@@ -202,20 +231,30 @@ peers_repair() {
         [[ "$reply" =~ ^[Yy]$ ]] || { info "Cancelled."; return 1; }
     fi
 
-    local done_n=0
+    local done_n=0 stuck=0
     for entry in "${resets[@]}"; do
         IFS='|' read -r svc2 conf2 user2 <<<"$entry"
-        local envf="$state_dir/users/$user2/${svc2}.env"
-        if peers_drop_block "$conf2" "$user2"; then
-            rm -f "$envf" 2>/dev/null || true
+        if ! peers_drop_block "$conf2" "$user2"; then
+            echo -e "    ${RED}✗${NC} could not edit $conf2 for $user2"
+            continue
+        fi
+        # Dropping the block alone is not a reset: with the stored address still
+        # readable the next regenerate re-adds the very same duplicate.
+        if peers_clear_state_env "$svc2" "$user2"; then
             echo -e "    ${GREEN}✓${NC} reset $svc2 peer for $user2"
             done_n=$((done_n + 1))
         else
-            echo -e "    ${RED}✗${NC} could not edit $conf2 for $user2"
+            echo -e "    ${YELLOW}!${NC} dropped $svc2 peer for $user2 but found no stored state to clear"
+            stuck=$((stuck + 1))
         fi
     done
 
     echo ""
+    if [[ "$stuck" -gt 0 ]]; then
+        warn "$stuck peer(s) had no state file in ./state or the moav_state volume."
+        echo -e "  ${DIM}Their address came from somewhere else, so a regenerate may re-add the${NC}"
+        echo -e "  ${DIM}duplicate. Check 'docker volume ls' for moav_moav_state, then report this.${NC}"
+    fi
     success "Reset $done_n peer(s)."
     echo -e "  ${CYAN}Next:${NC} moav regenerate-users   ${DIM}# reassigns addresses + rebuilds bundles${NC}"
     echo -e "  Then distribute the new bundles to the users listed above."

--- a/moav.sh
+++ b/moav.sh
@@ -96,6 +96,7 @@ trap goodbye SIGINT
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/nettune.sh"   # before doctor: doctor_check_net calls nt_*
 source "$SCRIPT_DIR/lib/peers.sh"     # doctor_check_peers + the --fix repair
+source "$SCRIPT_DIR/lib/hostload.sh"  # doctor_check_host (load/swap/zombies)
 source "$SCRIPT_DIR/lib/donate.sh"
 source "$SCRIPT_DIR/lib/cert.sh"
 source "$SCRIPT_DIR/lib/migrate.sh"

--- a/tests/hostload-test.sh
+++ b/tests/hostload-test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Regression test: `moav doctor host` must state the things that took four rounds
+# of hand-run commands to establish on two live servers.
+#
+# The blr1 box: load 1.00 on 1 vCPU, 681 MiB swapped, 39 zombies (28 of them under
+# the admin container's python), and moav-conduit -- a bandwidth-donation service
+# capped at half that machine -- as the busiest container. None of that was
+# visible from `moav doctor`; it came from uptime, top, docker stats and a ps
+# pipeline for the zombie parents.
+#
+# The probes are stubbed, so this tests the reporting logic and not the CI runner.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "doctor host: load, swap and zombie reporting"
+
+# Drive hostload_status with fixed probe values.
+# <ncpu> <load1> <swap_used_mib> <swap_total_mib> <zombie-ppids...> ; TOP=<name cpu%>
+run_host() {
+    # T_ prefix: hostload_status declares its own `local ncpu` / `local zppids`,
+    # and bash's dynamic scoping means those shadow anything the stubs would read.
+    local T_NCPU="$1" T_LOAD="$2" T_SWUSED="$3" T_SWTOTAL="$4"; shift 4
+    local T_ZPPIDS="$*"
+    (
+        GREEN=''; YELLOW=''; RED=''; DIM=''; NC=''; WHITE=''; CYAN=''
+        # shellcheck disable=SC1091
+        source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/hostload.sh"
+        host_metrics_available() { return 0; }
+        host_ncpu()           { echo "$T_NCPU"; }
+        host_load1()          { echo "$T_LOAD"; }
+        host_swap_used_mib()  { echo "$T_SWUSED"; }
+        host_swap_total_mib() { echo "$T_SWTOTAL"; }
+        host_mem_avail_mib()  { echo 851; }
+        host_zombie_ppids()   { [[ -n "$T_ZPPIDS" ]] && printf '%s\n' $T_ZPPIDS; }
+        host_proc_name()      { echo "python"; }
+        host_top_container()  { echo "${TOP:-}"; }
+        hostload_status 2>&1
+        echo "RC=$?"
+    )
+}
+
+# --- the blr1 shape ----------------------------------------------------------
+# 39 zombies, 28 of them under PID 843463 (the admin container's python).
+zom="843463 843463 843463 843463 843463 843463 843463 843463 843463 843463"
+zom="$zom 843463 843463 843463 843463 843463 843463 843463 843463 843463 843463"
+zom="$zom 843463 843463 843463 843463 843463 843463 843463 843463"
+zom="$zom 388303 388303 388303 388303 388303 388303 388303 388303 388303 388303 388303"
+
+out=$(TOP="moav-conduit 29.19%" run_host 1 1.00 681 2048 $zom)
+
+printf '%s' "$out" | grep -q 'load 1.00 on 1 vCPU' \
+    && ok "reports load against the core count" \
+    || bad "did not state load vs vCPU: $(printf '%s' "$out" | tr '\n' '|')"
+
+printf '%s' "$out" | grep -q 'moav-conduit' \
+    && ok "names the busiest container" \
+    || bad "did not name the busiest container"
+
+printf '%s' "$out" | grep -qi 'donates bandwidth' \
+    && ok "calls out that the busiest container is a donation service" \
+    || bad "did not flag moav-conduit as a donation service on a saturated host"
+
+printf '%s' "$out" | grep -q '681 MiB swapped' \
+    && ok "reports swap in use" \
+    || bad "did not report swap"
+
+printf '%s' "$out" | grep -q '39 zombie' \
+    && ok "counts zombies" \
+    || bad "wrong zombie count: $(printf '%s' "$out" | grep -i zombie | tr '\n' '|')"
+
+printf '%s' "$out" | grep -q 'PID 843463' \
+    && ok "names the parent holding the most zombies" \
+    || bad "did not name the worst zombie parent — 'restart something' is not actionable"
+
+printf '%s' "$out" | grep -q 'RC=1' \
+    && ok "fails the check so 'moav doctor' surfaces it" \
+    || bad "returned success on a saturated, swapping host with 39 zombies"
+
+# --- a healthy host must stay quiet ------------------------------------------
+out_ok=$(TOP="moav-sing-box 2.07%" run_host 4 0.35 0 0)
+printf '%s' "$out_ok" | grep -q 'RC=0' \
+    && ok "a healthy host passes" \
+    || bad "flagged a healthy host: $(printf '%s' "$out_ok" | tr '\n' '|')"
+printf '%s' "$out_ok" | grep -qi 'donates bandwidth' \
+    && bad "lectured about donation services on an idle host" \
+    || ok "stays quiet about donation services when there is headroom"
+
+# --- and the thresholds must actually be thresholds --------------------------
+# Without this, a check that always warns would pass everything above.
+out_near=$(TOP="moav-xray 4.60%" run_host 2 1.50 0 2048)
+printf '%s' "$out_near" | grep -q 'little headroom' \
+    && ok "0.75x load per core reads as 'little headroom', not saturated" \
+    || bad "no distinction between near-capacity and over: $(printf '%s' "$out_near" | tr '\n' '|')"
+printf '%s' "$out_near" | grep -q 'RC=0' \
+    && ok "near-capacity alone does not fail the check" \
+    || bad "'little headroom' failed the check — every busy server would look broken"
+
+# Swap just under the threshold must not warn.
+out_sw=$(run_host 4 0.10 64 2048)
+printf '%s' "$out_sw" | grep -q 'RC=0' \
+    && ok "64 MiB of swap is not reported as pressure" \
+    || bad "64 MiB of swap failed the check"
+
+# --- wiring: every doctor check must resolve to a real function ---------------
+# `moav doctor` calls "doctor_check_${name}" by string, so a name in the list
+# with no function is a runtime "command not found" for that check only -- and
+# nothing else in the suite looks for it.
+while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    if grep -rqE "^doctor_check_${name}\\(\\)" "$ROOT"/lib/*.sh; then
+        ok "doctor check '$name' resolves to a function"
+    else
+        bad "doctor check '$name' is listed but doctor_check_${name}() is not defined"
+    fi
+done < <(sed -n '/^DOCTOR_CHECKS=(/,/^)/p' "$ROOT/lib/doctor.sh" \
+         | grep -oE '"[a-z_]+:' | tr -d '":')
+
+# hostload.sh must be sourced before doctor.sh, like nettune.sh and peers.sh:
+# doctor.sh's list names the check, the implementation lives elsewhere.
+hl=$(grep -nE '^source .*lib/hostload\.sh' "$ROOT/moav.sh" | head -1 | cut -d: -f1)
+dr=$(grep -nE '^source .*lib/doctor\.sh'   "$ROOT/moav.sh" | head -1 | cut -d: -f1)
+if [ -n "$hl" ] && [ -n "$dr" ] && [ "$hl" -lt "$dr" ]; then
+    ok "moav.sh sources hostload.sh before doctor.sh"
+else
+    bad "hostload.sh is sourced after doctor.sh (or not at all): hl=${hl:-none} dr=${dr:-none}"
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/tests/nettune-template-test.sh
+++ b/tests/nettune-template-test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Regression test: the sysctl bundle has two copies and neither may go stale.
+#
+# A live 2.1.0 server was still running the tuning file written by v1.8.4:
+# `moav net apply` and install.sh both skip a host that already has the file, so
+# whatever key set was current when the operator first tuned is what they keep,
+# forever. tcp_max_syn_backlog was added in v1.8.5, so `moav doctor net` reported
+# "✓ Tuning file present" one line above "! tcp_max_syn_backlog = 256" -- which
+# reads as an external override and sends you hunting through /etc/sysctl.d.
+#
+# Two invariants:
+#   1. nt_status flags a file that lacks any key the current template sets.
+#   2. install.sh's inline copy of the bundle matches nt_render_config, or a
+#      fresh install writes an older bundle than `moav net apply` would.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "net tuning: stale-file detection + template drift"
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# --- 1. the two copies of the bundle must agree ------------------------------
+keys_of() { grep -E '^net\.' | sed 's/[[:space:]]\+/ /g' | sort; }
+sed -n '/^nt_render_config/,/^}/p' "$ROOT/lib/nettune.sh"        | keys_of > "$TMP/lib.txt"
+sed -n '/# MoaV network tuning/,/^EOF$/p' "$ROOT/install.sh"     | keys_of > "$TMP/inst.txt"
+
+if [ ! -s "$TMP/lib.txt" ]; then
+    bad "could not extract the template from lib/nettune.sh (nt_render_config renamed?)"
+elif [ ! -s "$TMP/inst.txt" ]; then
+    bad "could not extract the template from install.sh (heredoc markers changed?)"
+elif diff -q "$TMP/lib.txt" "$TMP/inst.txt" >/dev/null; then
+    ok "install.sh and lib/nettune.sh set the same $(wc -l < "$TMP/lib.txt" | tr -d ' ') keys"
+else
+    bad "template drift between install.sh and lib/nettune.sh: $(diff "$TMP/lib.txt" "$TMP/inst.txt" | tr '\n' ' ')"
+fi
+
+# --- 2. nt_status must notice a file missing a current key --------------------
+# Drive the real function with NT_CONF_PATH pointed at a fixture.
+status_against() {   # <fixture-file> -> stdout of nt_status
+    (
+        # shellcheck disable=SC1091
+        source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1
+        RED=''; GREEN=''; YELLOW=''; CYAN=''; WHITE=''; DIM=''; NC=''
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/nettune.sh"
+        NT_CONF_PATH="$1"
+        # The fixture stands in for the file; the kernel probes read this host and
+        # are not what is under test here.
+        nt_kernel_supports_bbr() { return 0; }
+        nt_status 2>&1
+    )
+}
+
+# A current file: whatever the template renders right now.
+(
+    # shellcheck disable=SC1091
+    source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1
+    # shellcheck disable=SC1091
+    source "$ROOT/lib/nettune.sh"
+    nt_render_config 16777216
+) > "$TMP/current.conf"
+
+if grep -q '^net\.ipv4\.tcp_max_syn_backlog' "$TMP/current.conf"; then
+    ok "the current template sets tcp_max_syn_backlog"
+else
+    bad "the current template no longer sets tcp_max_syn_backlog -- fixture below is meaningless"
+fi
+
+# The v1.8.4 file, reproduced by dropping that one line: exactly what the live
+# server had.
+grep -v '^net\.ipv4\.tcp_max_syn_backlog' "$TMP/current.conf" > "$TMP/stale.conf"
+
+out_stale=$(status_against "$TMP/stale.conf")
+if printf '%s' "$out_stale" | grep -q 'from an older MoaV'; then
+    if printf '%s' "$out_stale" | grep -q 'tcp_max_syn_backlog'; then
+        ok "a stale file is reported as stale, naming the missing key"
+    else
+        bad "reported stale but did not name the missing key: $(printf '%s' "$out_stale" | tr '\n' ' ')"
+    fi
+else
+    bad "a file missing tcp_max_syn_backlog still reported as present/OK -- the operator is sent hunting"
+fi
+
+out_cur=$(status_against "$TMP/current.conf")
+if printf '%s' "$out_cur" | grep -q 'Tuning file present'; then
+    ok "an up-to-date file is not flagged"
+else
+    bad "a current file was reported stale: $(printf '%s' "$out_cur" | tr '\n' ' ')"
+fi
+
+# --- 3. and the check is not vacuous -----------------------------------------
+# If the comparison silently matched nothing, the stale fixture above would pass
+# for the wrong reason. Drop three keys and require all three to be named.
+grep -vE '^net\.(ipv4\.tcp_mtu_probing|core\.somaxconn|ipv4\.tcp_notsent_lowat)' \
+    "$TMP/current.conf" > "$TMP/older.conf"
+out_older=$(status_against "$TMP/older.conf")
+missed=""
+for k in tcp_mtu_probing somaxconn tcp_notsent_lowat; do
+    printf '%s' "$out_older" | grep -q "$k" || missed="$missed $k"
+done
+[ -z "$missed" ] && ok "names every missing key, not just the first" \
+                 || bad "did not name:$missed"
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/tests/peers-repair-test.sh
+++ b/tests/peers-repair-test.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Regression test: `moav doctor peers --fix` must survive a busy server, and a
+# "reset" must actually clear the stored address.
+#
+# Two failures seen on live 2.1.0 servers, both silent:
+#
+# 1. peers_live_owner piped `docker exec ... wg show` into an awk that exits on
+#    the first match. On a server with enough peers the writer is still going
+#    when awk exits, so docker dies of SIGPIPE; `set -o pipefail` makes the
+#    assignment fail and `set -e` kills the repair with NO output at all -- the
+#    report printed, then the shell returned to the prompt. It survived on a
+#    19-peer server and died on a 171-peer one, because it is a race.
+#
+# 2. The reset removed ./state/users/<u>/<svc>.env only. `moav regenerate-users`
+#    provisions in a container reading /state from the moav_state volume, so the
+#    stored address survived and the duplicate came straight back.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "doctor peers --fix: survives a busy server, clears the stored address"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK"/{configs/wireguard,configs/amneziawg,state/users,bin}
+
+# Two users on one address; the live owner is the second one.
+build_conf() {   # <conf> <prefix>
+    printf '[Interface]\nAddress = %s.1/24\n' "$2" > "$1"
+    local u
+    for u in loser keeper; do
+        printf '\n[Peer]\n# %s\nPublicKey = pk-%s\nAllowedIPs = %s.9/32\n' "$u" "$u" "$2" >> "$1"
+    done
+}
+build_conf "$WORK/configs/wireguard/wg0.conf"   10.66.66
+build_conf "$WORK/configs/amneziawg/awg0.conf"  10.67.67
+for u in loser keeper; do
+    mkdir -p "$WORK/state/users/$u"
+    printf 'WG_PRIVATE_KEY=x\nWG_PUBLIC_KEY=pk-%s\nWG_CLIENT_IP=10.66.66.9\n' "$u" \
+        > "$WORK/state/users/$u/wireguard.env"
+    cp "$WORK/state/users/$u/wireguard.env" "$WORK/state/users/$u/amneziawg.env"
+done
+
+# A `wg show` that keeps writing long after the first match -- the busy server.
+# `docker run` (the volume cleanup) records its argv and reports "nothing there",
+# so the host copy is what has to satisfy the reset.
+cat > "$WORK/bin/docker" <<'STUB'
+#!/bin/bash
+case "${1:-}" in
+    exec)
+        echo "pk-keeper	10.66.66.9/32"
+        echo "pk-keeper	10.67.67.9/32"
+        # 200k lines of other peers: awk has long since exited on the match above
+        seq 1 200000 | sed 's|^|pk-other	10.66.66.|'
+        ;;
+    run)
+        echo "$*" >> "${DOCKER_ARGV_LOG:-/dev/null}"
+        exit 1
+        ;;
+esac
+STUB
+chmod +x "$WORK/bin/docker"
+
+run_repair() {
+    (
+        cd "$WORK" || exit 99
+        export PATH="$WORK/bin:$PATH"
+        export DOCKER_ARGV_LOG="$WORK/docker-argv.log"
+        set -euo pipefail                      # exactly how moav.sh runs
+        RED=''; GREEN=''; YELLOW=''; CYAN=''; WHITE=''; DIM=''; NC=''
+        # shellcheck disable=SC1091
+        source "$ROOT/scripts/lib/common.sh"
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/common.sh"
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/peers.sh"
+        STATE_DIR="state"
+        peers_repair --yes
+    ) >"$WORK/out.txt" 2>&1
+}
+
+run_repair
+rc=$?
+
+# --- 1. it must not die on the way through ----------------------------------
+if [ "$rc" -eq 0 ]; then
+    ok "repair completes against a long-writing 'wg show' (exit 0)"
+elif [ "$rc" -eq 141 ]; then
+    bad "repair died of SIGPIPE (141) -- peers_live_owner is piping into an early-exit awk again"
+else
+    bad "repair exited $rc; output: $(tr '\n' ' ' < "$WORK/out.txt" | tail -c 200)"
+fi
+
+# --- 2. it kept the live owner and reset the other one -----------------------
+if grep -q 'reset wireguard peer for loser' "$WORK/out.txt"; then
+    ok "resets the peer that lost the address"
+else
+    bad "did not reset 'loser' -- output: $(tr '\n' ' ' < "$WORK/out.txt" | tail -c 200)"
+fi
+if grep -q 'peer for keeper' "$WORK/out.txt"; then
+    bad "reset the live owner 'keeper' -- that breaks the one tunnel that works"
+else
+    ok "leaves the live owner alone"
+fi
+
+# --- 3. the stored address is really gone ------------------------------------
+[ -f "$WORK/state/users/loser/wireguard.env" ] \
+    && bad "loser's state env survived -- regenerate would re-add the same address" \
+    || ok "loser's stored address is cleared from the host state tree"
+[ -f "$WORK/state/users/keeper/wireguard.env" ] \
+    && ok "keeper's state is untouched" \
+    || bad "keeper's state was cleared -- the working user would be re-keyed"
+
+# --- 4. and the volume copy was attempted too --------------------------------
+# The container provisioning path reads /state from moav_state, not ./state.
+if grep -q 'moav_moav_state:/state' "$WORK/docker-argv.log" 2>/dev/null; then
+    ok "also clears the moav_state volume copy"
+else
+    bad "never touched the moav_state volume -- the container path keeps the old address"
+fi
+
+# --- 5. negative control: the old piped form really does die -----------------
+# Without this, a stub that never triggers SIGPIPE would make check 1 vacuous.
+oldform=$(
+    cd "$WORK" || exit 99
+    export PATH="$WORK/bin:$PATH"
+    set -euo pipefail
+    x=$(docker exec c wg show wg0 allowed-ips 2>/dev/null \
+        | awk '$0 ~ /10[.]66[.]66[.]9(\/|,|$)/ {print $1; exit}')
+    echo "survived:$x"
+)
+if [ -z "$oldform" ]; then
+    ok "the negative control confirms the piped form still dies on this stub"
+else
+    bad "the stub no longer provokes SIGPIPE ($oldform) -- check 1 proves nothing"
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/tests/zombie-reaper-test.sh
+++ b/tests/zombie-reaper-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Regression test: containers that inherit orphaned processes need a PID-1 reaper.
+#
+# Both live servers had zombies, and `ps -eo stat,ppid` named the parents:
+# 28 under `python main.py` (moav-admin) and 11 under `grafana server` on one,
+# 11 under grafana on the other. Both entrypoints `exec` their app, so PID 1 is
+# the app, and neither python nor grafana reaps processes it did not spawn. A
+# user-add script killed on timeout leaves its `docker`/`bash` grandchildren
+# reparented to PID 1, where they stay forever.
+#
+# `init: true` puts tini at PID 1, which reaps orphans and forwards signals.
+#
+# Only these two are asserted: the other eleven entrypoints exec a proxy binary
+# that spawns nothing, and neither live server had zombies under any of them.
+# This is deliberately evidence-driven rather than a blanket init: true.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="$ROOT/docker-compose.yml"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "compose: PID-1 reaper on the containers that inherit orphans"
+
+# Print one service's block. Service keys are the only 2-space-indented names.
+service_block() {   # <service>
+    awk -v want="  $1:" '
+        $0 == want { inblock = 1; next }
+        inblock && /^  [a-zA-Z0-9_-]+:$/ { exit }
+        inblock { print }
+    ' "$COMPOSE"
+}
+
+has_init() {        # <service>
+    service_block "$1" | grep -qE '^[[:space:]]+init:[[:space:]]*true[[:space:]]*$'
+}
+
+for svc in admin grafana; do
+    if [ -z "$(service_block "$svc")" ]; then
+        bad "could not find the '$svc' service block (renamed?)"
+    elif has_init "$svc"; then
+        ok "$svc has init: true"
+    else
+        bad "$svc has no init: true — orphaned children become permanent zombies"
+    fi
+done
+
+# --- the parser must be able to tell the difference --------------------------
+# Without this, a broken service_block that returns nothing for every service
+# would fail loudly above, but a grep that matched everything would pass silently.
+if has_init xray; then
+    bad "xray reports init: true — the block parser is matching other services"
+else
+    ok "the parser distinguishes services (xray, which has no init, reads as absent)"
+fi
+
+# --- and the reason must survive in the file ---------------------------------
+# A future reader deleting "init: true" as noise is exactly how this regresses.
+if service_block admin | grep -qi 'reap\|zombie'; then
+    ok "admin's init: true carries the why"
+else
+    bad "admin's init: true has no comment — it will be removed as clutter"
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Two failures in `moav doctor peers --fix`, both found on the live 2.1.0 servers, both silent. Reproduced locally before fixing.

## 1. It died mid-run on the busy server

`peers_live_owner` piped `docker exec … wg show <iface> allowed-ips` into an awk that `exit`s on the first match. The early exit closes the pipe while `wg show` is still writing its remaining peers, so **docker takes SIGPIPE**. `set -o pipefail` turns that into a failed assignment and `set -e` kills the run — with no message at all, which is why the transcript shows the report and then the shell prompt.

The report survived the identical call only because `cmd_doctor` invokes it as `peers_report || true`, and that suppresses `set -e` for the whole function body.

**It is a race, not a size threshold** — which is why the 19-peer server repaired fine and the 171-peer server died every time:

```
$ bash -c 'set -euo pipefail; x=$(yes hello | awk "{print \$1; exit}"); echo alive'
$ echo $?
141                       # 128 + SIGPIPE, no output

$ bash -c 'set -euo pipefail; x=$(printf "a\nb\n" | awk "{print \$1; exit}"); echo alive'
alive, got: a             # short writer finishes first -- survives
```

Fix: capture the output, then match it. `awk` reading a here-string cannot close anything upstream.

## 2. The reset did not reset

This is the one that matters for the operator. On the smaller server all 18 peers reported `✓ reset`, `moav regenerate-users` ran clean, and `moav doctor` then reported **the identical duplicates** — same addresses, same users, only the config order changed.

The repair removed `./state/users/<u>/<svc>.env`. But there are **two state trees**:

| tree | mounted as | who reads it |
|---|---|---|
| `./state` (host dir) | `/project/state`, `/host-state:ro` | host CLI path (`scripts/wg-user-add.sh`, `STATE_DIR=./state`) |
| `moav_state` (docker volume) | `/state` | container path — `scripts/generate-user.sh`, i.e. `moav regenerate-users` |

`wireguard_add_peer` reuses a stored `WG_CLIENT_IP` whenever it can read one, so with the volume copy intact the regenerate faithfully re-added the same colliding address. Dropping the `[Peer]` block without clearing the stored address is not a reset — it just moves the block to the end of the file, which is exactly what the post-fix report showed.

Fix: clear both copies, the same way `scripts/user-revoke.sh` already does for the volume, and print an honest warning when neither exists rather than a tick.

## Test

`tests/peers-repair-test.sh` — 7 checks, wired into CI:

- repair completes against a `wg show` stub that writes 200k lines after the match
- the peer that lost the address is reset; the live owner is left alone
- the stored address is gone from the host tree, and the `moav_state` cleanup was attempted (stub logs its argv)
- **negative control**: asserts the stub still provokes SIGPIPE, so the first check cannot silently go vacuous

Against the pre-fix code it fails 4 of 7, naming the exit-141 signature. Verified by reverting only the `peers_live_owner` hunk and re-running.

## Not fixed here — worth a decision

`wireguard_add_peer` trusts a stored `WG_CLIENT_IP` **without checking whether another user already claims it** in `wg0.conf`. Fresh allocation is safe (`net_next_free_octet` takes max+1), so this is the remaining way a duplicate can appear on 2.x: re-adding a user whose state file outlived their peer block. It is also why the broken repair *created* new duplicates rather than leaving things as they were.

The fix is small — if the stored address is claimed by a different user, reallocate and keep the keypair, so only the address changes and the bundle is rewritten in the same run. I left it out because it changes an address on a user who looks fine today, and that call is yours.

---

# Also here: the `net` check lied about the tuning file

Same testing round, unrelated code. `moav doctor net` on a 2.1.0 server printed:

```
✓ Tuning file present: /etc/sysctl.d/99-moav-net.conf
! tcp_max_syn_backlog = 256 (expected ≥ 8192)
```

That reads as an external override, and it sent the operator through `/etc/sysctl.conf`, `/etc/sysctl.d`, `/usr/lib/sysctl.d` and `/run/sysctl.d` looking for whoever set 256. **Nobody did.** The key was never in the file, and 256 is the kernel's own default for that host.

The file was written by **v1.8.4 or earlier** — 13 keys, `somaxconn` present, `tcp_max_syn_backlog` absent, which v1.8.5 added. Its key set matches `git show v1.8.4:moav.sh` exactly, and matches what `sysctl -p` echoed on the box. Both `nt_apply`'s caller in install.sh and the installer skip a host that already has the file, and `nt_status` only checked existence — so a server tuned once keeps that vintage forever, and every key added since reads as operator drift.

Fix: diff the installed file's keys against the current template and name what is missing, with the remedy.

```
! Tuning file is from an older MoaV — missing: net.ipv4.tcp_max_syn_backlog
  Re-run 'moav net apply' to refresh it (it rewrites the file).
```

Also labelled the drop counters `since boot` and pointed at `nstat` for a rate — `SndbufErrors=631747` reads as an ongoing emergency when it may be entirely historical.

`tests/nettune-template-test.sh` (5 checks) reproduces the v1.8.4 file by dropping that one line, and **gates the second copy of the bundle** — install.sh duplicates the sysctl block verbatim, which is precisely how one copy silently ages behind the other. Fails 2/5 with the detector disabled, and requires *every* missing key to be named so the comparison cannot pass by matching nothing.

---

# And: zombie processes in admin + grafana

`ps -eo stat,ppid` on the two servers named the parents: **28 zombies under `python main.py`** (moav-admin) plus 11 under `grafana server` on the 1-vCPU box, and 11 under grafana on the other.

Both entrypoints `exec` their app, so PID 1 is python / grafana, and neither reaps a process it did not spawn. The admin's own `subprocess.run()` calls are fine — it is the **grandchildren** that leak: a user-add script killed on timeout leaves its `bash`/`docker` children reparented to PID 1, where they stay forever.

`init: true` puts tini at PID 1, which reaps orphans and forwards signals.

Scoped to these two on purpose. The other eleven entrypoints exec a proxy binary that spawns nothing, and neither live server had a zombie under any of them:

```
dns-router-entrypoint.sh    exec dns-router
xray-entrypoint.sh          exec xray run -c "$CONFIG_FILE"
sing-box-entrypoint.sh      exec setpriv ... sing-box
...
```

**Applying this to a running server needs `docker compose up -d admin grafana`** — `moav restart` uses `docker compose restart`, which keeps the old container config, so it will not pick this up.

`tests/zombie-reaper-test.sh` (4 checks) asserts both services carry `init: true`, that the comment explaining why survives (this is exactly the line a future reader deletes as clutter), and — negative control — that the block parser reads `xray` as *not* having it, so a grep that matched everything could not pass silently.
