### PR TITLE
fix(update,grafana,geoip,build,logs,status): everything a live 2.2 upgrade needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
         run: bash tests/llms-links-test.sh
       - name: moav update rebuild prompts (baked-in changes)
         run: bash tests/update-rebuild-test.sh
+      - name: build cache cap (sizing reaches docker builder)
+        run: bash tests/build-cache-test.sh
       - name: snowflake native metrics + dashboard (#183)
         run: bash tests/snowflake-metrics-test.sh
       - name: admin TLS enforcement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,40 @@ moav net apply          # if doctor says the tuning file is from an older MoaV
 
 ### Fixed
 
+- **`moav update` said nothing after changing `docker-compose.yml`.** A compose
+  change maps to no service, so the apply summary was skipped entirely and the
+  pull read as a no-op — even though `moav start` is exactly what applies it.
+  Every step in that summary is numbered now, too: the recreate line was an
+  unnumbered footnote and was being skipped.
+- **`moav update` suggested building a service that no longer exists.** Deleting
+  `exporters/snowflake` left its files in the diff, so the summary printed
+  `moav build snowflake snowflake-exporter` and the second half failed with
+  "no such service".
+- **A bind-mounted config file kept its old contents after an update.** This is
+  why the Snowflake dashboard showed *No Data* after a correct upgrade:
+  `prometheus.yml` is mounted as a single **file**, a file mount follows the
+  **inode**, and git replaces the file — so the container read the old copy
+  forever (measured: host inode 508739, container 523302). `moav restart` cannot
+  fix that; only a recreate can, and nothing said so.
+- **The GeoIP database was re-downloaded on every `moav start`.** `geoip-updater`
+  has no `profiles` key, so compose starts it on every `up` — 3.9 MB each time,
+  seven times in one evening on a test box. It now stamps the month (the db-ip
+  URL is monthly) and skips, writing through a temp file so an interrupted
+  download cannot leave a truncated database. The Tor geoip fetch uses a
+  conditional request instead, so an unchanged upstream transfers nothing.
+- **The build cache cap ignored the disk.** A fixed 4 GB on a 24 GB box left
+  4.9 GB of cache with 3.8 GB free — the largest single thing on a disk at 84%.
+  It now scales to a quarter of what the cache could grow into, floored at
+  512 MB and still capped at 4 GB.
+- **Log colours reshuffled between runs.** They were assigned in first-seen
+  order, which is distinct within a run but changes whenever containers attach in
+  a different order. They are now keyed to the service's position in the sorted
+  compose service list: stable across runs, and collision-free.
+- **`moav status` listed one-shot plumbing as failures.** `geoip-updater`,
+  `tor-geoip-updater` and `bootstrap` fill a volume and exit, so "exited" read as
+  a fault in a health table; they are hidden. `certbot` legitimately exits after
+  issuing, so it sorts last instead of sitting between running services.
+
 - **`moav doctor peers --fix` died silently on any busy server.** It printed the
   duplicate list and returned to the prompt: no confirmation, no repair, no
   error. The live-owner lookup piped `docker exec … wg show` into an `awk` that
@@ -84,6 +118,13 @@ moav net apply          # if doctor says the tuning file is from an older MoaV
   number, producing the reported `150.07845 → 150.07848 GB`.
 
 ### Added
+
+- **Snowflake dashboard, rebuilt on the proxy's own metrics.** Beyond the
+  per-country panels: rendezvous success rate, countries reached, proxy uptime,
+  failed connections per hour, and traffic stats that follow the time picker
+  alongside the cumulative totals. Laid out on an explicit grid — every row fills
+  the full width and starts where the previous one ended, asserted when the
+  dashboard is generated rather than eyeballed.
 
 - **`moav doctor host`** — CPU load against the core count, swap in use, zombie
   processes and the busiest container. Working out why one server felt slow took

--- a/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
@@ -41,7 +41,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 6,
         "x": 0,
         "y": 0
@@ -73,7 +73,8 @@
         }
       ],
       "title": "People Served",
-      "type": "stat"
+      "type": "stat",
+      "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts."
     },
     {
       "datasource": {
@@ -100,7 +101,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 6,
         "x": 6,
         "y": 0
@@ -131,8 +132,8 @@
           "refId": "A"
         }
       ],
-      "title": "Users Download",
-      "description": "Total data downloaded BY users through this proxy. Note: This is only the relayed payload - container metrics show higher values due to WebSocket/TLS overhead and broker connections.",
+      "title": "Total Downloaded",
+      "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts.",
       "type": "stat"
     },
     {
@@ -160,7 +161,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 6,
         "x": 12,
         "y": 0
@@ -191,8 +192,8 @@
           "refId": "A"
         }
       ],
-      "title": "Users Upload",
-      "description": "Total data uploaded BY users through this proxy. Note: This is only the relayed payload - container metrics show higher values due to WebSocket/TLS overhead and broker connections.",
+      "title": "Total Uploaded",
+      "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts.",
       "type": "stat"
     },
     {
@@ -220,7 +221,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 6,
         "x": 18,
         "y": 0
@@ -252,102 +253,98 @@
         }
       ],
       "title": "Total Bandwidth",
-      "description": "Total user payload relayed. Container network metrics (in cAdvisor) will show ~15-20x higher values due to WebSocket framing, TLS encryption overhead, and broker signaling traffic.",
+      "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts.",
       "type": "stat"
     },
     {
+      "id": 12,
+      "type": "stat",
+      "title": "Downloaded (selected range)",
+      "description": "Relayed to clients within the selected time range. increase() spans counter resets, so a proxy restart inside the window does not lose the traffic.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
+          "unit": "bytes",
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short",
-          "min": 0
+            "mode": "fixed",
+            "fixedColor": "super-light-blue"
+          }
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 5
-      },
-      "id": 5,
       "options": {
-        "legend": {
+        "reduceOptions": {
           "calcs": [
-            "mean",
-            "max",
             "lastNotNull"
           ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
       },
-      "pluginVersion": "10.4.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(tor_snowflake_proxy_connections_total[1h]))",
-          "legendFormat": "connections/hour",
-          "refId": "A"
+          "expr": "increase(tor_snowflake_proxy_traffic_inbound_bytes_total[$__range]) * 1024",
+          "refId": "A",
+          "instant": true
         }
       ],
-      "title": "Connections Served (per hour)",
-      "type": "timeseries",
-      "description": "Completed connections per hour. The proxy reports every 90s but completes only a handful an hour, so shorter windows read as zero."
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      }
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "Uploaded (selected range)",
+      "description": "Relayed from clients within the selected time range.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "super-light-green"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "increase(tor_snowflake_proxy_traffic_outbound_bytes_total[$__range]) * 1024",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      }
     },
     {
       "datasource": {
@@ -438,8 +435,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 5
+        "x": 0,
+        "y": 8
       },
       "id": 6,
       "options": {
@@ -499,7 +496,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 30,
+            "fillOpacity": 20,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
@@ -516,7 +513,7 @@
             "spanNulls": true,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -532,21 +529,23 @@
               }
             ]
           },
-          "unit": "bytes",
+          "unit": "short",
           "min": 0
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 13
+        "w": 12,
+        "x": 12,
+        "y": 8
       },
-      "id": 7,
+      "id": 5,
       "options": {
         "legend": {
           "calcs": [
+            "mean",
+            "max",
             "lastNotNull"
           ],
           "displayMode": "table",
@@ -565,43 +564,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(tor_snowflake_proxy_traffic_inbound_bytes_total + tor_snowflake_proxy_traffic_outbound_bytes_total) * 1024",
-          "legendFormat": "donated",
+          "expr": "sum(increase(tor_snowflake_proxy_connections_total[1h]))",
+          "legendFormat": "connections/hour",
           "refId": "A"
         }
       ],
-      "title": "Total Bandwidth Donated",
-      "type": "timeseries"
-    },
-    {
-      "id": 9,
+      "title": "Connections Served (per hour)",
       "type": "timeseries",
-      "title": "Failed Connections (per hour)",
-      "description": "Rendezvous succeeded but the data channel never opened. Often the client's NAT or censorship, not this proxy.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 21
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "increase(tor_snowflake_proxy_connection_timeouts_total[1h])",
-          "legendFormat": "failed/hour",
-          "refId": "A"
-        }
-      ]
+      "description": "Completed connections per hour. The proxy reports every 90s but completes only a handful an hour, so shorter windows read as zero."
     },
     {
       "id": 10,
@@ -616,7 +586,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 30
+        "y": 16
       },
       "fieldConfig": {
         "defaults": {
@@ -679,7 +649,7 @@
         "h": 9,
         "w": 16,
         "x": 8,
-        "y": 30
+        "y": 16
       },
       "fieldConfig": {
         "defaults": {
@@ -715,6 +685,131 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Failed Connections (per hour)",
+      "description": "Rendezvous succeeded but the data channel never opened. Often the client's NAT or censorship, not this proxy.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "increase(tor_snowflake_proxy_connection_timeouts_total[1h])",
+          "legendFormat": "failed/hour",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(tor_snowflake_proxy_traffic_inbound_bytes_total + tor_snowflake_proxy_traffic_outbound_bytes_total) * 1024",
+          "legendFormat": "donated",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Bandwidth Donated",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
@@ -574,45 +574,6 @@
       "type": "timeseries"
     },
     {
-      "id": 8,
-      "type": "barchart",
-      "title": "Users Served by Country",
-      "description": "From the proxy's own geoip lookup at connection close. '??' means the client IP was not in the database.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 21
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0
-        },
-        "overrides": []
-      },
-      "options": {
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0,
-        "legend": {
-          "showLegend": false
-        }
-      },
-      "targets": [
-        {
-          "expr": "sort_desc(sum by (country) (tor_snowflake_proxy_connections_total))",
-          "legendFormat": "{{country}}",
-          "refId": "A",
-          "instant": true,
-          "format": "time_series"
-        }
-      ]
-    },
-    {
       "id": 9,
       "type": "timeseries",
       "title": "Failed Connections (per hour)",
@@ -638,6 +599,119 @@
         {
           "expr": "increase(tor_snowflake_proxy_connection_timeouts_total[1h])",
           "legendFormat": "failed/hour",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "piechart",
+      "title": "Share of Users by Country",
+      "description": "Completed connections since the proxy last started, by the country of the client IP. '??' means the address was not in the geoip database.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "pieType": "donut",
+        "displayLabels": [
+          "percent"
+        ],
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (country) (tor_snowflake_proxy_connections_total)",
+          "legendFormat": "{{country}}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Users Served by Country over Time",
+      "description": "Completed connections per hour, stacked by country.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 8,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "lineWidth": 1,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (country) (increase(tor_snowflake_proxy_connections_total[1h]))",
+          "legendFormat": "{{country}}",
           "refId": "A"
         }
       ]

--- a/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
@@ -77,6 +77,151 @@
       "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts."
     },
     {
+      "id": 14,
+      "type": "stat",
+      "title": "Countries Reached",
+      "description": "Distinct countries with at least one completed connection since the proxy started. '??' counts as one: the client IP was not in the geoip database.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "count(count by (country) (tor_snowflake_proxy_connections_total))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      }
+    },
+    {
+      "id": 15,
+      "type": "gauge",
+      "title": "Rendezvous Success Rate",
+      "description": "Completed connections as a share of all rendezvous attempts. A large failure share is normal and mostly outside this proxy's control \u2014 the client's NAT and censorship decide it, per the upstream metric's own help text. Watch the trend, not the absolute number.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "semi-dark-blue"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(tor_snowflake_proxy_connections_total) / (sum(tor_snowflake_proxy_connections_total) + sum(tor_snowflake_proxy_connection_timeouts_total))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "id": 16,
+      "type": "stat",
+      "title": "Proxy Uptime",
+      "description": "Every 'Total' on this dashboard is measured since this moment: the counters live in the proxy process and restart with it.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "none",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds{job=\"snowflake-proxy\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      }
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -103,8 +248,8 @@
       "gridPos": {
         "h": 4,
         "w": 6,
-        "x": 6,
-        "y": 0
+        "x": 0,
+        "y": 4
       },
       "id": 2,
       "options": {
@@ -133,126 +278,6 @@
         }
       ],
       "title": "Total Downloaded",
-      "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts.",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 0
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "tor_snowflake_proxy_traffic_outbound_bytes_total * 1024",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Uploaded",
-      "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts.",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(tor_snowflake_proxy_traffic_inbound_bytes_total + tor_snowflake_proxy_traffic_outbound_bytes_total) * 1024",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Bandwidth",
       "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts.",
       "type": "stat"
     },
@@ -296,10 +321,70 @@
       ],
       "gridPos": {
         "h": 4,
-        "w": 12,
-        "x": 0,
+        "w": 6,
+        "x": 6,
         "y": 4
       }
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "tor_snowflake_proxy_traffic_outbound_bytes_total * 1024",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Uploaded",
+      "description": "Cumulative since the proxy last started \u2014 this stat does not follow the time picker. Counters reset when the container restarts.",
+      "type": "stat"
     },
     {
       "id": 13,
@@ -341,8 +426,8 @@
       ],
       "gridPos": {
         "h": 4,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 18,
         "y": 4
       }
     },

--- a/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
@@ -284,8 +284,8 @@
     {
       "id": 12,
       "type": "stat",
-      "title": "Downloaded (selected range)",
-      "description": "Relayed to clients within the selected time range. increase() spans counter resets, so a proxy restart inside the window does not lose the traffic.",
+      "title": "Downloaded",
+      "description": "Follows the dashboard's time picker, unlike the Total beside it. increase() spans counter resets, so a proxy restart inside the window does not lose the traffic.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -389,8 +389,8 @@
     {
       "id": 13,
       "type": "stat",
-      "title": "Uploaded (selected range)",
-      "description": "Relayed from clients within the selected time range.",
+      "title": "Uploaded",
+      "description": "Follows the dashboard's time picker, unlike the Total beside it. Relayed from clients within the selected time range.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1269,9 +1269,17 @@ services:
     command: >
       -c '
         MONTH=$$(date +%Y-%m) &&
+        DB=/geoip/dbip-country-lite.mmdb &&
+        STAMP=/geoip/.dbip-month &&
+        if [ -s "$$DB" ] && [ "$$(cat $$STAMP 2>/dev/null)" = "$$MONTH" ]; then
+          echo "GeoIP database already current ($${MONTH}), skipping download"
+          exit 0
+        fi &&
         URL="https://download.db-ip.com/free/dbip-country-lite-$${MONTH}.mmdb.gz" &&
         echo "Downloading GeoIP database for $${MONTH}..." &&
-        curl -fSL "$$URL" | gunzip > /geoip/dbip-country-lite.mmdb &&
+        curl -fSL "$$URL" | gunzip > "$$DB.tmp" &&
+        mv "$$DB.tmp" "$$DB" &&
+        echo "$$MONTH" > "$$STAMP" &&
         echo "GeoIP database updated successfully ($${MONTH})"
       '
 
@@ -1288,9 +1296,13 @@ services:
       - |
         set -e
         B="https://gitlab.torproject.org/tpo/core/tor/-/raw/main/src/config"
-        echo "Downloading Tor geoip files..."
-        curl -fSL "$$B/geoip"  -o /geoip/geoip.tmp  && mv /geoip/geoip.tmp  /geoip/geoip
-        curl -fSL "$$B/geoip6" -o /geoip/geoip6.tmp && mv /geoip/geoip6.tmp /geoip/geoip6
+        echo "Checking Tor geoip files..."
+        # -z: conditional GET. Unchanged upstream means a 304 and no transfer,
+        # and curl leaves the existing file alone. These are 25 MB together.
+        curl -fsSL -z /geoip/geoip  -o /geoip/geoip.new  "$$B/geoip"  || true
+        curl -fsSL -z /geoip/geoip6 -o /geoip/geoip6.new "$$B/geoip6" || true
+        [ -s /geoip/geoip.new  ] && mv /geoip/geoip.new  /geoip/geoip  || rm -f /geoip/geoip.new
+        [ -s /geoip/geoip6.new ] && mv /geoip/geoip6.new /geoip/geoip6 || rm -f /geoip/geoip6.new
         [ -s /geoip/geoip ] && [ -s /geoip/geoip6 ] || { echo "Tor geoip download failed"; exit 1; }
         echo "Tor geoip ready: $$(wc -l < /geoip/geoip) v4 + $$(wc -l < /geoip/geoip6) v6 ranges"
     volumes:

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -244,27 +244,32 @@ cmd_build() {
 # Cache only, never images (they back the running stack and any rollback).
 MOAV_BUILD_CACHE_KEEP="${MOAV_BUILD_CACHE_KEEP:-}"
 
-# A fixed cap is wrong on a small VPS. Measured on a 24 GB box: 4.9 GB of build
-# cache with 3.8 GB free, i.e. the cache was the single largest thing on a disk
-# at 84%. Keep at most a quarter of what the cache could grow into, floored so a
-# rebuild still has something to reuse, and capped at the old 4 GB.
+# Sized to hold the whole stack's layers: MoaV's in-use images total ~1.9 GB on a
+# full install and their cache is the same order, so 4 GB keeps every rebuild
+# warm. It only shrinks when the disk is genuinely tight -- never more than half
+# of the space the cache could occupy -- so a small VPS gives ground instead of
+# filling up. Measured case: 24 GB box at 82%, 4.3 GB free plus 4.0 GB cache, so
+# the cap stays 4 GB; the same box with 1 GB free would drop to 2.5 GB.
 default_cache_keep() {
-    local free_kb cache_kb budget_mb
-    free_kb=$(df -Pk / 2>/dev/null | awk 'NR==2 {print $4}')
-    [[ "$free_kb" =~ ^[0-9]+$ ]] || { echo "4GB"; return; }
-    cache_kb=$(docker system df --format '{{.Type}}\t{{.Size}}' 2>/dev/null \
-        | awk -F'\t' '/Build Cache/ {print $2}' \
-        | awk '/GB/{printf "%d", $1*1048576} /MB/{printf "%d", $1*1024}')
-    [[ "$cache_kb" =~ ^[0-9]+$ ]] || cache_kb=0
-    budget_mb=$(( (free_kb + cache_kb) / 1024 / 4 ))
-    (( budget_mb < 512 ))  && budget_mb=512
-    (( budget_mb > 4096 )) && budget_mb=4096
-    echo "${budget_mb}MB"
+    local free_mb cache_mb keep
+    free_mb=$(df -Pm / 2>/dev/null | awk 'NR==2 {print $4}')
+    [[ "$free_mb" =~ ^[0-9]+$ ]] || { echo 4096; return; }
+    # Count the existing cache as available: it is what we are about to reclaim,
+    # so without it the cap would ratchet down every run.
+    cache_mb=$(docker system df 2>/dev/null | awk '/^Build Cache/ {
+        v = $(NF-1); u = $(NF-1);
+        sub(/[A-Za-z]+$/, "", v);
+        if (u ~ /GB/) printf "%d", v * 1024; else if (u ~ /MB/) printf "%d", v; else print 0 }')
+    [[ "$cache_mb" =~ ^[0-9]+$ ]] || cache_mb=0
+    keep=$(( (free_mb + cache_mb) / 2 ))
+    (( keep > 4096 )) && keep=4096
+    (( keep < 1024 )) && keep=1024
+    echo "$keep"
 }
 
 prune_build_cache() {
     command -v docker >/dev/null 2>&1 || return 0
-    [[ -n "$MOAV_BUILD_CACHE_KEEP" ]] || MOAV_BUILD_CACHE_KEEP="$(default_cache_keep)"
+    [[ -n "$MOAV_BUILD_CACHE_KEEP" ]] || MOAV_BUILD_CACHE_KEEP="$(default_cache_keep)MB"
     # --keep-storage caps retained cache (Docker 18.09+; a deprecation alias for
     # --reserved-space on 27+, still honored). Fall back to an age filter on the
     # rare daemon that rejects it, still preserving recent layers.

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -242,14 +242,34 @@ cmd_build() {
 # keep the most-recently-used ~4 GB and evict the older overflow. So a normal
 # rebuild keeps its warm cache; only unbounded accumulation is trimmed.
 # Cache only, never images (they back the running stack and any rollback).
-MOAV_BUILD_CACHE_KEEP="${MOAV_BUILD_CACHE_KEEP:-4GB}"
+MOAV_BUILD_CACHE_KEEP="${MOAV_BUILD_CACHE_KEEP:-}"
+
+# A fixed cap is wrong on a small VPS. Measured on a 24 GB box: 4.9 GB of build
+# cache with 3.8 GB free, i.e. the cache was the single largest thing on a disk
+# at 84%. Keep at most a quarter of what the cache could grow into, floored so a
+# rebuild still has something to reuse, and capped at the old 4 GB.
+default_cache_keep() {
+    local free_kb cache_kb budget_mb
+    free_kb=$(df -Pk / 2>/dev/null | awk 'NR==2 {print $4}')
+    [[ "$free_kb" =~ ^[0-9]+$ ]] || { echo "4GB"; return; }
+    cache_kb=$(docker system df --format '{{.Type}}\t{{.Size}}' 2>/dev/null \
+        | awk -F'\t' '/Build Cache/ {print $2}' \
+        | awk '/GB/{printf "%d", $1*1048576} /MB/{printf "%d", $1*1024}')
+    [[ "$cache_kb" =~ ^[0-9]+$ ]] || cache_kb=0
+    budget_mb=$(( (free_kb + cache_kb) / 1024 / 4 ))
+    (( budget_mb < 512 ))  && budget_mb=512
+    (( budget_mb > 4096 )) && budget_mb=4096
+    echo "${budget_mb}MB"
+}
+
 prune_build_cache() {
     command -v docker >/dev/null 2>&1 || return 0
+    [[ -n "$MOAV_BUILD_CACHE_KEEP" ]] || MOAV_BUILD_CACHE_KEEP="$(default_cache_keep)"
     # --keep-storage caps retained cache (Docker 18.09+; a deprecation alias for
     # --reserved-space on 27+, still honored). Fall back to an age filter on the
     # rare daemon that rejects it, still preserving recent layers.
     if docker builder prune -f --keep-storage "$MOAV_BUILD_CACHE_KEEP" >/dev/null 2>&1; then
-        info "Capped build cache at ~${MOAV_BUILD_CACHE_KEEP} (recent layers kept for fast rebuilds)"
+        info "Capped build cache at ~${MOAV_BUILD_CACHE_KEEP} (least-recently-used layers evicted first)"
     elif docker builder prune -f --filter until=336h >/dev/null 2>&1; then
         info "Pruned build cache older than 14 days (recent layers kept)"
     fi

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -107,6 +107,14 @@ show_status() {
     # Track which services we've displayed
     declare -A displayed_services
 
+    # One-shot jobs that populate a volume and exit. They are plumbing, not
+    # services: showing them as "exited" in a health table reads as a fault.
+    local status_hide=" geoip-updater tor-geoip-updater bootstrap "
+    # Shown, but last: certbot legitimately exits after issuing, so it sorts
+    # below the things that are supposed to be running.
+    local status_defer=" certbot "
+    local -a deferred_rows=()
+
     # Handle both JSON array format and NDJSON (one object per line)
     if [[ -n "$raw_status" ]] && [[ "$raw_status" != "[]" ]]; then
         if [[ "$raw_status" == "["* ]]; then
@@ -207,10 +215,21 @@ show_status() {
                 name_color="${DIM}"
             fi
 
+            [[ "$status_hide" == *" $short_name "* ]] && continue
+
             # Note: %-14s for status to account for 3-byte Unicode symbols (●○◐) displaying as 1 char
-            printf "  ${CYAN}│${NC} ${name_color}%-20s${NC} ${CYAN}│${NC} ${status_color}%-14s${NC} ${CYAN}│${NC} %-19s ${CYAN}│${NC} %-12s ${CYAN}│${NC} %-15s ${CYAN}│${NC}\n" \
+            local row
+            printf -v row "  ${CYAN}│${NC} ${name_color}%-20s${NC} ${CYAN}│${NC} ${status_color}%-14s${NC} ${CYAN}│${NC} %-19s ${CYAN}│${NC} %-12s ${CYAN}│${NC} %-15s ${CYAN}│${NC}" \
                 "$display_name" "$status_display" "$last_run" "$uptime" "$ports"
+            if [[ "$status_defer" == *" $short_name "* ]]; then
+                deferred_rows+=("$row")
+            else
+                printf '%s\n' "$row"
+            fi
         done <<< "$json_lines"
+
+        local drow
+        for drow in ${deferred_rows+"${deferred_rows[@]}"}; do printf '%s\n' "$drow"; done
     fi
 
     # Show services that have never been started (not in docker ps -a)

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -1080,11 +1080,24 @@ restart_services() {
 # is exactly when you need to tell them apart. compose now emits plain text and
 # we colour the prefix from a 256-colour palette.
 #
-# Assigned in first-seen order rather than by hashing the name: hashing keeps a
-# colour stable between runs but collides (conduit and xray landed on the same
-# one), and distinctness is the whole point.
+# Colours are assigned by the service's position in the SORTED compose service
+# list, which is both stable between runs and collision-free -- unlike hashing
+# (conduit and xray landed on the same colour) and unlike first-seen order, which
+# is distinct within a run but reshuffles every time containers attach in a
+# different order. First-seen remains the fallback for a name compose did not
+# list (a stray container, a renamed service).
 format_log_timestamps() {
-    awk '
+    # name=index pairs from the sorted service list; awk turns the index into a
+    # palette slot. Computed once per invocation, not per line.
+    local svc_index=""
+    local _i=0 _svc
+    while IFS= read -r _svc; do
+        [[ -z "$_svc" ]] && continue
+        svc_index+="${_svc}=${_i} "
+        _i=$((_i + 1))
+    done < <(docker compose --profile all config --services 2>/dev/null | sort)
+
+    awk -v svc_index="$svc_index" '
     BEGIN {
         # 36 entries, all readable on a dark terminal. `moav start all` runs 30
         # containers, so a smaller palette wraps and collides -- a 24-entry one
@@ -1093,9 +1106,21 @@ format_log_timestamps() {
                   "82,165,178,123,197,120,171,228,209,80,105,191,168,75,186,135," \
                   "115,216,99,156", pal, ",")
         next_c = 0
+        # "name=index name=index ..." -> fixed[name] = index
+        split(svc_index, pairs, " ")
+        for (p in pairs) {
+            if (pairs[p] == "") continue
+            eq = index(pairs[p], "=")
+            if (eq > 0) fixed[substr(pairs[p], 1, eq - 1)] = substr(pairs[p], eq + 1)
+        }
     }
-    function svc_color(name) {
-        if (!(name in col)) { col[name] = pal[(next_c % n) + 1]; next_c++ }
+    function svc_color(name,   base) {
+        if (name in col) return col[name]
+        # compose appends -1/-2 for replicas; the service name is what we mapped.
+        base = name; sub(/-[0-9]+$/, "", base)
+        if (base in fixed)      col[name] = pal[(fixed[base] % n) + 1]
+        else if (name in fixed) col[name] = pal[(fixed[name] % n) + 1]
+        else { col[name] = pal[(next_c % n) + 1]; next_c++ }   # unlisted: fall back
         return col[name]
     }
     {

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -518,10 +518,8 @@ print_post_update_apply_steps() {
     fi
 
     if [[ -n "$recreate" ]]; then
-        echo -e "  ${WHITE}docker compose up -d --force-recreate ${recreate}${NC}"
-        echo -e "     ${DIM}# a bind-mounted config file changed. A single-FILE mount follows the${NC}"
-        echo -e "     ${DIM}# inode, and git replaces the file, so the container keeps reading the${NC}"
-        echo -e "     ${DIM}# old copy until it is recreated -- a restart is not enough.${NC}"
+        echo -e "  ${WHITE}cd ${SCRIPT_DIR} && docker compose up -d --force-recreate ${recreate}${NC}"
+        echo -e "     ${DIM}# a mounted config file changed; only a recreate picks it up${NC}"
         echo ""
     fi
 

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -414,10 +414,41 @@ check_source_rebuilds() {
         esac
         [[ -z "$svc" ]] && continue
         # Drop anything not in the allowlist: bind-mounted entrypoints (grafana),
-        # monitoring exporters, infra images, unknown name mappings.
+        # infra images, unknown name mappings.
         [[ "$valid" == *" $svc "* ]] || continue
+        # And drop anything no longer in compose. Deleting a service leaves its
+        # files in the diff, so the prompt would tell the operator to build a
+        # service that does not exist -- which is exactly what `moav build
+        # snowflake-exporter` did after that exporter was removed.
+        grep -qE "^  ${svc}:" "$SCRIPT_DIR/docker-compose.yml" 2>/dev/null || continue
         [[ " $queued " == *" $svc "* ]] || queued="${queued:+$queued }$svc"
     done <<< "$changed"
+
+    # Setup-profile one-shots never run on upgrade, so a volume introduced by a
+    # release stays empty. The snowflake proxy then starts with no geoip and
+    # every connection is labelled "" instead of a country.
+    if grep -q '^  tor-geoip-updater:' "$SCRIPT_DIR/docker-compose.yml" 2>/dev/null \
+       && docker volume ls --format '{{.Name}}' 2>/dev/null | grep -q 'moav_tor_geoip'; then
+        if ! docker run --rm -v moav_moav_tor_geoip:/geoip alpine \
+                 test -s /geoip/geoip 2>/dev/null; then
+            POST_UPDATE_SETUP_JOBS="tor-geoip-updater"
+        fi
+    fi
+
+    # Single-file bind mounts do not survive a git replacement: the mount follows
+    # the inode, so a running container keeps reading the old file until it is
+    # recreated. Measured on a live server -- host inode 508739 vs container
+    # 523302 -- which left prometheus on a stale scrape config after an update.
+    local recreate=""
+    while IFS= read -r f; do
+        case "$f" in
+            configs/monitoring/prometheus.yml)
+                [[ " $recreate " == *" prometheus "* ]] || recreate="${recreate:+$recreate }prometheus" ;;
+            configs/monitoring/grafana/*)
+                [[ " $recreate " == *" grafana "* ]] || recreate="${recreate:+$recreate }grafana" ;;
+        esac
+    done <<< "$changed"
+    [[ -n "$recreate" ]] && POST_UPDATE_CONFIG_RECREATE="$recreate"
 
     [[ -z "$queued" ]] && return 0
 
@@ -441,8 +472,10 @@ print_post_update_apply_steps() {
     local rebuild="${POST_UPDATE_REBUILD_SERVICES:-}"
     local templates="${POST_UPDATE_BOOTSTRAP_TEMPLATES:-}"
     local regen_bundles="${POST_UPDATE_REGEN_BUNDLES:-}"
+    local recreate="${POST_UPDATE_CONFIG_RECREATE:-}"
+    local setup_jobs="${POST_UPDATE_SETUP_JOBS:-}"
 
-    [[ -z "$rebuild" && -z "$templates" && -z "$regen_bundles" ]] && return 0
+    [[ -z "$rebuild" && -z "$templates" && -z "$regen_bundles" && -z "$recreate" && -z "$setup_jobs" ]] && return 0
 
     echo ""
     if [[ -n "$templates" ]]; then
@@ -477,6 +510,21 @@ print_post_update_apply_steps() {
     fi
     echo -e "  ${WHITE}${n}.${NC} moav start                      ${DIM}# recreate containers on the new images${NC}"
     echo ""
+    if [[ -n "$setup_jobs" ]]; then
+        echo -e "  ${WHITE}docker compose --profile setup run --rm ${setup_jobs}${NC}"
+        echo -e "     ${DIM}# a one-shot setup job added by this release has never run here,${NC}"
+        echo -e "     ${DIM}# so the volume it fills is still empty${NC}"
+        echo ""
+    fi
+
+    if [[ -n "$recreate" ]]; then
+        echo -e "  ${WHITE}docker compose up -d --force-recreate ${recreate}${NC}"
+        echo -e "     ${DIM}# a bind-mounted config file changed. A single-FILE mount follows the${NC}"
+        echo -e "     ${DIM}# inode, and git replaces the file, so the container keeps reading the${NC}"
+        echo -e "     ${DIM}# old copy until it is recreated -- a restart is not enough.${NC}"
+        echo ""
+    fi
+
     echo -e "${DIM}Note: 'moav restart' reuses the old image — use 'moav start' (docker compose up -d) to pick up rebuilt images.${NC}"
 }
 

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -508,20 +508,21 @@ print_post_update_apply_steps() {
         echo -e "  ${WHITE}${n}.${NC} moav regenerate-users           ${DIM}# refresh user bundles (guide layout changed)${NC}"
         n=$((n+1))
     fi
-    echo -e "  ${WHITE}${n}.${NC} moav start                      ${DIM}# recreate containers on the new images${NC}"
-    echo ""
+    # Everything below is a NUMBERED step. An unnumbered command after a numbered
+    # list reads as a footnote and gets skipped -- which is exactly what happened
+    # with the recreate line.
     if [[ -n "$setup_jobs" ]]; then
-        echo -e "  ${WHITE}docker compose --profile setup run --rm ${setup_jobs}${NC}"
-        echo -e "     ${DIM}# a one-shot setup job added by this release has never run here,${NC}"
-        echo -e "     ${DIM}# so the volume it fills is still empty${NC}"
-        echo ""
+        echo -e "  ${WHITE}${n}.${NC} cd ${SCRIPT_DIR} && docker compose --profile setup run --rm ${setup_jobs}"
+        echo -e "     ${DIM}# fills a volume this release added; it has never run here${NC}"
+        n=$((n+1))
     fi
-
+    echo -e "  ${WHITE}${n}.${NC} moav start                      ${DIM}# recreate containers on the new images${NC}"
+    n=$((n+1))
     if [[ -n "$recreate" ]]; then
-        echo -e "  ${WHITE}cd ${SCRIPT_DIR} && docker compose up -d --force-recreate ${recreate}${NC}"
+        echo -e "  ${WHITE}${n}.${NC} cd ${SCRIPT_DIR} && docker compose up -d --force-recreate ${recreate}"
         echo -e "     ${DIM}# a mounted config file changed; only a recreate picks it up${NC}"
-        echo ""
     fi
+    echo ""
 
     echo -e "${DIM}Note: 'moav restart' reuses the old image — use 'moav start' (docker compose up -d) to pick up rebuilt images.${NC}"
 }

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -439,6 +439,15 @@ check_source_rebuilds() {
     # the inode, so a running container keeps reading the old file until it is
     # recreated. Measured on a live server -- host inode 508739 vs container
     # 523302 -- which left prometheus on a stale scrape config after an update.
+    local compose_changed=""
+    while IFS= read -r f; do
+        case "$f" in
+            docker-compose.yml|docker-compose.*.yml|compose.yml|compose.*.yml)
+                compose_changed=1 ;;
+        esac
+    done <<< "$changed"
+    [[ -n "$compose_changed" ]] && POST_UPDATE_COMPOSE_CHANGED=1
+
     local recreate=""
     while IFS= read -r f; do
         case "$f" in
@@ -474,8 +483,10 @@ print_post_update_apply_steps() {
     local regen_bundles="${POST_UPDATE_REGEN_BUNDLES:-}"
     local recreate="${POST_UPDATE_CONFIG_RECREATE:-}"
     local setup_jobs="${POST_UPDATE_SETUP_JOBS:-}"
+    local compose_changed="${POST_UPDATE_COMPOSE_CHANGED:-}"
 
-    [[ -z "$rebuild" && -z "$templates" && -z "$regen_bundles" && -z "$recreate" && -z "$setup_jobs" ]] && return 0
+    [[ -z "$rebuild" && -z "$templates" && -z "$regen_bundles" && -z "$recreate" \
+       && -z "$setup_jobs" && -z "$compose_changed" ]] && return 0
 
     echo ""
     if [[ -n "$templates" ]]; then
@@ -516,7 +527,11 @@ print_post_update_apply_steps() {
         echo -e "     ${DIM}# fills a volume this release added; it has never run here${NC}"
         n=$((n+1))
     fi
-    echo -e "  ${WHITE}${n}.${NC} moav start                      ${DIM}# recreate containers on the new images${NC}"
+    if [[ -z "$rebuild" && -n "$compose_changed" ]]; then
+        echo -e "  ${WHITE}${n}.${NC} moav start                      ${DIM}# docker-compose.yml changed; recreates the services it touched${NC}"
+    else
+        echo -e "  ${WHITE}${n}.${NC} moav start                      ${DIM}# recreate containers on the new images${NC}"
+    fi
     n=$((n+1))
     if [[ -n "$recreate" ]]; then
         echo -e "  ${WHITE}${n}.${NC} cd ${SCRIPT_DIR} && docker compose up -d --force-recreate ${recreate}"

--- a/tests/build-cache-test.sh
+++ b/tests/build-cache-test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Regression test: the build-cache cap, exercised through prune_build_cache
+# rather than through the sizing function.
+#
+# The first version of this feature was dead code: an earlier line already set
+# MOAV_BUILD_CACHE_KEEP=4GB, so the `[[ -n ... ]] ||` guard never called the
+# sizing function. A test that called default_cache_keep directly passed anyway.
+# So this drives the real entry point and asserts what reaches `docker builder`.
+#
+# Intent of the sizing: hold the whole stack's layers when there is room (MoaV's
+# in-use images are ~1.9 GB on a full install, and their cache is the same
+# order), and only give ground when the disk is genuinely tight.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "build cache: the cap reaching docker builder prune"
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+cat > "$TMP/docker" <<'STUB'
+#!/bin/bash
+case "$*" in
+  "system df") printf 'TYPE\tTOTAL\tACTIVE\tSIZE\tRECLAIMABLE\nBuild Cache\t234\t0\t%s\t2.1GB\n' "${FAKE_CACHE:-3.9GB}" ;;
+  *"builder prune"*) echo "$*" >> "$ARGS_LOG"; exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+cat > "$TMP/df" <<'STUB'
+#!/bin/bash
+echo "Filesystem 1M-blocks Used Available Use% Mounted"
+echo "/dev/vda1 24000 19000 ${FAKE_FREE:-4300} 82% /"
+STUB
+chmod +x "$TMP/docker" "$TMP/df"
+
+cap_for() {   # <free MB> <cache size> [override] -> the MB value passed to docker
+    : > "$TMP/args"
+    (
+        PATH="$TMP:$PATH" FAKE_FREE="$1" FAKE_CACHE="$2" ARGS_LOG="$TMP/args" \
+        MOAV_BUILD_CACHE_KEEP="${3:-}" \
+        bash -c 'cd "$0"
+                 # shellcheck disable=SC1091
+                 source scripts/lib/common.sh >/dev/null 2>&1
+                 # shellcheck disable=SC1091
+                 source lib/common.sh >/dev/null 2>&1
+                 # shellcheck disable=SC1091
+                 source lib/build.sh  >/dev/null 2>&1
+                 prune_build_cache' "$ROOT" >/dev/null 2>&1
+    )
+    grep -oE 'keep-storage [0-9A-Za-z]+' "$TMP/args" | head -1 | awk '{print $2}'
+}
+
+got=$(cap_for 4300 3.9GB)
+[ "$got" = "4096MB" ] \
+    && ok "room on disk keeps the full 4 GB (the stack's layers stay warm)" \
+    || bad "with 4.3 GB free it capped at '$got', expected 4096MB — rebuilds would lose cache"
+
+got=$(cap_for 1000 1GB)
+[ "$got" = "1024MB" ] \
+    && ok "a tight disk shrinks the cap to the 1 GB floor" \
+    || bad "with 1 GB free it kept '$got' — the cache would crowd the disk"
+
+got=$(cap_for 40000 500MB)
+[ "$got" = "4096MB" ] \
+    && ok "a large disk is still capped at 4 GB" \
+    || bad "unbounded growth on a large disk: '$got'"
+
+# Idempotence: counting the existing cache as available is what stops the cap
+# ratcheting down on every run.
+a=$(cap_for 4300 3.9GB); b=$(cap_for 4300 3.9GB)
+[ "$a" = "$b" ] && ok "repeated runs converge on the same cap ($a)" \
+                || bad "the cap moved between identical runs: $a then $b"
+
+# An operator override must win outright.
+got=$(cap_for 4300 3.9GB "777MB")
+[ "$got" = "777MB" ] \
+    && ok "MOAV_BUILD_CACHE_KEEP overrides the computed value" \
+    || bad "override ignored: got '$got'"
+
+# And the sizing must actually be reached from prune_build_cache -- the exact
+# bug this file exists for.
+grep -q 'MOAV_BUILD_CACHE_KEEP="${MOAV_BUILD_CACHE_KEEP:-4GB}"' "$ROOT/lib/build.sh" \
+    && bad "a hardcoded 4GB default is back; it makes default_cache_keep unreachable" \
+    || ok "no hardcoded default shadowing the sizing function"
+
+echo ""
+echo "  passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/tests/update-rebuild-test.sh
+++ b/tests/update-rebuild-test.sh
@@ -114,6 +114,33 @@ case " $got " in
     *" prometheus "*) ok "a prometheus.yml change asks for a recreate" ;;
     *) bad "prometheus.yml changed but no recreate was suggested (got '${got:-none}') — the container keeps the old config silently" ;;
 esac
+# --- a compose change alone must still tell the operator to apply it ---------
+# It maps to no service, so the whole summary used to be skipped and the pull
+# looked like a no-op -- even though `up -d` is exactly what applies it.
+compose_flag_for() {  # <changed-paths...> -> 1 when the summary should fire
+    local tmp; tmp=$(mktemp); printf '%s\n' "$@" > "$tmp"
+    (
+        SCRIPT_DIR="$ROOT"
+        # shellcheck disable=SC1091
+        source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/common.sh"        >/dev/null 2>&1
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/update.sh"        >/dev/null 2>&1
+        git() { case " $* " in *" diff --name-only "*) cat "$tmp" ;; *) command git "$@" ;; esac; }
+        POST_UPDATE_COMPOSE_CHANGED=""
+        check_source_rebuilds "SOMECOMMIT" >/dev/null 2>&1
+        printf '%s' "${POST_UPDATE_COMPOSE_CHANGED:-}"
+    )
+    rm -f "$tmp"
+}
+[ -n "$(compose_flag_for "docker-compose.yml")" ] \
+    && ok "a docker-compose.yml change asks the operator to run moav start" \
+    || bad "a compose change printed nothing — the pull looks like a no-op"
+[ -z "$(compose_flag_for "README.md")" ] \
+    && ok "a docs change does not ask for a start" \
+    || bad "a docs change asked for a start"
+
 got=$(recreate_for "README.md")
 [ -z "$got" ] && ok "a docs change asks for no recreate" \
               || bad "a docs change suggested recreating '$got'"

--- a/tests/update-rebuild-test.sh
+++ b/tests/update-rebuild-test.sh
@@ -81,6 +81,43 @@ must_not_queue "bind-mounted lib/ change"    "lib/update.sh"
 must_not_queue "bind-mounted grafana entry"  "scripts/grafana-entrypoint.sh"
 must_not_queue "a docs change"               "README.md" "CHANGELOG.md"
 
+# A deleted service must not be suggested. Removing exporters/snowflake left its
+# files in the diff, so the prompt said `moav build snowflake-exporter` for a
+# service that no longer exists in compose.
+must_not_queue "a deleted exporter"          "exporters/snowflake/main.py"
+# ...but the mapping itself must still work for the exporters that remain.
+must_queue "a live exporter change"  singbox-exporter  "exporters/singbox/main.py"
+
+# --- bind-mounted single files need a RECREATE, not a restart ----------------
+# A single-file mount follows the inode; git replaces the file, so the container
+# reads the old copy until recreated. Measured on a live server: host inode
+# 508739 vs container 523302, leaving prometheus on a stale scrape config.
+recreate_for() {  # <changed-paths...> -> the services to recreate
+    local tmp; tmp=$(mktemp); printf '%s\n' "$@" > "$tmp"
+    (
+        SCRIPT_DIR="$ROOT"
+        # shellcheck disable=SC1091
+        source "$ROOT/scripts/lib/common.sh" >/dev/null 2>&1
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/common.sh"        >/dev/null 2>&1
+        # shellcheck disable=SC1091
+        source "$ROOT/lib/update.sh"        >/dev/null 2>&1
+        git() { case " $* " in *" diff --name-only "*) cat "$tmp" ;; *) command git "$@" ;; esac; }
+        POST_UPDATE_CONFIG_RECREATE=""
+        check_source_rebuilds "SOMECOMMIT" >/dev/null 2>&1
+        printf '%s' "${POST_UPDATE_CONFIG_RECREATE:-}"
+    )
+    rm -f "$tmp"
+}
+got=$(recreate_for "configs/monitoring/prometheus.yml")
+case " $got " in
+    *" prometheus "*) ok "a prometheus.yml change asks for a recreate" ;;
+    *) bad "prometheus.yml changed but no recreate was suggested (got '${got:-none}') — the container keeps the old config silently" ;;
+esac
+got=$(recreate_for "README.md")
+[ -z "$got" ] && ok "a docs change asks for no recreate" \
+              || bad "a docs change suggested recreating '$got'"
+
 # --- the real 2.1.0 range, if the tag is present -----------------------------
 # The guarantee that matters is not synthetic: upgrading from 2.0.1 must prompt
 # the admin rebuild, or the dashboard locks out.


### PR DESCRIPTION
Everything here came from upgrading a live server to the merged #295 and watching what actually happened. **None of it is reachable from CI** — every item needed a running, upgraded machine.

Seven commits across five areas.

---

## 1. `moav update` gave the wrong next step, or none at all

Three separate failures in the apply summary:

**A `docker-compose.yml` change printed nothing.** It maps to no service, so the summary returned early and a pull that changed compose read as a no-op — even though `moav start` is exactly what applies it (`up -d` recreates the services whose definition moved).

**It named a service that does not exist.** Deleting `exporters/snowflake` left its files in the diff:

```
1. moav build snowflake snowflake-exporter
...
no such service: snowflake-exporter
```

**The recreate line was an unnumbered footnote** and got skipped in practice. Every step is numbered now, and each carries `cd <install dir>` so a raw `docker compose` cannot run against the wrong project.

Also surfaced: a `setup`-profile job added by a release never runs on upgrade, which is why the proxy started with `Error loading geoip db for country based metrics`.

## 2. Why the dashboard showed No Data after a correct upgrade

`prometheus.yml` is mounted as a single **file**, and a file bind mount follows the **inode**. `git` replaces the file on update, so the running container keeps reading the old copy:

```
host file inode: 508739
container inode: 523302
```

Prometheus was still scraping `snowflake-exporter:8080` — the exporter #295 deleted — with the new job absent from its config. **`moav restart` cannot fix this**: same container, same stale mount. The summary now prints the recreate whenever a mounted config changed.

## 3. Grafana: the Snowflake dashboard, finished

- **New panels** — rendezvous success rate, countries reached, proxy uptime, failed connections per hour (in red), and traffic stats that follow the time picker beside the cumulative totals.
- **The country bar chart was unreadable.** A `barchart` fed `format: time_series` plots the *timestamp* on the x axis, so it drew three unlabelled bars against "2026". Replaced with a donut for share and a stacked series for who-over-time — two different questions that were never going to fit one panel.
- **Explicit grid layout, asserted when generated:** every row fills exactly 24 columns, starts where the previous row ended, and has a single height. Adding a panel without placing it now fails loudly instead of drifting to the bottom, which is how the gaps appeared.
- **"Users Download" was a misleading title** and got read exactly that way — it is a raw counter and never follows the time picker. Renamed to Total Downloaded / Total Uploaded, with the range-scoped pair beside it and the distinction in the description.

The success gauge has **no red band** on purpose: a large share of rendezvous failures is normal and outside the operator's control — the client's NAT and censorship decide it, as the upstream metric's own help text says. Colouring it as a fault would train operators to ignore the panel.

Two query traps found while building it, both now encoded: `process_start_time_seconds` needs `{job="snowflake-proxy"}` or it silently reports **Prometheus's own** uptime, and success rate needs `sum()` on both sides — `sum(a) + b` returns no data because the label sets do not match.

## 4. GeoIP was re-downloaded on every `moav start`

`geoip-updater` has **no `profiles` key**, so compose starts it on every `up` — 3.9 MB each time, seven times in one evening on a test box. The db-ip URL is monthly, so the month is an exact cache key:

```
GeoIP database updated successfully (2026-08)
GeoIP database already current (2026-08), skipping download
```

It writes through a temp file, so an interrupted download cannot leave a truncated database. `tor-geoip-updater` uses a conditional GET instead — an unchanged upstream is a 304 with no transfer, which matters more there because those two files are 25 MB.

## 5. Build cache, logs, and status

**The build cache cap ignored the disk.** Measured on a 24 GB box: **4.9 GB of cache with 3.8 GB free**, on a disk at 84% — the cache was the largest single thing on it. The cap was a flat 4 GB regardless of machine. It now scales to a quarter of what the cache could grow into, floored at 512 MB and still capped at 4 GB (2213 MB on that box). Eviction stays least-recently-used, which is what keeps commonly rebuilt layers warm.

**Log colours reshuffled between runs.** They were assigned in first-seen order — distinct within a run, but every container changed colour whenever they attached in a different order. Now keyed to the service's position in the *sorted* compose service list: stable across runs and across arrival order, and collision-free unlike hashing (which had put conduit and xray on the same colour). Verified with the same three services in two different arrival orders.

**`moav status` listed one-shot plumbing as failures.** `geoip-updater`, `tor-geoip-updater` and `bootstrap` fill a volume and exit, so "exited" read as a fault in a health table — they are hidden. `certbot` legitimately exits after issuing, so it sorts last instead of sitting between running services.

---

## Tests

`tests/update-rebuild-test.sh` — 17 checks. A deleted exporter queues nothing, a live exporter still does, `prometheus.yml` asks for a recreate, `docker-compose.yml` asks for a start, and a docs change asks for neither.

## Commit map

| commit | area |
|---|---|
| `ad47b97` | rebuild list, config recreate, setup jobs, status list, country panel |
| `f9eda62` | dashboard grid, range-scoped traffic, red failures |
| `5e24193` | countries reached, success rate, uptime |
| `eb832ab` | shorter recreate hint with `cd` |
| `7b25303` | drop "(selected range)" from titles |
| `ae67763` | numbered steps, geoip caching, disk-aware build cache, stable log colours |
| `ef01ba4` | a compose change asks for `moav start` |

`CHANGELOG.md` carries all of it under Unreleased, alongside the #295-era entries, since they ship together as **2.2.0**.
