### PR TITLE
fix(cdn): upgrading must not switch off a CDN that is already running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
         run: bash tests/enable-flag-gating-test.sh
       - name: ENABLE_CDN opt-in flag
         run: bash tests/cdn-flag-test.sh
+      - name: CDN survives an upgrade (flag inference + path rotation)
+        run: bash tests/cdn-upgrade-test.sh
       - name: llms.txt link hygiene (structure)
         run: bash tests/llms-links-test.sh
       - name: moav update rebuild prompts (baked-in changes)

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -612,6 +612,17 @@ check_env_additions() {
             done
         fi
 
+        # A new opt-in flag must not switch off a feature the server is already
+        # running. ENABLE_CDN's absence means "on if CDN_SUBDOMAIN is set" (see
+        # cdn_enabled), so appending the example's `false` would leave a working
+        # CDN alive until the next bootstrap and then silently drop the inbound.
+        if [[ "$var" == "ENABLE_CDN" ]]; then
+            if [[ -n "$(get_env_val "CDN_SUBDOMAIN" "$env_file" "")" \
+               || -n "$(get_env_val "CDN_DOMAIN"    "$env_file" "")" ]]; then
+                value_line="ENABLE_CDN=true"
+            fi
+        fi
+
         # Display: variable name with its default value
         local default_val
         default_val=$(echo "$value_line" | cut -d'=' -f2-)

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -393,6 +393,7 @@ fi
 if [[ -f "$STATE_DIR/keys/cdn.env" ]]; then
     source "$STATE_DIR/keys/cdn.env"
 fi
+_cdn_path_before="${CDN_WS_PATH:-}"
 if [[ -z "${CDN_WS_PATH:-}" || "${CDN_WS_PATH}" == "/ws" ]]; then
     # Generate a random realistic-looking path that blends with normal web traffic
     _cdn_prefixes=("api/v3/storage" "api/v2/assets" "api/v4/cdn" "api/v1/files" "cdn/v2/objects" "static/v3/resources" "dl/v2/packages")
@@ -411,7 +412,16 @@ if [[ -z "${CDN_WS_PATH:-}" || "${CDN_WS_PATH}" == "/ws" ]]; then
     CDN_WS_PATH="/${_rand_prefix}/${_rand_mid}/${_rand_file}-${_rand_num}.${_rand_ext}"
     # Do not log the value — it ships in bundles but bootstrap output lands in
     # docker logs / install transcripts that get pasted around.
-    log_info "Generated CDN WS path"
+    if [[ -n "$_cdn_path_before" ]]; then
+        # Rotating off the old /ws default breaks every CDN config already handed
+        # out, and only CDN: it is the one protocol whose link carries a path, so
+        # everything else keeps working and the report is "just this one broke".
+        log_warn "CDN WS path rotated away from the old /ws default"
+        log_warn "  Existing CDN configs will get 404 until their bundles are reissued:"
+        log_warn "    moav regenerate-users   # then redistribute the bundles"
+    else
+        log_info "Generated CDN WS path"
+    fi
 
     # Persist for subsequent bootstraps
     mkdir -p "$STATE_DIR/keys"

--- a/tests/cdn-upgrade-test.sh
+++ b/tests/cdn-upgrade-test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Regression test: upgrading must not silently take a working CDN away.
+#
+# From a user report: "all the other configs work, only CDN doesn't, and it used
+# to work a few versions ago". Two ways an upgrade does that, both silent:
+#
+# 1. ENABLE_CDN arrived in 2.1.0 defaulting to false. cdn_enabled() treats an
+#    ABSENT flag as "on if CDN_SUBDOMAIN is set", which is what keeps existing
+#    servers working -- but `moav update` offers to append every new variable
+#    from .env.example with its default, the prompt defaults to yes, and the
+#    appended `ENABLE_CDN=false` then beats that inference. The CDN survives
+#    until the next bootstrap and then the inbound disappears.
+#
+# 2. bootstrap rotates CDN_WS_PATH when it is empty or the old "/ws" default.
+#    CDN is the only protocol whose share link carries a path, so every other
+#    protocol keeps working and the already-distributed CDN configs 404. Rotating
+#    is correct (a guessable path is an active-probing target); doing it without
+#    telling the operator to reissue bundles is not.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "CDN across an upgrade: flag inference and path rotation"
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# --- 1. the appended flag must preserve the running behaviour ----------------
+# Drive the real function: a pre-2.1.0 .env (CDN in use, no ENABLE_CDN) against
+# an .env.example that has ENABLE_CDN=false.
+# check_env_additions takes no arguments: it reads $SCRIPT_DIR/.env against
+# $SCRIPT_DIR/.env.example, so the fixture is a directory holding both.
+append_for() {   # <env-contents-file> -> the resulting .env
+    local work; work=$(mktemp -d)
+    cp "$1" "$work/.env"
+    printf 'DOMAIN=example.com\nENABLE_CDN=false\nCDN_SUBDOMAIN=cdn\n' > "$work/.env.example"
+    (
+        GREEN=''; YELLOW=''; RED=''; DIM=''; NC=''; WHITE=''; CYAN=''; BLUE=''
+        SCRIPT_DIR="$work"
+        # shellcheck disable=SC1091
+        source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/common.sh"         >/dev/null 2>&1
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/update.sh"         >/dev/null 2>&1
+        # Answer the prompt with the default (Enter = yes).
+        check_env_additions </dev/null >/dev/null 2>&1
+        cat "$work/.env"
+    )
+    rm -rf "$work"
+}
+
+printf 'DOMAIN=example.com\nCDN_SUBDOMAIN=cdn\n' > "$TMP/pre210.env"
+out=$(append_for "$TMP/pre210.env")
+
+if printf '%s' "$out" | grep -qE '^ENABLE_CDN=true'; then
+    ok "a server already using CDN keeps it: ENABLE_CDN=true is written"
+elif printf '%s' "$out" | grep -qE '^ENABLE_CDN=false'; then
+    bad "wrote ENABLE_CDN=false onto a server with CDN_SUBDOMAIN set — CDN dies at the next bootstrap"
+else
+    bad "ENABLE_CDN was not added at all: $(printf '%s' "$out" | tr '\n' '|')"
+fi
+
+# A server NOT using CDN must still get the safe default.
+printf 'DOMAIN=example.com\n' > "$TMP/nocdn.env"
+out_nocdn=$(append_for "$TMP/nocdn.env")
+if printf '%s' "$out_nocdn" | grep -qE '^ENABLE_CDN=false'; then
+    ok "a server without a CDN subdomain gets the opt-in default (false)"
+else
+    bad "turned CDN on for a server that never had it: $(printf '%s' "$out_nocdn" | tr '\n' '|')"
+fi
+
+# --- 2. cdn_enabled must still honour an explicit false ----------------------
+# The fix above is about what gets WRITTEN. An operator who deliberately sets
+# false must still be obeyed, or the flag is meaningless.
+explicit=$(
+    cd "$TMP" || exit 99
+    printf 'ENABLE_CDN=false\nCDN_SUBDOMAIN=cdn\n' > .env
+    # shellcheck disable=SC1091
+    source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1
+    unset ENABLE_CDN CDN_SUBDOMAIN CDN_DOMAIN
+    cdn_enabled && echo on || echo off
+)
+[ "$explicit" = "off" ] \
+    && ok "an explicit ENABLE_CDN=false still wins over CDN_SUBDOMAIN" \
+    || bad "explicit false was ignored ($explicit) — the flag does nothing"
+
+inferred=$(
+    cd "$TMP" || exit 99
+    printf 'CDN_SUBDOMAIN=cdn\n' > .env
+    # shellcheck disable=SC1091
+    source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1
+    unset ENABLE_CDN CDN_SUBDOMAIN CDN_DOMAIN
+    cdn_enabled && echo on || echo off
+)
+[ "$inferred" = "on" ] \
+    && ok "an absent flag still infers CDN from CDN_SUBDOMAIN" \
+    || bad "absent flag read as off ($inferred) — every pre-2.1.0 server loses CDN"
+
+# --- 3. rotating the WS path must say so -------------------------------------
+rotate_block=$(sed -n '/^# Generate or load CDN WS path/,/^export CDN_WS_PATH/p' "$ROOT/scripts/bootstrap.sh")
+if [ -z "$rotate_block" ]; then
+    bad "could not find the CDN WS path block in bootstrap.sh"
+else
+    if printf '%s' "$rotate_block" | grep -qi 'rotated'; then
+        ok "bootstrap warns when it rotates an existing path"
+    else
+        bad "path rotation is silent — the operator never learns to reissue bundles"
+    fi
+    # The warning is only useful if it says what to do about it.
+    if printf '%s' "$rotate_block" | grep -q 'regenerate-users'; then
+        ok "the warning names the fix (regenerate-users)"
+    else
+        bad "the rotation warning does not say how to recover"
+    fi
+    # And it must NOT fire on a first-time generation, or every fresh install
+    # ships a scary warning about configs that do not exist yet.
+    if printf '%s' "$rotate_block" | grep -q '_cdn_path_before'; then
+        ok "the warning is conditional on there having been a previous path"
+    else
+        bad "no first-install guard — a fresh bootstrap would warn about nothing"
+    fi
+    # The path itself must never reach the logs: bootstrap output gets pasted
+    # into issues, and this path is an active-probing barrier.
+    if printf '%s' "$rotate_block" | grep -qE 'log_(info|warn).*\$\{?CDN_WS_PATH'; then
+        bad "the CDN WS path is logged — it ends up in pasted install transcripts"
+    else
+        ok "the path value stays out of the logs"
+    fi
+fi
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
From a user report, in full: *"I have a problem with the CDN config and it doesn't work for me. All the other configs work, only this one. I set the cdn subdomain proxied in Cloudflare, set the Origin Rule, SSL/TLS on flexible. `curl … https://cdn.yourdomain.com/x` returns 404. I don't remember which version, but it worked a few versions ago."*

Their Cloudflare setup was correct and **the 404 was the healthy response** — the CDN WebSocket path is a random secret, so `/x` can never match and sing-box rightly 404s it. Two real upgrade paths explain the actual breakage, and both are silent.

## 1. The new opt-in flag switches off a running CDN

`cdn_enabled()` reads an **absent** `ENABLE_CDN` as "on if `CDN_SUBDOMAIN` is set". That inference is the entire reason pre-2.1.0 servers kept working when the flag was introduced.

But `check_env_additions` offers to append every new variable from `.env.example` with its default:

```
New configuration options available (7):
  ENABLE_CDN=false
  ...
Add these to your .env with default values? [Y/n]
```

The prompt defaults to **yes**. One Enter writes `ENABLE_CDN=false`, which beats the inference. Nothing appears to break — until the next `moav bootstrap`, which sets `CDN_DOMAIN=""` and drops the inbound entirely.

Fixed by writing `true` when `CDN_SUBDOMAIN` or `CDN_DOMAIN` is already set. An explicit `false` still wins, or the flag would mean nothing.

## 2. The WS path rotates without a word

`scripts/bootstrap.sh` regenerates `CDN_WS_PATH` when it is empty **or the old `/ws` default**. CDN is the only protocol whose share link carries a path, so after that bootstrap every other protocol keeps working and only the already-distributed CDN configs start returning 404 — precisely "همه کار می‌کنه، فقط این یکی".

Rotating is correct: `/ws` is a guessable active-probing target. Doing it silently is not. It now warns and names the recovery:

```
[WARN] CDN WS path rotated away from the old /ws default
[WARN]   Existing CDN configs will get 404 until their bundles are reissued:
[WARN]     moav regenerate-users   # then redistribute the bundles
```

Only when a path existed before — a fresh install shouldn't warn about configs that don't exist yet — and the value still never reaches the logs, since bootstrap output gets pasted into issues.

## Test

`tests/cdn-upgrade-test.sh` (8 checks) drives the real `check_env_additions` against a pre-2.1.0 `.env`. Against the current code it fails 3, naming each consequence. It also pins the two halves of the inference that must not drift: an explicit `false` still wins, and an absent flag still infers from `CDN_SUBDOMAIN`.

## Docs

Separately in moav-site: the "should return 400 or 404 (sing-box responding)" line was buried under *Cloudflare 521*, so someone debugging a different symptom reads 404 as the fault. It moves to the top of the CDN section, alongside the path-rotation recovery.