### PR TITLE
Update Conduit dashboard: Window Max/Session High panels, peak-time annotation, decluttered region graph

### DIFF
--- a/configs/monitoring/grafana/provisioning/dashboards/conduit.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/conduit.json
@@ -27,7 +27,7 @@
         },
         "hide": false,
         "iconColor": "orange",
-        "name": "Window Max (Connected)",
+        "name": "Mark Peak on Client Connections Graph",
         "target": {
           "expr": "conduit_connected_clients == max_over_time(conduit_connected_clients[$__range:$__interval] @ end())",
           "interval": "15s",
@@ -520,7 +520,7 @@
           "refId": "B"
         }
       ],
-      "title": "Window Max",
+      "title": "Window Max - ${client_state_total:text}",
       "type": "stat"
     },
     {
@@ -1008,7 +1008,7 @@
           "refId": "A"
         }
       ],
-      "title": "Session High",
+      "title": "Session High - ${client_state_session_high:text}",
       "type": "stat"
     },
     {
@@ -8403,7 +8403,7 @@
       {
         "current": {},
         "includeAll": false,
-        "label": "Client State",
+        "label": "Client State (Top 5 Regions)",
         "name": "client_state",
         "options": [],
         "query": "Connected : conduit_region_connected_clients,Connecting : conduit_region_connecting_clients",
@@ -8413,7 +8413,7 @@
       {
         "current": {},
         "includeAll": false,
-        "label": "Client State (Total)",
+        "label": "Client State (Window Max)",
         "name": "client_state_total",
         "options": [],
         "query": "Connected : conduit_connected_clients,Connecting : conduit_connecting_clients",

--- a/configs/monitoring/grafana/provisioning/dashboards/conduit.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/conduit.json
@@ -1,439 +1,7288 @@
 {
-  "annotations": { "list": [] },
-  "editable": false,
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "yellow", "value": 50 },
-            { "color": "orange", "value": 100 }
-          ]}
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 0 },
-      "id": 1,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_connected_clients)", "refId": "A" }
-      ],
-      "title": "Connected",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "blue", "value": null }
-          ]}
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 0 },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_connecting_clients)", "refId": "A" }
-      ],
-      "title": "Connecting",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "orange", "value": null }
-          ]}
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 0 },
-      "id": 10,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(max_over_time(conduit_connected_clients[$__range])) + sum(max_over_time(conduit_connecting_clients[$__range]))", "refId": "A" }
-      ],
-      "title": "Peak Clients",
-      "description": "Maximum concurrent clients (connected + connecting) in the selected time range",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 0 },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_bytes_downloaded)", "refId": "A" }
-      ],
-      "title": "Total Download",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 0 },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_bytes_uploaded)", "refId": "A" }
-      ],
-      "title": "Total Upload",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "red", "text": "Offline" }, "1": { "color": "green", "text": "Live" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Offline"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Live"
+                }
+              },
+              "type": "value"
+            }
           ],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "red", "value": null },
-            { "color": "green", "value": 1 }
-          ]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 0 },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
       "id": 5,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "conduit_is_live", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_is_live",
+          "refId": "A"
+        }
       ],
       "title": "Status",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
-          "unit": "binBps"
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 18, "y": 0 },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 3,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_downloaded)",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Download",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 7,
+        "y": 0
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_downloaded_lifetime)",
+          "legendFormat": "Lifetime Download",
+          "refId": "A"
+        }
+      ],
+      "title": "Lifetime Download",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 11,
+        "y": 0
+      },
       "id": 6,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(conduit_bytes_downloaded[5m])) + sum(rate(conduit_bytes_uploaded[5m]))", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_downloaded[5m])) + sum(rate(conduit_bytes_uploaded[5m]))",
+          "refId": "A"
+        }
       ],
       "title": "Current Rate",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "purple", "value": null }
-          ]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 21, "y": 0 },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connecting_clients)",
+          "refId": "A"
+        }
+      ],
+      "title": "Connecting",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 3
+      },
       "id": 11,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "conduit_max_common_clients", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_max_common_clients",
+          "refId": "A"
+        }
       ],
       "title": "Max Clients",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
-            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
-            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+          "color": {
+            "mode": "thresholds"
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 3,
+        "y": 3
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_uploaded)",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Upload",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 7,
+        "y": 3
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_uploaded_lifetime)",
+          "legendFormat": "Lifetime Upload",
+          "refId": "A"
+        }
+      ],
+      "title": "Lifetime Upload",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "orange",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 3
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connected_clients)",
+          "refId": "A"
+        }
+      ],
+      "title": "Connected",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "id": 7,
       "options": {
-        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_connected_clients)", "legendFormat": "Connected", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_connecting_clients)", "legendFormat": "Connecting", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connected_clients)",
+          "legendFormat": "Connected",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connecting_clients)",
+          "legendFormat": "Connecting",
+          "refId": "B"
+        }
       ],
       "title": "Client Connections",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
-            "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
-            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
-            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
-          "unit": "binBps"
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
       "id": 8,
       "options": {
-        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(conduit_bytes_downloaded[5m]))", "legendFormat": "Download", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(rate(conduit_bytes_uploaded[5m]))", "legendFormat": "Upload", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_downloaded[5m]))",
+          "legendFormat": "Download",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_uploaded[5m]))",
+          "legendFormat": "Upload",
+          "refId": "B"
+        }
       ],
       "title": "Bandwidth Rate",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
-            "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
-            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 30, "gradientMode": "opacity",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
-            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
-            "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" }
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
-          "unit": "bytes"
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
       "id": 9,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_bytes_downloaded)", "legendFormat": "Download", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(conduit_bytes_uploaded)", "legendFormat": "Upload", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_downloaded)",
+          "legendFormat": "Download",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_uploaded)",
+          "legendFormat": "Upload",
+          "refId": "B"
+        }
       ],
       "title": "Total Bandwidth Over Time",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
-            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
-            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+          "color": {
+            "mode": "palette-classic"
           },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "AD": {
+                  "index": 0,
+                  "text": "AD: Andorra"
+                },
+                "AE": {
+                  "index": 1,
+                  "text": "AE: United Arab Emirates"
+                },
+                "AF": {
+                  "index": 2,
+                  "text": "AF: Afghanistan"
+                },
+                "AG": {
+                  "index": 3,
+                  "text": "AG: Antigua and Barbuda"
+                },
+                "AI": {
+                  "index": 4,
+                  "text": "AI: Anguilla"
+                },
+                "AL": {
+                  "index": 5,
+                  "text": "AL: Albania"
+                },
+                "AM": {
+                  "index": 6,
+                  "text": "AM: Armenia"
+                },
+                "AO": {
+                  "index": 7,
+                  "text": "AO: Angola"
+                },
+                "AQ": {
+                  "index": 8,
+                  "text": "AQ: Antarctica"
+                },
+                "AR": {
+                  "index": 9,
+                  "text": "AR: Argentina"
+                },
+                "AS": {
+                  "index": 10,
+                  "text": "AS: American Samoa"
+                },
+                "AT": {
+                  "index": 11,
+                  "text": "AT: Austria"
+                },
+                "AU": {
+                  "index": 12,
+                  "text": "AU: Australia"
+                },
+                "AW": {
+                  "index": 13,
+                  "text": "AW: Aruba"
+                },
+                "AX": {
+                  "index": 14,
+                  "text": "AX: \u00c5land Islands"
+                },
+                "AZ": {
+                  "index": 15,
+                  "text": "AZ: Azerbaijan"
+                },
+                "BA": {
+                  "index": 16,
+                  "text": "BA: Bosnia and Herzegovina"
+                },
+                "BB": {
+                  "index": 17,
+                  "text": "BB: Barbados"
+                },
+                "BD": {
+                  "index": 18,
+                  "text": "BD: Bangladesh"
+                },
+                "BE": {
+                  "index": 19,
+                  "text": "BE: Belgium"
+                },
+                "BF": {
+                  "index": 20,
+                  "text": "BF: Burkina Faso"
+                },
+                "BG": {
+                  "index": 21,
+                  "text": "BG: Bulgaria"
+                },
+                "BH": {
+                  "index": 22,
+                  "text": "BH: Bahrain"
+                },
+                "BI": {
+                  "index": 23,
+                  "text": "BI: Burundi"
+                },
+                "BJ": {
+                  "index": 24,
+                  "text": "BJ: Benin"
+                },
+                "BL": {
+                  "index": 25,
+                  "text": "BL: Saint Barth\u00e9lemy"
+                },
+                "BM": {
+                  "index": 26,
+                  "text": "BM: Bermuda"
+                },
+                "BN": {
+                  "index": 27,
+                  "text": "BN: Brunei Darussalam"
+                },
+                "BO": {
+                  "index": 28,
+                  "text": "BO: Bolivia, Plurinational State of"
+                },
+                "BQ": {
+                  "index": 29,
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba"
+                },
+                "BR": {
+                  "index": 30,
+                  "text": "BR: Brazil"
+                },
+                "BS": {
+                  "index": 31,
+                  "text": "BS: Bahamas"
+                },
+                "BT": {
+                  "index": 32,
+                  "text": "BT: Bhutan"
+                },
+                "BV": {
+                  "index": 33,
+                  "text": "BV: Bouvet Island"
+                },
+                "BW": {
+                  "index": 34,
+                  "text": "BW: Botswana"
+                },
+                "BY": {
+                  "index": 35,
+                  "text": "BY: Belarus"
+                },
+                "BZ": {
+                  "index": 36,
+                  "text": "BZ: Belize"
+                },
+                "CA": {
+                  "index": 37,
+                  "text": "CA: Canada"
+                },
+                "CC": {
+                  "index": 38,
+                  "text": "CC: Cocos (Keeling) Islands"
+                },
+                "CD": {
+                  "index": 39,
+                  "text": "CD: Congo, The Democratic Republic of the"
+                },
+                "CF": {
+                  "index": 40,
+                  "text": "CF: Central African Republic"
+                },
+                "CG": {
+                  "index": 41,
+                  "text": "CG: Congo"
+                },
+                "CH": {
+                  "index": 42,
+                  "text": "CH: Switzerland"
+                },
+                "CI": {
+                  "index": 43,
+                  "text": "CI: C\u00f4te d'Ivoire"
+                },
+                "CK": {
+                  "index": 44,
+                  "text": "CK: Cook Islands"
+                },
+                "CL": {
+                  "index": 45,
+                  "text": "CL: Chile"
+                },
+                "CM": {
+                  "index": 46,
+                  "text": "CM: Cameroon"
+                },
+                "CN": {
+                  "index": 47,
+                  "text": "CN: China"
+                },
+                "CO": {
+                  "index": 48,
+                  "text": "CO: Colombia"
+                },
+                "CR": {
+                  "index": 49,
+                  "text": "CR: Costa Rica"
+                },
+                "CU": {
+                  "index": 50,
+                  "text": "CU: Cuba"
+                },
+                "CV": {
+                  "index": 51,
+                  "text": "CV: Cabo Verde"
+                },
+                "CW": {
+                  "index": 52,
+                  "text": "CW: Cura\u00e7ao"
+                },
+                "CX": {
+                  "index": 53,
+                  "text": "CX: Christmas Island"
+                },
+                "CY": {
+                  "index": 54,
+                  "text": "CY: Cyprus"
+                },
+                "CZ": {
+                  "index": 55,
+                  "text": "CZ: Czechia"
+                },
+                "DE": {
+                  "index": 56,
+                  "text": "DE: Germany"
+                },
+                "DJ": {
+                  "index": 57,
+                  "text": "DJ: Djibouti"
+                },
+                "DK": {
+                  "index": 58,
+                  "text": "DK: Denmark"
+                },
+                "DM": {
+                  "index": 59,
+                  "text": "DM: Dominica"
+                },
+                "DO": {
+                  "index": 60,
+                  "text": "DO: Dominican Republic"
+                },
+                "DZ": {
+                  "index": 61,
+                  "text": "DZ: Algeria"
+                },
+                "EC": {
+                  "index": 62,
+                  "text": "EC: Ecuador"
+                },
+                "EE": {
+                  "index": 63,
+                  "text": "EE: Estonia"
+                },
+                "EG": {
+                  "index": 64,
+                  "text": "EG: Egypt"
+                },
+                "EH": {
+                  "index": 65,
+                  "text": "EH: Western Sahara"
+                },
+                "ER": {
+                  "index": 66,
+                  "text": "ER: Eritrea"
+                },
+                "ES": {
+                  "index": 67,
+                  "text": "ES: Spain"
+                },
+                "ET": {
+                  "index": 68,
+                  "text": "ET: Ethiopia"
+                },
+                "FI": {
+                  "index": 69,
+                  "text": "FI: Finland"
+                },
+                "FJ": {
+                  "index": 70,
+                  "text": "FJ: Fiji"
+                },
+                "FK": {
+                  "index": 71,
+                  "text": "FK: Falkland Islands (Malvinas)"
+                },
+                "FM": {
+                  "index": 72,
+                  "text": "FM: Micronesia, Federated States of"
+                },
+                "FO": {
+                  "index": 73,
+                  "text": "FO: Faroe Islands"
+                },
+                "FR": {
+                  "index": 74,
+                  "text": "FR: France"
+                },
+                "GA": {
+                  "index": 75,
+                  "text": "GA: Gabon"
+                },
+                "GB": {
+                  "index": 76,
+                  "text": "GB: United Kingdom"
+                },
+                "GD": {
+                  "index": 77,
+                  "text": "GD: Grenada"
+                },
+                "GE": {
+                  "index": 78,
+                  "text": "GE: Georgia"
+                },
+                "GF": {
+                  "index": 79,
+                  "text": "GF: French Guiana"
+                },
+                "GG": {
+                  "index": 80,
+                  "text": "GG: Guernsey"
+                },
+                "GH": {
+                  "index": 81,
+                  "text": "GH: Ghana"
+                },
+                "GI": {
+                  "index": 82,
+                  "text": "GI: Gibraltar"
+                },
+                "GL": {
+                  "index": 83,
+                  "text": "GL: Greenland"
+                },
+                "GM": {
+                  "index": 84,
+                  "text": "GM: Gambia"
+                },
+                "GN": {
+                  "index": 85,
+                  "text": "GN: Guinea"
+                },
+                "GP": {
+                  "index": 86,
+                  "text": "GP: Guadeloupe"
+                },
+                "GQ": {
+                  "index": 87,
+                  "text": "GQ: Equatorial Guinea"
+                },
+                "GR": {
+                  "index": 88,
+                  "text": "GR: Greece"
+                },
+                "GS": {
+                  "index": 89,
+                  "text": "GS: South Georgia and the South Sandwich Islands"
+                },
+                "GT": {
+                  "index": 90,
+                  "text": "GT: Guatemala"
+                },
+                "GU": {
+                  "index": 91,
+                  "text": "GU: Guam"
+                },
+                "GW": {
+                  "index": 92,
+                  "text": "GW: Guinea-Bissau"
+                },
+                "GY": {
+                  "index": 93,
+                  "text": "GY: Guyana"
+                },
+                "HK": {
+                  "index": 94,
+                  "text": "HK: Hong Kong"
+                },
+                "HM": {
+                  "index": 95,
+                  "text": "HM: Heard Island and McDonald Islands"
+                },
+                "HN": {
+                  "index": 96,
+                  "text": "HN: Honduras"
+                },
+                "HR": {
+                  "index": 97,
+                  "text": "HR: Croatia"
+                },
+                "HT": {
+                  "index": 98,
+                  "text": "HT: Haiti"
+                },
+                "HU": {
+                  "index": 99,
+                  "text": "HU: Hungary"
+                },
+                "ID": {
+                  "index": 100,
+                  "text": "ID: Indonesia"
+                },
+                "IE": {
+                  "index": 101,
+                  "text": "IE: Ireland"
+                },
+                "IL": {
+                  "index": 102,
+                  "text": "IL: Israel"
+                },
+                "IM": {
+                  "index": 103,
+                  "text": "IM: Isle of Man"
+                },
+                "IN": {
+                  "index": 104,
+                  "text": "IN: India"
+                },
+                "IO": {
+                  "index": 105,
+                  "text": "IO: British Indian Ocean Territory"
+                },
+                "IQ": {
+                  "index": 106,
+                  "text": "IQ: Iraq"
+                },
+                "IR": {
+                  "index": 107,
+                  "text": "IR: Iran, Islamic Republic of"
+                },
+                "IS": {
+                  "index": 108,
+                  "text": "IS: Iceland"
+                },
+                "IT": {
+                  "index": 109,
+                  "text": "IT: Italy"
+                },
+                "JE": {
+                  "index": 110,
+                  "text": "JE: Jersey"
+                },
+                "JM": {
+                  "index": 111,
+                  "text": "JM: Jamaica"
+                },
+                "JO": {
+                  "index": 112,
+                  "text": "JO: Jordan"
+                },
+                "JP": {
+                  "index": 113,
+                  "text": "JP: Japan"
+                },
+                "KE": {
+                  "index": 114,
+                  "text": "KE: Kenya"
+                },
+                "KG": {
+                  "index": 115,
+                  "text": "KG: Kyrgyzstan"
+                },
+                "KH": {
+                  "index": 116,
+                  "text": "KH: Cambodia"
+                },
+                "KI": {
+                  "index": 117,
+                  "text": "KI: Kiribati"
+                },
+                "KM": {
+                  "index": 118,
+                  "text": "KM: Comoros"
+                },
+                "KN": {
+                  "index": 119,
+                  "text": "KN: Saint Kitts and Nevis"
+                },
+                "KP": {
+                  "index": 120,
+                  "text": "KP: Korea, Democratic People's Republic of"
+                },
+                "KR": {
+                  "index": 121,
+                  "text": "KR: Korea, Republic of"
+                },
+                "KW": {
+                  "index": 122,
+                  "text": "KW: Kuwait"
+                },
+                "KY": {
+                  "index": 123,
+                  "text": "KY: Cayman Islands"
+                },
+                "KZ": {
+                  "index": 124,
+                  "text": "KZ: Kazakhstan"
+                },
+                "LA": {
+                  "index": 125,
+                  "text": "LA: Lao People's Democratic Republic"
+                },
+                "LB": {
+                  "index": 126,
+                  "text": "LB: Lebanon"
+                },
+                "LC": {
+                  "index": 127,
+                  "text": "LC: Saint Lucia"
+                },
+                "LI": {
+                  "index": 128,
+                  "text": "LI: Liechtenstein"
+                },
+                "LK": {
+                  "index": 129,
+                  "text": "LK: Sri Lanka"
+                },
+                "LR": {
+                  "index": 130,
+                  "text": "LR: Liberia"
+                },
+                "LS": {
+                  "index": 131,
+                  "text": "LS: Lesotho"
+                },
+                "LT": {
+                  "index": 132,
+                  "text": "LT: Lithuania"
+                },
+                "LU": {
+                  "index": 133,
+                  "text": "LU: Luxembourg"
+                },
+                "LV": {
+                  "index": 134,
+                  "text": "LV: Latvia"
+                },
+                "LY": {
+                  "index": 135,
+                  "text": "LY: Libya"
+                },
+                "MA": {
+                  "index": 136,
+                  "text": "MA: Morocco"
+                },
+                "MC": {
+                  "index": 137,
+                  "text": "MC: Monaco"
+                },
+                "MD": {
+                  "index": 138,
+                  "text": "MD: Moldova, Republic of"
+                },
+                "ME": {
+                  "index": 139,
+                  "text": "ME: Montenegro"
+                },
+                "MF": {
+                  "index": 140,
+                  "text": "MF: Saint Martin (French part)"
+                },
+                "MG": {
+                  "index": 141,
+                  "text": "MG: Madagascar"
+                },
+                "MH": {
+                  "index": 142,
+                  "text": "MH: Marshall Islands"
+                },
+                "MK": {
+                  "index": 143,
+                  "text": "MK: North Macedonia"
+                },
+                "ML": {
+                  "index": 144,
+                  "text": "ML: Mali"
+                },
+                "MM": {
+                  "index": 145,
+                  "text": "MM: Myanmar"
+                },
+                "MN": {
+                  "index": 146,
+                  "text": "MN: Mongolia"
+                },
+                "MO": {
+                  "index": 147,
+                  "text": "MO: Macao"
+                },
+                "MP": {
+                  "index": 148,
+                  "text": "MP: Northern Mariana Islands"
+                },
+                "MQ": {
+                  "index": 149,
+                  "text": "MQ: Martinique"
+                },
+                "MR": {
+                  "index": 150,
+                  "text": "MR: Mauritania"
+                },
+                "MS": {
+                  "index": 151,
+                  "text": "MS: Montserrat"
+                },
+                "MT": {
+                  "index": 152,
+                  "text": "MT: Malta"
+                },
+                "MU": {
+                  "index": 153,
+                  "text": "MU: Mauritius"
+                },
+                "MV": {
+                  "index": 154,
+                  "text": "MV: Maldives"
+                },
+                "MW": {
+                  "index": 155,
+                  "text": "MW: Malawi"
+                },
+                "MX": {
+                  "index": 156,
+                  "text": "MX: Mexico"
+                },
+                "MY": {
+                  "index": 157,
+                  "text": "MY: Malaysia"
+                },
+                "MZ": {
+                  "index": 158,
+                  "text": "MZ: Mozambique"
+                },
+                "NA": {
+                  "index": 159,
+                  "text": "NA: Namibia"
+                },
+                "NC": {
+                  "index": 160,
+                  "text": "NC: New Caledonia"
+                },
+                "NE": {
+                  "index": 161,
+                  "text": "NE: Niger"
+                },
+                "NF": {
+                  "index": 162,
+                  "text": "NF: Norfolk Island"
+                },
+                "NG": {
+                  "index": 163,
+                  "text": "NG: Nigeria"
+                },
+                "NI": {
+                  "index": 164,
+                  "text": "NI: Nicaragua"
+                },
+                "NL": {
+                  "index": 165,
+                  "text": "NL: Netherlands"
+                },
+                "NO": {
+                  "index": 166,
+                  "text": "NO: Norway"
+                },
+                "NP": {
+                  "index": 167,
+                  "text": "NP: Nepal"
+                },
+                "NR": {
+                  "index": 168,
+                  "text": "NR: Nauru"
+                },
+                "NU": {
+                  "index": 169,
+                  "text": "NU: Niue"
+                },
+                "NZ": {
+                  "index": 170,
+                  "text": "NZ: New Zealand"
+                },
+                "OM": {
+                  "index": 171,
+                  "text": "OM: Oman"
+                },
+                "PA": {
+                  "index": 172,
+                  "text": "PA: Panama"
+                },
+                "PE": {
+                  "index": 173,
+                  "text": "PE: Peru"
+                },
+                "PF": {
+                  "index": 174,
+                  "text": "PF: French Polynesia"
+                },
+                "PG": {
+                  "index": 175,
+                  "text": "PG: Papua New Guinea"
+                },
+                "PH": {
+                  "index": 176,
+                  "text": "PH: Philippines"
+                },
+                "PK": {
+                  "index": 177,
+                  "text": "PK: Pakistan"
+                },
+                "PL": {
+                  "index": 178,
+                  "text": "PL: Poland"
+                },
+                "PM": {
+                  "index": 179,
+                  "text": "PM: Saint Pierre and Miquelon"
+                },
+                "PN": {
+                  "index": 180,
+                  "text": "PN: Pitcairn"
+                },
+                "PR": {
+                  "index": 181,
+                  "text": "PR: Puerto Rico"
+                },
+                "PS": {
+                  "index": 182,
+                  "text": "PS: Palestine, State of"
+                },
+                "PT": {
+                  "index": 183,
+                  "text": "PT: Portugal"
+                },
+                "PW": {
+                  "index": 184,
+                  "text": "PW: Palau"
+                },
+                "PY": {
+                  "index": 185,
+                  "text": "PY: Paraguay"
+                },
+                "QA": {
+                  "index": 186,
+                  "text": "QA: Qatar"
+                },
+                "RE": {
+                  "index": 187,
+                  "text": "RE: R\u00e9union"
+                },
+                "RO": {
+                  "index": 188,
+                  "text": "RO: Romania"
+                },
+                "RS": {
+                  "index": 189,
+                  "text": "RS: Serbia"
+                },
+                "RU": {
+                  "index": 190,
+                  "text": "RU: Russian Federation"
+                },
+                "RW": {
+                  "index": 191,
+                  "text": "RW: Rwanda"
+                },
+                "SA": {
+                  "index": 192,
+                  "text": "SA: Saudi Arabia"
+                },
+                "SB": {
+                  "index": 193,
+                  "text": "SB: Solomon Islands"
+                },
+                "SC": {
+                  "index": 194,
+                  "text": "SC: Seychelles"
+                },
+                "SD": {
+                  "index": 195,
+                  "text": "SD: Sudan"
+                },
+                "SE": {
+                  "index": 196,
+                  "text": "SE: Sweden"
+                },
+                "SG": {
+                  "index": 197,
+                  "text": "SG: Singapore"
+                },
+                "SH": {
+                  "index": 198,
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha"
+                },
+                "SI": {
+                  "index": 199,
+                  "text": "SI: Slovenia"
+                },
+                "SJ": {
+                  "index": 200,
+                  "text": "SJ: Svalbard and Jan Mayen"
+                },
+                "SK": {
+                  "index": 201,
+                  "text": "SK: Slovakia"
+                },
+                "SL": {
+                  "index": 202,
+                  "text": "SL: Sierra Leone"
+                },
+                "SM": {
+                  "index": 203,
+                  "text": "SM: San Marino"
+                },
+                "SN": {
+                  "index": 204,
+                  "text": "SN: Senegal"
+                },
+                "SO": {
+                  "index": 205,
+                  "text": "SO: Somalia"
+                },
+                "SR": {
+                  "index": 206,
+                  "text": "SR: Suriname"
+                },
+                "SS": {
+                  "index": 207,
+                  "text": "SS: South Sudan"
+                },
+                "ST": {
+                  "index": 208,
+                  "text": "ST: Sao Tome and Principe"
+                },
+                "SV": {
+                  "index": 209,
+                  "text": "SV: El Salvador"
+                },
+                "SX": {
+                  "index": 210,
+                  "text": "SX: Sint Maarten (Dutch part)"
+                },
+                "SY": {
+                  "index": 211,
+                  "text": "SY: Syrian Arab Republic"
+                },
+                "SZ": {
+                  "index": 212,
+                  "text": "SZ: Eswatini"
+                },
+                "TC": {
+                  "index": 213,
+                  "text": "TC: Turks and Caicos Islands"
+                },
+                "TD": {
+                  "index": 214,
+                  "text": "TD: Chad"
+                },
+                "TF": {
+                  "index": 215,
+                  "text": "TF: French Southern Territories"
+                },
+                "TG": {
+                  "index": 216,
+                  "text": "TG: Togo"
+                },
+                "TH": {
+                  "index": 217,
+                  "text": "TH: Thailand"
+                },
+                "TJ": {
+                  "index": 218,
+                  "text": "TJ: Tajikistan"
+                },
+                "TK": {
+                  "index": 219,
+                  "text": "TK: Tokelau"
+                },
+                "TL": {
+                  "index": 220,
+                  "text": "TL: Timor-Leste"
+                },
+                "TM": {
+                  "index": 221,
+                  "text": "TM: Turkmenistan"
+                },
+                "TN": {
+                  "index": 222,
+                  "text": "TN: Tunisia"
+                },
+                "TO": {
+                  "index": 223,
+                  "text": "TO: Tonga"
+                },
+                "TR": {
+                  "index": 224,
+                  "text": "TR: T\u00fcrkiye"
+                },
+                "TT": {
+                  "index": 225,
+                  "text": "TT: Trinidad and Tobago"
+                },
+                "TV": {
+                  "index": 226,
+                  "text": "TV: Tuvalu"
+                },
+                "TW": {
+                  "index": 227,
+                  "text": "TW: Taiwan, Province of China"
+                },
+                "TZ": {
+                  "index": 228,
+                  "text": "TZ: Tanzania, United Republic of"
+                },
+                "UA": {
+                  "index": 229,
+                  "text": "UA: Ukraine"
+                },
+                "UG": {
+                  "index": 230,
+                  "text": "UG: Uganda"
+                },
+                "UM": {
+                  "index": 231,
+                  "text": "UM: United States Minor Outlying Islands"
+                },
+                "US": {
+                  "index": 232,
+                  "text": "US: United States"
+                },
+                "UY": {
+                  "index": 233,
+                  "text": "UY: Uruguay"
+                },
+                "UZ": {
+                  "index": 234,
+                  "text": "UZ: Uzbekistan"
+                },
+                "VA": {
+                  "index": 235,
+                  "text": "VA: Holy See (Vatican City State)"
+                },
+                "VC": {
+                  "index": 236,
+                  "text": "VC: Saint Vincent and the Grenadines"
+                },
+                "VE": {
+                  "index": 237,
+                  "text": "VE: Venezuela, Bolivarian Republic of"
+                },
+                "VG": {
+                  "index": 238,
+                  "text": "VG: Virgin Islands, British"
+                },
+                "VI": {
+                  "index": 239,
+                  "text": "VI: Virgin Islands, U.S."
+                },
+                "VN": {
+                  "index": 240,
+                  "text": "VN: Viet Nam"
+                },
+                "VU": {
+                  "index": 241,
+                  "text": "VU: Vanuatu"
+                },
+                "WF": {
+                  "index": 242,
+                  "text": "WF: Wallis and Futuna"
+                },
+                "WS": {
+                  "index": 243,
+                  "text": "WS: Samoa"
+                },
+                "YE": {
+                  "index": 244,
+                  "text": "YE: Yemen"
+                },
+                "YT": {
+                  "index": 245,
+                  "text": "YT: Mayotte"
+                },
+                "ZA": {
+                  "index": 246,
+                  "text": "ZA: South Africa"
+                },
+                "ZM": {
+                  "index": 247,
+                  "text": "ZM: Zambia"
+                },
+                "ZW": {
+                  "index": 248,
+                  "text": "ZW: Zimbabwe"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AD: Andorra"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AE: United Arab Emirates"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AF: Afghanistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AG: Antigua and Barbuda"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AI: Anguilla"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AL: Albania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AM: Armenia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AO: Angola"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AQ: Antarctica"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AR: Argentina"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AS: American Samoa"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AT: Austria"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AU: Australia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AW: Aruba"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AX: \u00c5land Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "AZ: Azerbaijan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BA: Bosnia and Herzegovina"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BB: Barbados"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BD: Bangladesh"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BE: Belgium"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BF: Burkina Faso"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BG: Bulgaria"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BH: Bahrain"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BI: Burundi"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BJ: Benin"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BL: Saint Barth\u00e9lemy"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BM: Bermuda"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BN: Brunei Darussalam"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BO: Bolivia, Plurinational State of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BQ: Bonaire, Sint Eustatius and Saba"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BR: Brazil"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BS: Bahamas"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BT: Bhutan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BV: Bouvet Island"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BW: Botswana"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BY: Belarus"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "BZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BZ: Belize"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CA: Canada"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CC: Cocos (Keeling) Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CD: Congo, The Democratic Republic of the"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CF: Central African Republic"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CG: Congo"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CH: Switzerland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CI: C\u00f4te d'Ivoire"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CK: Cook Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CL: Chile"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CM: Cameroon"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CN: China"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CO: Colombia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CR: Costa Rica"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CU: Cuba"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CV: Cabo Verde"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CW: Cura\u00e7ao"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CX: Christmas Island"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CY: Cyprus"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "CZ: Czechia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DE: Germany"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DJ: Djibouti"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DK: Denmark"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DM: Dominica"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DO: Dominican Republic"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DZ: Algeria"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "EC: Ecuador"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "EE: Estonia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "EG: Egypt"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "EH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "EH: Western Sahara"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ER"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ER: Eritrea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ES"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ES: Spain"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ET"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ET: Ethiopia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FI: Finland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FJ: Fiji"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FK: Falkland Islands (Malvinas)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FM: Micronesia, Federated States of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FO: Faroe Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FR: France"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GA: Gabon"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GB: United Kingdom"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GD: Grenada"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GE: Georgia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GF: French Guiana"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GG: Guernsey"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GH: Ghana"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GI: Gibraltar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GL: Greenland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GM: Gambia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GN: Guinea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GP: Guadeloupe"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GQ: Equatorial Guinea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GR: Greece"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GS: South Georgia and the South Sandwich Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GT: Guatemala"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GU: Guam"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GW: Guinea-Bissau"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "GY: Guyana"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HK: Hong Kong"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HM: Heard Island and McDonald Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HN: Honduras"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HR: Croatia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HT: Haiti"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "HU: Hungary"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ID"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ID: Indonesia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IE: Ireland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IL: Israel"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IM: Isle of Man"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IN: India"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IO: British Indian Ocean Territory"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IQ: Iraq"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IR: Iran, Islamic Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IS: Iceland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "IT: Italy"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "JE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "JE: Jersey"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "JM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "JM: Jamaica"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "JO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "JO: Jordan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "JP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "JP: Japan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KE: Kenya"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KG: Kyrgyzstan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KH: Cambodia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KI: Kiribati"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KM: Comoros"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KN: Saint Kitts and Nevis"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KP: Korea, Democratic People's Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KR: Korea, Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KW: Kuwait"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KY: Cayman Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "KZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KZ: Kazakhstan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LA: Lao People's Democratic Republic"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LB: Lebanon"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LC: Saint Lucia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LI: Liechtenstein"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LK: Sri Lanka"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LR: Liberia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LS: Lesotho"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LT: Lithuania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LU: Luxembourg"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LV: Latvia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "LY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "LY: Libya"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MA: Morocco"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MC: Monaco"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MD: Moldova, Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ME"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ME: Montenegro"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MF: Saint Martin (French part)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MG: Madagascar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MH: Marshall Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MK: North Macedonia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ML"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ML: Mali"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MM: Myanmar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MN: Mongolia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MO: Macao"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MP: Northern Mariana Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MQ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MQ: Martinique"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MR: Mauritania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MS: Montserrat"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MT: Malta"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MU: Mauritius"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MV: Maldives"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MW: Malawi"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MX: Mexico"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MY: Malaysia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "MZ: Mozambique"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NA: Namibia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NC: New Caledonia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NE: Niger"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NF: Norfolk Island"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NG: Nigeria"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NI: Nicaragua"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NL: Netherlands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NO: Norway"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NP"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NP: Nepal"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NR: Nauru"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NU: Niue"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "NZ: New Zealand"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "OM: Oman"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PA: Panama"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PE: Peru"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PF: French Polynesia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PG: Papua New Guinea"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PH: Philippines"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PK: Pakistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PL: Poland"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PM: Saint Pierre and Miquelon"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PN: Pitcairn"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PR: Puerto Rico"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PS: Palestine, State of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PT: Portugal"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PW: Palau"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PY: Paraguay"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "QA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "QA: Qatar"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RE: R\u00e9union"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RO: Romania"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RS: Serbia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RU: Russian Federation"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "RW: Rwanda"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SA: Saudi Arabia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SB: Solomon Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SC: Seychelles"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SD: Sudan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SE: Sweden"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SG: Singapore"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SH: Saint Helena, Ascension and Tristan da Cunha"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SI: Slovenia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SJ: Svalbard and Jan Mayen"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SK: Slovakia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SL: Sierra Leone"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SM: San Marino"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SN: Senegal"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SO: Somalia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SR: Suriname"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SS: South Sudan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ST"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ST: Sao Tome and Principe"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SV: El Salvador"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SX: Sint Maarten (Dutch part)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SY: Syrian Arab Republic"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "SZ: Eswatini"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TC: Turks and Caicos Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TD"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TD: Chad"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TF: French Southern Territories"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TG: Togo"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TH"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TH: Thailand"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TJ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TJ: Tajikistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TK"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TK: Tokelau"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TL"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TL: Timor-Leste"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TM: Turkmenistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TN: Tunisia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TO"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TO: Tonga"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TR"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TR: T\u00fcrkiye"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TT: Trinidad and Tobago"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TV"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TV: Tuvalu"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TW: Taiwan, Province of China"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TZ: Tanzania, United Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UA: Ukraine"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UG: Uganda"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UM: United States Minor Outlying Islands"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "US"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "US: United States"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UY"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UY: Uruguay"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UZ"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "UZ: Uzbekistan"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VA: Holy See (Vatican City State)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VC: Saint Vincent and the Grenadines"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VE: Venezuela, Bolivarian Republic of"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VG"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VG: Virgin Islands, British"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VI"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VI: Virgin Islands, U.S."
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VN"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VN: Viet Nam"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VU"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "VU: Vanuatu"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WF"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "WF: Wallis and Futuna"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WS"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "WS: Samoa"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "YE"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "YE: Yemen"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "YT"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "YT: Mayotte"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ZA"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ZA: South Africa"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ZM"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ZM: Zambia"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ZW"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "ZW: Zimbabwe"
+              }
+            ]
+          }
+        ]
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
       "id": 12,
       "options": {
-        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (region) (conduit_region_connected_clients)", "legendFormat": "{{region}}", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "legendFormat": "{{region}}",
+          "refId": "A"
+        }
       ],
       "title": "Connected Clients by Region",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current connected clients and cumulative traffic per region",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "align": "auto",
-            "cellOptions": { "type": "auto" },
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
-          "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "mappings": [
+            {
+              "options": {
+                "AD": {
+                  "index": 0,
+                  "text": "AD: Andorra"
+                },
+                "AE": {
+                  "index": 1,
+                  "text": "AE: United Arab Emirates"
+                },
+                "AF": {
+                  "index": 2,
+                  "text": "AF: Afghanistan"
+                },
+                "AG": {
+                  "index": 3,
+                  "text": "AG: Antigua and Barbuda"
+                },
+                "AI": {
+                  "index": 4,
+                  "text": "AI: Anguilla"
+                },
+                "AL": {
+                  "index": 5,
+                  "text": "AL: Albania"
+                },
+                "AM": {
+                  "index": 6,
+                  "text": "AM: Armenia"
+                },
+                "AO": {
+                  "index": 7,
+                  "text": "AO: Angola"
+                },
+                "AQ": {
+                  "index": 8,
+                  "text": "AQ: Antarctica"
+                },
+                "AR": {
+                  "index": 9,
+                  "text": "AR: Argentina"
+                },
+                "AS": {
+                  "index": 10,
+                  "text": "AS: American Samoa"
+                },
+                "AT": {
+                  "index": 11,
+                  "text": "AT: Austria"
+                },
+                "AU": {
+                  "index": 12,
+                  "text": "AU: Australia"
+                },
+                "AW": {
+                  "index": 13,
+                  "text": "AW: Aruba"
+                },
+                "AX": {
+                  "index": 14,
+                  "text": "AX: \u00c5land Islands"
+                },
+                "AZ": {
+                  "index": 15,
+                  "text": "AZ: Azerbaijan"
+                },
+                "BA": {
+                  "index": 16,
+                  "text": "BA: Bosnia and Herzegovina"
+                },
+                "BB": {
+                  "index": 17,
+                  "text": "BB: Barbados"
+                },
+                "BD": {
+                  "index": 18,
+                  "text": "BD: Bangladesh"
+                },
+                "BE": {
+                  "index": 19,
+                  "text": "BE: Belgium"
+                },
+                "BF": {
+                  "index": 20,
+                  "text": "BF: Burkina Faso"
+                },
+                "BG": {
+                  "index": 21,
+                  "text": "BG: Bulgaria"
+                },
+                "BH": {
+                  "index": 22,
+                  "text": "BH: Bahrain"
+                },
+                "BI": {
+                  "index": 23,
+                  "text": "BI: Burundi"
+                },
+                "BJ": {
+                  "index": 24,
+                  "text": "BJ: Benin"
+                },
+                "BL": {
+                  "index": 25,
+                  "text": "BL: Saint Barth\u00e9lemy"
+                },
+                "BM": {
+                  "index": 26,
+                  "text": "BM: Bermuda"
+                },
+                "BN": {
+                  "index": 27,
+                  "text": "BN: Brunei Darussalam"
+                },
+                "BO": {
+                  "index": 28,
+                  "text": "BO: Bolivia, Plurinational State of"
+                },
+                "BQ": {
+                  "index": 29,
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba"
+                },
+                "BR": {
+                  "index": 30,
+                  "text": "BR: Brazil"
+                },
+                "BS": {
+                  "index": 31,
+                  "text": "BS: Bahamas"
+                },
+                "BT": {
+                  "index": 32,
+                  "text": "BT: Bhutan"
+                },
+                "BV": {
+                  "index": 33,
+                  "text": "BV: Bouvet Island"
+                },
+                "BW": {
+                  "index": 34,
+                  "text": "BW: Botswana"
+                },
+                "BY": {
+                  "index": 35,
+                  "text": "BY: Belarus"
+                },
+                "BZ": {
+                  "index": 36,
+                  "text": "BZ: Belize"
+                },
+                "CA": {
+                  "index": 37,
+                  "text": "CA: Canada"
+                },
+                "CC": {
+                  "index": 38,
+                  "text": "CC: Cocos (Keeling) Islands"
+                },
+                "CD": {
+                  "index": 39,
+                  "text": "CD: Congo, The Democratic Republic of the"
+                },
+                "CF": {
+                  "index": 40,
+                  "text": "CF: Central African Republic"
+                },
+                "CG": {
+                  "index": 41,
+                  "text": "CG: Congo"
+                },
+                "CH": {
+                  "index": 42,
+                  "text": "CH: Switzerland"
+                },
+                "CI": {
+                  "index": 43,
+                  "text": "CI: C\u00f4te d'Ivoire"
+                },
+                "CK": {
+                  "index": 44,
+                  "text": "CK: Cook Islands"
+                },
+                "CL": {
+                  "index": 45,
+                  "text": "CL: Chile"
+                },
+                "CM": {
+                  "index": 46,
+                  "text": "CM: Cameroon"
+                },
+                "CN": {
+                  "index": 47,
+                  "text": "CN: China"
+                },
+                "CO": {
+                  "index": 48,
+                  "text": "CO: Colombia"
+                },
+                "CR": {
+                  "index": 49,
+                  "text": "CR: Costa Rica"
+                },
+                "CU": {
+                  "index": 50,
+                  "text": "CU: Cuba"
+                },
+                "CV": {
+                  "index": 51,
+                  "text": "CV: Cabo Verde"
+                },
+                "CW": {
+                  "index": 52,
+                  "text": "CW: Cura\u00e7ao"
+                },
+                "CX": {
+                  "index": 53,
+                  "text": "CX: Christmas Island"
+                },
+                "CY": {
+                  "index": 54,
+                  "text": "CY: Cyprus"
+                },
+                "CZ": {
+                  "index": 55,
+                  "text": "CZ: Czechia"
+                },
+                "DE": {
+                  "index": 56,
+                  "text": "DE: Germany"
+                },
+                "DJ": {
+                  "index": 57,
+                  "text": "DJ: Djibouti"
+                },
+                "DK": {
+                  "index": 58,
+                  "text": "DK: Denmark"
+                },
+                "DM": {
+                  "index": 59,
+                  "text": "DM: Dominica"
+                },
+                "DO": {
+                  "index": 60,
+                  "text": "DO: Dominican Republic"
+                },
+                "DZ": {
+                  "index": 61,
+                  "text": "DZ: Algeria"
+                },
+                "EC": {
+                  "index": 62,
+                  "text": "EC: Ecuador"
+                },
+                "EE": {
+                  "index": 63,
+                  "text": "EE: Estonia"
+                },
+                "EG": {
+                  "index": 64,
+                  "text": "EG: Egypt"
+                },
+                "EH": {
+                  "index": 65,
+                  "text": "EH: Western Sahara"
+                },
+                "ER": {
+                  "index": 66,
+                  "text": "ER: Eritrea"
+                },
+                "ES": {
+                  "index": 67,
+                  "text": "ES: Spain"
+                },
+                "ET": {
+                  "index": 68,
+                  "text": "ET: Ethiopia"
+                },
+                "FI": {
+                  "index": 69,
+                  "text": "FI: Finland"
+                },
+                "FJ": {
+                  "index": 70,
+                  "text": "FJ: Fiji"
+                },
+                "FK": {
+                  "index": 71,
+                  "text": "FK: Falkland Islands (Malvinas)"
+                },
+                "FM": {
+                  "index": 72,
+                  "text": "FM: Micronesia, Federated States of"
+                },
+                "FO": {
+                  "index": 73,
+                  "text": "FO: Faroe Islands"
+                },
+                "FR": {
+                  "index": 74,
+                  "text": "FR: France"
+                },
+                "GA": {
+                  "index": 75,
+                  "text": "GA: Gabon"
+                },
+                "GB": {
+                  "index": 76,
+                  "text": "GB: United Kingdom"
+                },
+                "GD": {
+                  "index": 77,
+                  "text": "GD: Grenada"
+                },
+                "GE": {
+                  "index": 78,
+                  "text": "GE: Georgia"
+                },
+                "GF": {
+                  "index": 79,
+                  "text": "GF: French Guiana"
+                },
+                "GG": {
+                  "index": 80,
+                  "text": "GG: Guernsey"
+                },
+                "GH": {
+                  "index": 81,
+                  "text": "GH: Ghana"
+                },
+                "GI": {
+                  "index": 82,
+                  "text": "GI: Gibraltar"
+                },
+                "GL": {
+                  "index": 83,
+                  "text": "GL: Greenland"
+                },
+                "GM": {
+                  "index": 84,
+                  "text": "GM: Gambia"
+                },
+                "GN": {
+                  "index": 85,
+                  "text": "GN: Guinea"
+                },
+                "GP": {
+                  "index": 86,
+                  "text": "GP: Guadeloupe"
+                },
+                "GQ": {
+                  "index": 87,
+                  "text": "GQ: Equatorial Guinea"
+                },
+                "GR": {
+                  "index": 88,
+                  "text": "GR: Greece"
+                },
+                "GS": {
+                  "index": 89,
+                  "text": "GS: South Georgia and the South Sandwich Islands"
+                },
+                "GT": {
+                  "index": 90,
+                  "text": "GT: Guatemala"
+                },
+                "GU": {
+                  "index": 91,
+                  "text": "GU: Guam"
+                },
+                "GW": {
+                  "index": 92,
+                  "text": "GW: Guinea-Bissau"
+                },
+                "GY": {
+                  "index": 93,
+                  "text": "GY: Guyana"
+                },
+                "HK": {
+                  "index": 94,
+                  "text": "HK: Hong Kong"
+                },
+                "HM": {
+                  "index": 95,
+                  "text": "HM: Heard Island and McDonald Islands"
+                },
+                "HN": {
+                  "index": 96,
+                  "text": "HN: Honduras"
+                },
+                "HR": {
+                  "index": 97,
+                  "text": "HR: Croatia"
+                },
+                "HT": {
+                  "index": 98,
+                  "text": "HT: Haiti"
+                },
+                "HU": {
+                  "index": 99,
+                  "text": "HU: Hungary"
+                },
+                "ID": {
+                  "index": 100,
+                  "text": "ID: Indonesia"
+                },
+                "IE": {
+                  "index": 101,
+                  "text": "IE: Ireland"
+                },
+                "IL": {
+                  "index": 102,
+                  "text": "IL: Israel"
+                },
+                "IM": {
+                  "index": 103,
+                  "text": "IM: Isle of Man"
+                },
+                "IN": {
+                  "index": 104,
+                  "text": "IN: India"
+                },
+                "IO": {
+                  "index": 105,
+                  "text": "IO: British Indian Ocean Territory"
+                },
+                "IQ": {
+                  "index": 106,
+                  "text": "IQ: Iraq"
+                },
+                "IR": {
+                  "index": 107,
+                  "text": "IR: Iran, Islamic Republic of"
+                },
+                "IS": {
+                  "index": 108,
+                  "text": "IS: Iceland"
+                },
+                "IT": {
+                  "index": 109,
+                  "text": "IT: Italy"
+                },
+                "JE": {
+                  "index": 110,
+                  "text": "JE: Jersey"
+                },
+                "JM": {
+                  "index": 111,
+                  "text": "JM: Jamaica"
+                },
+                "JO": {
+                  "index": 112,
+                  "text": "JO: Jordan"
+                },
+                "JP": {
+                  "index": 113,
+                  "text": "JP: Japan"
+                },
+                "KE": {
+                  "index": 114,
+                  "text": "KE: Kenya"
+                },
+                "KG": {
+                  "index": 115,
+                  "text": "KG: Kyrgyzstan"
+                },
+                "KH": {
+                  "index": 116,
+                  "text": "KH: Cambodia"
+                },
+                "KI": {
+                  "index": 117,
+                  "text": "KI: Kiribati"
+                },
+                "KM": {
+                  "index": 118,
+                  "text": "KM: Comoros"
+                },
+                "KN": {
+                  "index": 119,
+                  "text": "KN: Saint Kitts and Nevis"
+                },
+                "KP": {
+                  "index": 120,
+                  "text": "KP: Korea, Democratic People's Republic of"
+                },
+                "KR": {
+                  "index": 121,
+                  "text": "KR: Korea, Republic of"
+                },
+                "KW": {
+                  "index": 122,
+                  "text": "KW: Kuwait"
+                },
+                "KY": {
+                  "index": 123,
+                  "text": "KY: Cayman Islands"
+                },
+                "KZ": {
+                  "index": 124,
+                  "text": "KZ: Kazakhstan"
+                },
+                "LA": {
+                  "index": 125,
+                  "text": "LA: Lao People's Democratic Republic"
+                },
+                "LB": {
+                  "index": 126,
+                  "text": "LB: Lebanon"
+                },
+                "LC": {
+                  "index": 127,
+                  "text": "LC: Saint Lucia"
+                },
+                "LI": {
+                  "index": 128,
+                  "text": "LI: Liechtenstein"
+                },
+                "LK": {
+                  "index": 129,
+                  "text": "LK: Sri Lanka"
+                },
+                "LR": {
+                  "index": 130,
+                  "text": "LR: Liberia"
+                },
+                "LS": {
+                  "index": 131,
+                  "text": "LS: Lesotho"
+                },
+                "LT": {
+                  "index": 132,
+                  "text": "LT: Lithuania"
+                },
+                "LU": {
+                  "index": 133,
+                  "text": "LU: Luxembourg"
+                },
+                "LV": {
+                  "index": 134,
+                  "text": "LV: Latvia"
+                },
+                "LY": {
+                  "index": 135,
+                  "text": "LY: Libya"
+                },
+                "MA": {
+                  "index": 136,
+                  "text": "MA: Morocco"
+                },
+                "MC": {
+                  "index": 137,
+                  "text": "MC: Monaco"
+                },
+                "MD": {
+                  "index": 138,
+                  "text": "MD: Moldova, Republic of"
+                },
+                "ME": {
+                  "index": 139,
+                  "text": "ME: Montenegro"
+                },
+                "MF": {
+                  "index": 140,
+                  "text": "MF: Saint Martin (French part)"
+                },
+                "MG": {
+                  "index": 141,
+                  "text": "MG: Madagascar"
+                },
+                "MH": {
+                  "index": 142,
+                  "text": "MH: Marshall Islands"
+                },
+                "MK": {
+                  "index": 143,
+                  "text": "MK: North Macedonia"
+                },
+                "ML": {
+                  "index": 144,
+                  "text": "ML: Mali"
+                },
+                "MM": {
+                  "index": 145,
+                  "text": "MM: Myanmar"
+                },
+                "MN": {
+                  "index": 146,
+                  "text": "MN: Mongolia"
+                },
+                "MO": {
+                  "index": 147,
+                  "text": "MO: Macao"
+                },
+                "MP": {
+                  "index": 148,
+                  "text": "MP: Northern Mariana Islands"
+                },
+                "MQ": {
+                  "index": 149,
+                  "text": "MQ: Martinique"
+                },
+                "MR": {
+                  "index": 150,
+                  "text": "MR: Mauritania"
+                },
+                "MS": {
+                  "index": 151,
+                  "text": "MS: Montserrat"
+                },
+                "MT": {
+                  "index": 152,
+                  "text": "MT: Malta"
+                },
+                "MU": {
+                  "index": 153,
+                  "text": "MU: Mauritius"
+                },
+                "MV": {
+                  "index": 154,
+                  "text": "MV: Maldives"
+                },
+                "MW": {
+                  "index": 155,
+                  "text": "MW: Malawi"
+                },
+                "MX": {
+                  "index": 156,
+                  "text": "MX: Mexico"
+                },
+                "MY": {
+                  "index": 157,
+                  "text": "MY: Malaysia"
+                },
+                "MZ": {
+                  "index": 158,
+                  "text": "MZ: Mozambique"
+                },
+                "NA": {
+                  "index": 159,
+                  "text": "NA: Namibia"
+                },
+                "NC": {
+                  "index": 160,
+                  "text": "NC: New Caledonia"
+                },
+                "NE": {
+                  "index": 161,
+                  "text": "NE: Niger"
+                },
+                "NF": {
+                  "index": 162,
+                  "text": "NF: Norfolk Island"
+                },
+                "NG": {
+                  "index": 163,
+                  "text": "NG: Nigeria"
+                },
+                "NI": {
+                  "index": 164,
+                  "text": "NI: Nicaragua"
+                },
+                "NL": {
+                  "index": 165,
+                  "text": "NL: Netherlands"
+                },
+                "NO": {
+                  "index": 166,
+                  "text": "NO: Norway"
+                },
+                "NP": {
+                  "index": 167,
+                  "text": "NP: Nepal"
+                },
+                "NR": {
+                  "index": 168,
+                  "text": "NR: Nauru"
+                },
+                "NU": {
+                  "index": 169,
+                  "text": "NU: Niue"
+                },
+                "NZ": {
+                  "index": 170,
+                  "text": "NZ: New Zealand"
+                },
+                "OM": {
+                  "index": 171,
+                  "text": "OM: Oman"
+                },
+                "PA": {
+                  "index": 172,
+                  "text": "PA: Panama"
+                },
+                "PE": {
+                  "index": 173,
+                  "text": "PE: Peru"
+                },
+                "PF": {
+                  "index": 174,
+                  "text": "PF: French Polynesia"
+                },
+                "PG": {
+                  "index": 175,
+                  "text": "PG: Papua New Guinea"
+                },
+                "PH": {
+                  "index": 176,
+                  "text": "PH: Philippines"
+                },
+                "PK": {
+                  "index": 177,
+                  "text": "PK: Pakistan"
+                },
+                "PL": {
+                  "index": 178,
+                  "text": "PL: Poland"
+                },
+                "PM": {
+                  "index": 179,
+                  "text": "PM: Saint Pierre and Miquelon"
+                },
+                "PN": {
+                  "index": 180,
+                  "text": "PN: Pitcairn"
+                },
+                "PR": {
+                  "index": 181,
+                  "text": "PR: Puerto Rico"
+                },
+                "PS": {
+                  "index": 182,
+                  "text": "PS: Palestine, State of"
+                },
+                "PT": {
+                  "index": 183,
+                  "text": "PT: Portugal"
+                },
+                "PW": {
+                  "index": 184,
+                  "text": "PW: Palau"
+                },
+                "PY": {
+                  "index": 185,
+                  "text": "PY: Paraguay"
+                },
+                "QA": {
+                  "index": 186,
+                  "text": "QA: Qatar"
+                },
+                "RE": {
+                  "index": 187,
+                  "text": "RE: R\u00e9union"
+                },
+                "RO": {
+                  "index": 188,
+                  "text": "RO: Romania"
+                },
+                "RS": {
+                  "index": 189,
+                  "text": "RS: Serbia"
+                },
+                "RU": {
+                  "index": 190,
+                  "text": "RU: Russian Federation"
+                },
+                "RW": {
+                  "index": 191,
+                  "text": "RW: Rwanda"
+                },
+                "SA": {
+                  "index": 192,
+                  "text": "SA: Saudi Arabia"
+                },
+                "SB": {
+                  "index": 193,
+                  "text": "SB: Solomon Islands"
+                },
+                "SC": {
+                  "index": 194,
+                  "text": "SC: Seychelles"
+                },
+                "SD": {
+                  "index": 195,
+                  "text": "SD: Sudan"
+                },
+                "SE": {
+                  "index": 196,
+                  "text": "SE: Sweden"
+                },
+                "SG": {
+                  "index": 197,
+                  "text": "SG: Singapore"
+                },
+                "SH": {
+                  "index": 198,
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha"
+                },
+                "SI": {
+                  "index": 199,
+                  "text": "SI: Slovenia"
+                },
+                "SJ": {
+                  "index": 200,
+                  "text": "SJ: Svalbard and Jan Mayen"
+                },
+                "SK": {
+                  "index": 201,
+                  "text": "SK: Slovakia"
+                },
+                "SL": {
+                  "index": 202,
+                  "text": "SL: Sierra Leone"
+                },
+                "SM": {
+                  "index": 203,
+                  "text": "SM: San Marino"
+                },
+                "SN": {
+                  "index": 204,
+                  "text": "SN: Senegal"
+                },
+                "SO": {
+                  "index": 205,
+                  "text": "SO: Somalia"
+                },
+                "SR": {
+                  "index": 206,
+                  "text": "SR: Suriname"
+                },
+                "SS": {
+                  "index": 207,
+                  "text": "SS: South Sudan"
+                },
+                "ST": {
+                  "index": 208,
+                  "text": "ST: Sao Tome and Principe"
+                },
+                "SV": {
+                  "index": 209,
+                  "text": "SV: El Salvador"
+                },
+                "SX": {
+                  "index": 210,
+                  "text": "SX: Sint Maarten (Dutch part)"
+                },
+                "SY": {
+                  "index": 211,
+                  "text": "SY: Syrian Arab Republic"
+                },
+                "SZ": {
+                  "index": 212,
+                  "text": "SZ: Eswatini"
+                },
+                "TC": {
+                  "index": 213,
+                  "text": "TC: Turks and Caicos Islands"
+                },
+                "TD": {
+                  "index": 214,
+                  "text": "TD: Chad"
+                },
+                "TF": {
+                  "index": 215,
+                  "text": "TF: French Southern Territories"
+                },
+                "TG": {
+                  "index": 216,
+                  "text": "TG: Togo"
+                },
+                "TH": {
+                  "index": 217,
+                  "text": "TH: Thailand"
+                },
+                "TJ": {
+                  "index": 218,
+                  "text": "TJ: Tajikistan"
+                },
+                "TK": {
+                  "index": 219,
+                  "text": "TK: Tokelau"
+                },
+                "TL": {
+                  "index": 220,
+                  "text": "TL: Timor-Leste"
+                },
+                "TM": {
+                  "index": 221,
+                  "text": "TM: Turkmenistan"
+                },
+                "TN": {
+                  "index": 222,
+                  "text": "TN: Tunisia"
+                },
+                "TO": {
+                  "index": 223,
+                  "text": "TO: Tonga"
+                },
+                "TR": {
+                  "index": 224,
+                  "text": "TR: T\u00fcrkiye"
+                },
+                "TT": {
+                  "index": 225,
+                  "text": "TT: Trinidad and Tobago"
+                },
+                "TV": {
+                  "index": 226,
+                  "text": "TV: Tuvalu"
+                },
+                "TW": {
+                  "index": 227,
+                  "text": "TW: Taiwan, Province of China"
+                },
+                "TZ": {
+                  "index": 228,
+                  "text": "TZ: Tanzania, United Republic of"
+                },
+                "UA": {
+                  "index": 229,
+                  "text": "UA: Ukraine"
+                },
+                "UG": {
+                  "index": 230,
+                  "text": "UG: Uganda"
+                },
+                "UM": {
+                  "index": 231,
+                  "text": "UM: United States Minor Outlying Islands"
+                },
+                "US": {
+                  "index": 232,
+                  "text": "US: United States"
+                },
+                "UY": {
+                  "index": 233,
+                  "text": "UY: Uruguay"
+                },
+                "UZ": {
+                  "index": 234,
+                  "text": "UZ: Uzbekistan"
+                },
+                "VA": {
+                  "index": 235,
+                  "text": "VA: Holy See (Vatican City State)"
+                },
+                "VC": {
+                  "index": 236,
+                  "text": "VC: Saint Vincent and the Grenadines"
+                },
+                "VE": {
+                  "index": 237,
+                  "text": "VE: Venezuela, Bolivarian Republic of"
+                },
+                "VG": {
+                  "index": 238,
+                  "text": "VG: Virgin Islands, British"
+                },
+                "VI": {
+                  "index": 239,
+                  "text": "VI: Virgin Islands, U.S."
+                },
+                "VN": {
+                  "index": 240,
+                  "text": "VN: Viet Nam"
+                },
+                "VU": {
+                  "index": 241,
+                  "text": "VU: Vanuatu"
+                },
+                "WF": {
+                  "index": 242,
+                  "text": "WF: Wallis and Futuna"
+                },
+                "WS": {
+                  "index": 243,
+                  "text": "WS: Samoa"
+                },
+                "YE": {
+                  "index": 244,
+                  "text": "YE: Yemen"
+                },
+                "YT": {
+                  "index": 245,
+                  "text": "YT: Mayotte"
+                },
+                "ZA": {
+                  "index": 246,
+                  "text": "ZA: South Africa"
+                },
+                "ZM": {
+                  "index": 247,
+                  "text": "ZM: Zambia"
+                },
+                "ZW": {
+                  "index": 248,
+                  "text": "ZW: Zimbabwe"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "Region" },
-            "properties": [{ "id": "custom.width", "value": 100 }]
+            "matcher": {
+              "id": "byName",
+              "options": "Region"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 223
+              }
+            ]
           },
           {
-            "matcher": { "id": "byName", "options": "Download" },
-            "properties": [{ "id": "unit", "value": "bytes" }]
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
           },
           {
-            "matcher": { "id": "byName", "options": "Upload" },
-            "properties": [{ "id": "unit", "value": "bytes" }]
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "include",
+                "names": [
+                  "Connected",
+                  "Download",
+                  "Upload"
+                ]
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.footer.reducers",
+                "value": [
+                  "sum"
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connected"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 117
+              }
+            ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "gridPos": {
+        "h": 19,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
       "id": 13,
       "options": {
-        "showHeader": true,
         "cellHeight": "sm",
-        "footer": {
-          "show": true,
-          "reducer": ["sum"],
-          "countRows": false,
-          "fields": ["Connected", "Download", "Upload"]
-        },
-        "sortBy": [{ "displayName": "Connected", "desc": true }]
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Connected"
+          }
+        ]
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (region) (conduit_region_connected_clients)", "format": "table", "instant": true, "refId": "Connected" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (region) (conduit_region_bytes_downloaded)", "format": "table", "instant": true, "refId": "Download" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (region) (conduit_region_bytes_uploaded)", "format": "table", "instant": true, "refId": "Upload" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "format": "table",
+          "instant": true,
+          "refId": "Connected"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_bytes_downloaded)",
+          "format": "table",
+          "instant": true,
+          "refId": "Download"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_bytes_uploaded)",
+          "format": "table",
+          "instant": true,
+          "refId": "Upload"
+        }
       ],
       "title": "Traffic by Region",
-      "description": "Current connected clients and cumulative traffic per region",
       "transformations": [
         {
           "id": "seriesToColumns",
-          "options": { "byField": "region" }
+          "options": {
+            "byField": "region"
+          }
         },
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Time": true, "Time 1": true, "Time 2": true, "Time 3": true },
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
             "renameByName": {
-              "region": "Region",
               "Value #Connected": "Connected",
               "Value #Download": "Download",
-              "Value #Upload": "Upload"
+              "Value #Upload": "Upload",
+              "region": "Region"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "AD": {
+                  "index": 0,
+                  "text": "AD: Andorra"
+                },
+                "AE": {
+                  "index": 1,
+                  "text": "AE: United Arab Emirates"
+                },
+                "AF": {
+                  "index": 2,
+                  "text": "AF: Afghanistan"
+                },
+                "AG": {
+                  "index": 3,
+                  "text": "AG: Antigua and Barbuda"
+                },
+                "AI": {
+                  "index": 4,
+                  "text": "AI: Anguilla"
+                },
+                "AL": {
+                  "index": 5,
+                  "text": "AL: Albania"
+                },
+                "AM": {
+                  "index": 6,
+                  "text": "AM: Armenia"
+                },
+                "AO": {
+                  "index": 7,
+                  "text": "AO: Angola"
+                },
+                "AQ": {
+                  "index": 8,
+                  "text": "AQ: Antarctica"
+                },
+                "AR": {
+                  "index": 9,
+                  "text": "AR: Argentina"
+                },
+                "AS": {
+                  "index": 10,
+                  "text": "AS: American Samoa"
+                },
+                "AT": {
+                  "index": 11,
+                  "text": "AT: Austria"
+                },
+                "AU": {
+                  "index": 12,
+                  "text": "AU: Australia"
+                },
+                "AW": {
+                  "index": 13,
+                  "text": "AW: Aruba"
+                },
+                "AX": {
+                  "index": 14,
+                  "text": "AX: \u00c5land Islands"
+                },
+                "AZ": {
+                  "index": 15,
+                  "text": "AZ: Azerbaijan"
+                },
+                "BA": {
+                  "index": 16,
+                  "text": "BA: Bosnia and Herzegovina"
+                },
+                "BB": {
+                  "index": 17,
+                  "text": "BB: Barbados"
+                },
+                "BD": {
+                  "index": 18,
+                  "text": "BD: Bangladesh"
+                },
+                "BE": {
+                  "index": 19,
+                  "text": "BE: Belgium"
+                },
+                "BF": {
+                  "index": 20,
+                  "text": "BF: Burkina Faso"
+                },
+                "BG": {
+                  "index": 21,
+                  "text": "BG: Bulgaria"
+                },
+                "BH": {
+                  "index": 22,
+                  "text": "BH: Bahrain"
+                },
+                "BI": {
+                  "index": 23,
+                  "text": "BI: Burundi"
+                },
+                "BJ": {
+                  "index": 24,
+                  "text": "BJ: Benin"
+                },
+                "BL": {
+                  "index": 25,
+                  "text": "BL: Saint Barth\u00e9lemy"
+                },
+                "BM": {
+                  "index": 26,
+                  "text": "BM: Bermuda"
+                },
+                "BN": {
+                  "index": 27,
+                  "text": "BN: Brunei Darussalam"
+                },
+                "BO": {
+                  "index": 28,
+                  "text": "BO: Bolivia, Plurinational State of"
+                },
+                "BQ": {
+                  "index": 29,
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba"
+                },
+                "BR": {
+                  "index": 30,
+                  "text": "BR: Brazil"
+                },
+                "BS": {
+                  "index": 31,
+                  "text": "BS: Bahamas"
+                },
+                "BT": {
+                  "index": 32,
+                  "text": "BT: Bhutan"
+                },
+                "BV": {
+                  "index": 33,
+                  "text": "BV: Bouvet Island"
+                },
+                "BW": {
+                  "index": 34,
+                  "text": "BW: Botswana"
+                },
+                "BY": {
+                  "index": 35,
+                  "text": "BY: Belarus"
+                },
+                "BZ": {
+                  "index": 36,
+                  "text": "BZ: Belize"
+                },
+                "CA": {
+                  "index": 37,
+                  "text": "CA: Canada"
+                },
+                "CC": {
+                  "index": 38,
+                  "text": "CC: Cocos (Keeling) Islands"
+                },
+                "CD": {
+                  "index": 39,
+                  "text": "CD: Congo, The Democratic Republic of the"
+                },
+                "CF": {
+                  "index": 40,
+                  "text": "CF: Central African Republic"
+                },
+                "CG": {
+                  "index": 41,
+                  "text": "CG: Congo"
+                },
+                "CH": {
+                  "index": 42,
+                  "text": "CH: Switzerland"
+                },
+                "CI": {
+                  "index": 43,
+                  "text": "CI: C\u00f4te d'Ivoire"
+                },
+                "CK": {
+                  "index": 44,
+                  "text": "CK: Cook Islands"
+                },
+                "CL": {
+                  "index": 45,
+                  "text": "CL: Chile"
+                },
+                "CM": {
+                  "index": 46,
+                  "text": "CM: Cameroon"
+                },
+                "CN": {
+                  "index": 47,
+                  "text": "CN: China"
+                },
+                "CO": {
+                  "index": 48,
+                  "text": "CO: Colombia"
+                },
+                "CR": {
+                  "index": 49,
+                  "text": "CR: Costa Rica"
+                },
+                "CU": {
+                  "index": 50,
+                  "text": "CU: Cuba"
+                },
+                "CV": {
+                  "index": 51,
+                  "text": "CV: Cabo Verde"
+                },
+                "CW": {
+                  "index": 52,
+                  "text": "CW: Cura\u00e7ao"
+                },
+                "CX": {
+                  "index": 53,
+                  "text": "CX: Christmas Island"
+                },
+                "CY": {
+                  "index": 54,
+                  "text": "CY: Cyprus"
+                },
+                "CZ": {
+                  "index": 55,
+                  "text": "CZ: Czechia"
+                },
+                "DE": {
+                  "index": 56,
+                  "text": "DE: Germany"
+                },
+                "DJ": {
+                  "index": 57,
+                  "text": "DJ: Djibouti"
+                },
+                "DK": {
+                  "index": 58,
+                  "text": "DK: Denmark"
+                },
+                "DM": {
+                  "index": 59,
+                  "text": "DM: Dominica"
+                },
+                "DO": {
+                  "index": 60,
+                  "text": "DO: Dominican Republic"
+                },
+                "DZ": {
+                  "index": 61,
+                  "text": "DZ: Algeria"
+                },
+                "EC": {
+                  "index": 62,
+                  "text": "EC: Ecuador"
+                },
+                "EE": {
+                  "index": 63,
+                  "text": "EE: Estonia"
+                },
+                "EG": {
+                  "index": 64,
+                  "text": "EG: Egypt"
+                },
+                "EH": {
+                  "index": 65,
+                  "text": "EH: Western Sahara"
+                },
+                "ER": {
+                  "index": 66,
+                  "text": "ER: Eritrea"
+                },
+                "ES": {
+                  "index": 67,
+                  "text": "ES: Spain"
+                },
+                "ET": {
+                  "index": 68,
+                  "text": "ET: Ethiopia"
+                },
+                "FI": {
+                  "index": 69,
+                  "text": "FI: Finland"
+                },
+                "FJ": {
+                  "index": 70,
+                  "text": "FJ: Fiji"
+                },
+                "FK": {
+                  "index": 71,
+                  "text": "FK: Falkland Islands (Malvinas)"
+                },
+                "FM": {
+                  "index": 72,
+                  "text": "FM: Micronesia, Federated States of"
+                },
+                "FO": {
+                  "index": 73,
+                  "text": "FO: Faroe Islands"
+                },
+                "FR": {
+                  "index": 74,
+                  "text": "FR: France"
+                },
+                "GA": {
+                  "index": 75,
+                  "text": "GA: Gabon"
+                },
+                "GB": {
+                  "index": 76,
+                  "text": "GB: United Kingdom"
+                },
+                "GD": {
+                  "index": 77,
+                  "text": "GD: Grenada"
+                },
+                "GE": {
+                  "index": 78,
+                  "text": "GE: Georgia"
+                },
+                "GF": {
+                  "index": 79,
+                  "text": "GF: French Guiana"
+                },
+                "GG": {
+                  "index": 80,
+                  "text": "GG: Guernsey"
+                },
+                "GH": {
+                  "index": 81,
+                  "text": "GH: Ghana"
+                },
+                "GI": {
+                  "index": 82,
+                  "text": "GI: Gibraltar"
+                },
+                "GL": {
+                  "index": 83,
+                  "text": "GL: Greenland"
+                },
+                "GM": {
+                  "index": 84,
+                  "text": "GM: Gambia"
+                },
+                "GN": {
+                  "index": 85,
+                  "text": "GN: Guinea"
+                },
+                "GP": {
+                  "index": 86,
+                  "text": "GP: Guadeloupe"
+                },
+                "GQ": {
+                  "index": 87,
+                  "text": "GQ: Equatorial Guinea"
+                },
+                "GR": {
+                  "index": 88,
+                  "text": "GR: Greece"
+                },
+                "GS": {
+                  "index": 89,
+                  "text": "GS: South Georgia and the South Sandwich Islands"
+                },
+                "GT": {
+                  "index": 90,
+                  "text": "GT: Guatemala"
+                },
+                "GU": {
+                  "index": 91,
+                  "text": "GU: Guam"
+                },
+                "GW": {
+                  "index": 92,
+                  "text": "GW: Guinea-Bissau"
+                },
+                "GY": {
+                  "index": 93,
+                  "text": "GY: Guyana"
+                },
+                "HK": {
+                  "index": 94,
+                  "text": "HK: Hong Kong"
+                },
+                "HM": {
+                  "index": 95,
+                  "text": "HM: Heard Island and McDonald Islands"
+                },
+                "HN": {
+                  "index": 96,
+                  "text": "HN: Honduras"
+                },
+                "HR": {
+                  "index": 97,
+                  "text": "HR: Croatia"
+                },
+                "HT": {
+                  "index": 98,
+                  "text": "HT: Haiti"
+                },
+                "HU": {
+                  "index": 99,
+                  "text": "HU: Hungary"
+                },
+                "ID": {
+                  "index": 100,
+                  "text": "ID: Indonesia"
+                },
+                "IE": {
+                  "index": 101,
+                  "text": "IE: Ireland"
+                },
+                "IL": {
+                  "index": 102,
+                  "text": "IL: Israel"
+                },
+                "IM": {
+                  "index": 103,
+                  "text": "IM: Isle of Man"
+                },
+                "IN": {
+                  "index": 104,
+                  "text": "IN: India"
+                },
+                "IO": {
+                  "index": 105,
+                  "text": "IO: British Indian Ocean Territory"
+                },
+                "IQ": {
+                  "index": 106,
+                  "text": "IQ: Iraq"
+                },
+                "IR": {
+                  "index": 107,
+                  "text": "IR: Iran, Islamic Republic of"
+                },
+                "IS": {
+                  "index": 108,
+                  "text": "IS: Iceland"
+                },
+                "IT": {
+                  "index": 109,
+                  "text": "IT: Italy"
+                },
+                "JE": {
+                  "index": 110,
+                  "text": "JE: Jersey"
+                },
+                "JM": {
+                  "index": 111,
+                  "text": "JM: Jamaica"
+                },
+                "JO": {
+                  "index": 112,
+                  "text": "JO: Jordan"
+                },
+                "JP": {
+                  "index": 113,
+                  "text": "JP: Japan"
+                },
+                "KE": {
+                  "index": 114,
+                  "text": "KE: Kenya"
+                },
+                "KG": {
+                  "index": 115,
+                  "text": "KG: Kyrgyzstan"
+                },
+                "KH": {
+                  "index": 116,
+                  "text": "KH: Cambodia"
+                },
+                "KI": {
+                  "index": 117,
+                  "text": "KI: Kiribati"
+                },
+                "KM": {
+                  "index": 118,
+                  "text": "KM: Comoros"
+                },
+                "KN": {
+                  "index": 119,
+                  "text": "KN: Saint Kitts and Nevis"
+                },
+                "KP": {
+                  "index": 120,
+                  "text": "KP: Korea, Democratic People's Republic of"
+                },
+                "KR": {
+                  "index": 121,
+                  "text": "KR: Korea, Republic of"
+                },
+                "KW": {
+                  "index": 122,
+                  "text": "KW: Kuwait"
+                },
+                "KY": {
+                  "index": 123,
+                  "text": "KY: Cayman Islands"
+                },
+                "KZ": {
+                  "index": 124,
+                  "text": "KZ: Kazakhstan"
+                },
+                "LA": {
+                  "index": 125,
+                  "text": "LA: Lao People's Democratic Republic"
+                },
+                "LB": {
+                  "index": 126,
+                  "text": "LB: Lebanon"
+                },
+                "LC": {
+                  "index": 127,
+                  "text": "LC: Saint Lucia"
+                },
+                "LI": {
+                  "index": 128,
+                  "text": "LI: Liechtenstein"
+                },
+                "LK": {
+                  "index": 129,
+                  "text": "LK: Sri Lanka"
+                },
+                "LR": {
+                  "index": 130,
+                  "text": "LR: Liberia"
+                },
+                "LS": {
+                  "index": 131,
+                  "text": "LS: Lesotho"
+                },
+                "LT": {
+                  "index": 132,
+                  "text": "LT: Lithuania"
+                },
+                "LU": {
+                  "index": 133,
+                  "text": "LU: Luxembourg"
+                },
+                "LV": {
+                  "index": 134,
+                  "text": "LV: Latvia"
+                },
+                "LY": {
+                  "index": 135,
+                  "text": "LY: Libya"
+                },
+                "MA": {
+                  "index": 136,
+                  "text": "MA: Morocco"
+                },
+                "MC": {
+                  "index": 137,
+                  "text": "MC: Monaco"
+                },
+                "MD": {
+                  "index": 138,
+                  "text": "MD: Moldova, Republic of"
+                },
+                "ME": {
+                  "index": 139,
+                  "text": "ME: Montenegro"
+                },
+                "MF": {
+                  "index": 140,
+                  "text": "MF: Saint Martin (French part)"
+                },
+                "MG": {
+                  "index": 141,
+                  "text": "MG: Madagascar"
+                },
+                "MH": {
+                  "index": 142,
+                  "text": "MH: Marshall Islands"
+                },
+                "MK": {
+                  "index": 143,
+                  "text": "MK: North Macedonia"
+                },
+                "ML": {
+                  "index": 144,
+                  "text": "ML: Mali"
+                },
+                "MM": {
+                  "index": 145,
+                  "text": "MM: Myanmar"
+                },
+                "MN": {
+                  "index": 146,
+                  "text": "MN: Mongolia"
+                },
+                "MO": {
+                  "index": 147,
+                  "text": "MO: Macao"
+                },
+                "MP": {
+                  "index": 148,
+                  "text": "MP: Northern Mariana Islands"
+                },
+                "MQ": {
+                  "index": 149,
+                  "text": "MQ: Martinique"
+                },
+                "MR": {
+                  "index": 150,
+                  "text": "MR: Mauritania"
+                },
+                "MS": {
+                  "index": 151,
+                  "text": "MS: Montserrat"
+                },
+                "MT": {
+                  "index": 152,
+                  "text": "MT: Malta"
+                },
+                "MU": {
+                  "index": 153,
+                  "text": "MU: Mauritius"
+                },
+                "MV": {
+                  "index": 154,
+                  "text": "MV: Maldives"
+                },
+                "MW": {
+                  "index": 155,
+                  "text": "MW: Malawi"
+                },
+                "MX": {
+                  "index": 156,
+                  "text": "MX: Mexico"
+                },
+                "MY": {
+                  "index": 157,
+                  "text": "MY: Malaysia"
+                },
+                "MZ": {
+                  "index": 158,
+                  "text": "MZ: Mozambique"
+                },
+                "NA": {
+                  "index": 159,
+                  "text": "NA: Namibia"
+                },
+                "NC": {
+                  "index": 160,
+                  "text": "NC: New Caledonia"
+                },
+                "NE": {
+                  "index": 161,
+                  "text": "NE: Niger"
+                },
+                "NF": {
+                  "index": 162,
+                  "text": "NF: Norfolk Island"
+                },
+                "NG": {
+                  "index": 163,
+                  "text": "NG: Nigeria"
+                },
+                "NI": {
+                  "index": 164,
+                  "text": "NI: Nicaragua"
+                },
+                "NL": {
+                  "index": 165,
+                  "text": "NL: Netherlands"
+                },
+                "NO": {
+                  "index": 166,
+                  "text": "NO: Norway"
+                },
+                "NP": {
+                  "index": 167,
+                  "text": "NP: Nepal"
+                },
+                "NR": {
+                  "index": 168,
+                  "text": "NR: Nauru"
+                },
+                "NU": {
+                  "index": 169,
+                  "text": "NU: Niue"
+                },
+                "NZ": {
+                  "index": 170,
+                  "text": "NZ: New Zealand"
+                },
+                "OM": {
+                  "index": 171,
+                  "text": "OM: Oman"
+                },
+                "PA": {
+                  "index": 172,
+                  "text": "PA: Panama"
+                },
+                "PE": {
+                  "index": 173,
+                  "text": "PE: Peru"
+                },
+                "PF": {
+                  "index": 174,
+                  "text": "PF: French Polynesia"
+                },
+                "PG": {
+                  "index": 175,
+                  "text": "PG: Papua New Guinea"
+                },
+                "PH": {
+                  "index": 176,
+                  "text": "PH: Philippines"
+                },
+                "PK": {
+                  "index": 177,
+                  "text": "PK: Pakistan"
+                },
+                "PL": {
+                  "index": 178,
+                  "text": "PL: Poland"
+                },
+                "PM": {
+                  "index": 179,
+                  "text": "PM: Saint Pierre and Miquelon"
+                },
+                "PN": {
+                  "index": 180,
+                  "text": "PN: Pitcairn"
+                },
+                "PR": {
+                  "index": 181,
+                  "text": "PR: Puerto Rico"
+                },
+                "PS": {
+                  "index": 182,
+                  "text": "PS: Palestine, State of"
+                },
+                "PT": {
+                  "index": 183,
+                  "text": "PT: Portugal"
+                },
+                "PW": {
+                  "index": 184,
+                  "text": "PW: Palau"
+                },
+                "PY": {
+                  "index": 185,
+                  "text": "PY: Paraguay"
+                },
+                "QA": {
+                  "index": 186,
+                  "text": "QA: Qatar"
+                },
+                "RE": {
+                  "index": 187,
+                  "text": "RE: R\u00e9union"
+                },
+                "RO": {
+                  "index": 188,
+                  "text": "RO: Romania"
+                },
+                "RS": {
+                  "index": 189,
+                  "text": "RS: Serbia"
+                },
+                "RU": {
+                  "index": 190,
+                  "text": "RU: Russian Federation"
+                },
+                "RW": {
+                  "index": 191,
+                  "text": "RW: Rwanda"
+                },
+                "SA": {
+                  "index": 192,
+                  "text": "SA: Saudi Arabia"
+                },
+                "SB": {
+                  "index": 193,
+                  "text": "SB: Solomon Islands"
+                },
+                "SC": {
+                  "index": 194,
+                  "text": "SC: Seychelles"
+                },
+                "SD": {
+                  "index": 195,
+                  "text": "SD: Sudan"
+                },
+                "SE": {
+                  "index": 196,
+                  "text": "SE: Sweden"
+                },
+                "SG": {
+                  "index": 197,
+                  "text": "SG: Singapore"
+                },
+                "SH": {
+                  "index": 198,
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha"
+                },
+                "SI": {
+                  "index": 199,
+                  "text": "SI: Slovenia"
+                },
+                "SJ": {
+                  "index": 200,
+                  "text": "SJ: Svalbard and Jan Mayen"
+                },
+                "SK": {
+                  "index": 201,
+                  "text": "SK: Slovakia"
+                },
+                "SL": {
+                  "index": 202,
+                  "text": "SL: Sierra Leone"
+                },
+                "SM": {
+                  "index": 203,
+                  "text": "SM: San Marino"
+                },
+                "SN": {
+                  "index": 204,
+                  "text": "SN: Senegal"
+                },
+                "SO": {
+                  "index": 205,
+                  "text": "SO: Somalia"
+                },
+                "SR": {
+                  "index": 206,
+                  "text": "SR: Suriname"
+                },
+                "SS": {
+                  "index": 207,
+                  "text": "SS: South Sudan"
+                },
+                "ST": {
+                  "index": 208,
+                  "text": "ST: Sao Tome and Principe"
+                },
+                "SV": {
+                  "index": 209,
+                  "text": "SV: El Salvador"
+                },
+                "SX": {
+                  "index": 210,
+                  "text": "SX: Sint Maarten (Dutch part)"
+                },
+                "SY": {
+                  "index": 211,
+                  "text": "SY: Syrian Arab Republic"
+                },
+                "SZ": {
+                  "index": 212,
+                  "text": "SZ: Eswatini"
+                },
+                "TC": {
+                  "index": 213,
+                  "text": "TC: Turks and Caicos Islands"
+                },
+                "TD": {
+                  "index": 214,
+                  "text": "TD: Chad"
+                },
+                "TF": {
+                  "index": 215,
+                  "text": "TF: French Southern Territories"
+                },
+                "TG": {
+                  "index": 216,
+                  "text": "TG: Togo"
+                },
+                "TH": {
+                  "index": 217,
+                  "text": "TH: Thailand"
+                },
+                "TJ": {
+                  "index": 218,
+                  "text": "TJ: Tajikistan"
+                },
+                "TK": {
+                  "index": 219,
+                  "text": "TK: Tokelau"
+                },
+                "TL": {
+                  "index": 220,
+                  "text": "TL: Timor-Leste"
+                },
+                "TM": {
+                  "index": 221,
+                  "text": "TM: Turkmenistan"
+                },
+                "TN": {
+                  "index": 222,
+                  "text": "TN: Tunisia"
+                },
+                "TO": {
+                  "index": 223,
+                  "text": "TO: Tonga"
+                },
+                "TR": {
+                  "index": 224,
+                  "text": "TR: T\u00fcrkiye"
+                },
+                "TT": {
+                  "index": 225,
+                  "text": "TT: Trinidad and Tobago"
+                },
+                "TV": {
+                  "index": 226,
+                  "text": "TV: Tuvalu"
+                },
+                "TW": {
+                  "index": 227,
+                  "text": "TW: Taiwan, Province of China"
+                },
+                "TZ": {
+                  "index": 228,
+                  "text": "TZ: Tanzania, United Republic of"
+                },
+                "UA": {
+                  "index": 229,
+                  "text": "UA: Ukraine"
+                },
+                "UG": {
+                  "index": 230,
+                  "text": "UG: Uganda"
+                },
+                "UM": {
+                  "index": 231,
+                  "text": "UM: United States Minor Outlying Islands"
+                },
+                "US": {
+                  "index": 232,
+                  "text": "US: United States"
+                },
+                "UY": {
+                  "index": 233,
+                  "text": "UY: Uruguay"
+                },
+                "UZ": {
+                  "index": 234,
+                  "text": "UZ: Uzbekistan"
+                },
+                "VA": {
+                  "index": 235,
+                  "text": "VA: Holy See (Vatican City State)"
+                },
+                "VC": {
+                  "index": 236,
+                  "text": "VC: Saint Vincent and the Grenadines"
+                },
+                "VE": {
+                  "index": 237,
+                  "text": "VE: Venezuela, Bolivarian Republic of"
+                },
+                "VG": {
+                  "index": 238,
+                  "text": "VG: Virgin Islands, British"
+                },
+                "VI": {
+                  "index": 239,
+                  "text": "VI: Virgin Islands, U.S."
+                },
+                "VN": {
+                  "index": 240,
+                  "text": "VN: Viet Nam"
+                },
+                "VU": {
+                  "index": 241,
+                  "text": "VU: Vanuatu"
+                },
+                "WF": {
+                  "index": 242,
+                  "text": "WF: Wallis and Futuna"
+                },
+                "WS": {
+                  "index": 243,
+                  "text": "WS: Samoa"
+                },
+                "YE": {
+                  "index": 244,
+                  "text": "YE: Yemen"
+                },
+                "YT": {
+                  "index": 245,
+                  "text": "YT: Mayotte"
+                },
+                "ZA": {
+                  "index": 246,
+                  "text": "ZA: South Africa"
+                },
+                "ZM": {
+                  "index": 247,
+                  "text": "ZM: Zambia"
+                },
+                "ZW": {
+                  "index": 248,
+                  "text": "ZW: Zimbabwe"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Region"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 264
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Mean"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "legendFormat": "{{region}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Connected Clients by Region \u2014 Stats",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "mean",
+              "max",
+              "lastNotNull"
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Field": "Region",
+              "Last *": "Last",
+              "lastNotNull": "Last"
             }
           }
         }
@@ -441,15 +7290,24 @@
       "type": "table"
     }
   ],
-  "refresh": "30s",
-  "schemaVersion": 39,
-  "tags": ["moav", "conduit", "psiphon"],
-  "templating": { "list": [] },
-  "time": { "from": "now-6h", "to": "now" },
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "moav",
+    "conduit",
+    "psiphon"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "MoaV - Conduit",
-  "uid": "moav-conduit",
-  "version": 3,
-  "weekStart": ""
+  "weekStart": "",
+  "uid": "moav-conduit"
 }

--- a/configs/monitoring/grafana/provisioning/dashboards/conduit.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/conduit.json
@@ -12,6 +12,29 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            7
+          ]
+        },
+        "hide": false,
+        "iconColor": "orange",
+        "name": "Window Max (Connected)",
+        "target": {
+          "expr": "conduit_connected_clients == max_over_time(conduit_connected_clients[$__range:$__interval] @ end())",
+          "interval": "15s",
+          "refId": "Anno"
+        },
+        "textFormat": "{{value}} connected clients",
+        "titleFormat": "Window Max"
       }
     ]
   },
@@ -20,6 +43,486 @@
   "graphTooltip": 1,
   "links": [],
   "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_connecting_clients)",
+          "refId": "A"
+        }
+      ],
+      "title": "Connecting",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "-m"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BW"
+              },
+              {
+                "id": "unit",
+                "value": "bps"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 4,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "titleSize": 11,
+          "valueSize": 18
+        },
+        "textMode": "auto",
+        "wideLayout": false
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_max_common_clients",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_bandwidth_limit_bytes_per_second * 8",
+          "refId": "B"
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 7,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_downloaded)",
+          "refId": "A"
+        }
+      ],
+      "title": "D/L",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 10,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_downloaded[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "D/L Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 14,
+        "y": 0
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_downloaded_lifetime)",
+          "legendFormat": "Lifetime D/L",
+          "refId": "A"
+        }
+      ],
+      "title": "Lifetime D/L",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Max ${client_state_total:text}"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Time"
+              },
+              {
+                "id": "unit",
+                "value": "time:YYYY-MM-DD HH:mm:ss"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 17,
+        "y": 0
+      },
+      "id": 28,
+      "maxDataPoints": 3000,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "titleSize": 11,
+          "valueSize": 14
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "$client_state_total == on() max_over_time($client_state_total[$__range:$__interval] @ end())",
+          "interval": "15s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "timestamp($client_state_total == on() max_over_time($client_state_total[$__range:$__interval] @ end())) * 1000",
+          "interval": "15s",
+          "refId": "B"
+        }
+      ],
+      "title": "Window Max",
+      "type": "stat"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -64,7 +567,7 @@
       "gridPos": {
         "h": 3,
         "w": 3,
-        "x": 0,
+        "x": 21,
         "y": 0
       },
       "id": 5,
@@ -116,22 +619,29 @@
               {
                 "color": "green",
                 "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "orange",
+                "value": 100
               }
             ]
-          },
-          "unit": "decbytes"
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 3,
         "w": 4,
-        "x": 3,
-        "y": 0
+        "x": 0,
+        "y": 3
       },
-      "id": 3,
+      "id": 1,
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
@@ -144,6 +654,9 @@
           "values": false
         },
         "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
         "textMode": "auto",
         "wideLayout": true
       },
@@ -154,11 +667,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(conduit_bytes_downloaded)",
+          "expr": "sum(conduit_connected_clients)",
           "refId": "A"
         }
       ],
-      "title": "Total Download",
+      "title": "Connected",
       "type": "stat"
     },
     {
@@ -169,7 +682,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "purple",
+            "fixedColor": "orange",
             "mode": "fixed"
           },
           "mappings": [],
@@ -177,210 +690,25 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "orange",
                 "value": 0
               }
             ]
           },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 7,
-        "y": 0
-      },
-      "id": 20,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(conduit_bytes_downloaded_lifetime)",
-          "legendFormat": "Lifetime Download",
-          "refId": "A"
-        }
-      ],
-      "title": "Lifetime Download",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "Bps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 11,
-        "y": 0
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(conduit_bytes_downloaded[5m])) + sum(rate(conduit_bytes_uploaded[5m]))",
-          "refId": "A"
-        }
-      ],
-      "title": "Current Rate",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(conduit_connecting_clients)",
-          "refId": "A"
-        }
-      ],
-      "title": "Connecting",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": 0
-              }
-            ]
-          }
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 3,
         "w": 3,
-        "x": 0,
+        "x": 4,
         "y": 3
       },
-      "id": 11,
+      "id": 24,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
+        "colorMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "percentChangeColorMode": "standard",
@@ -402,11 +730,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "conduit_max_common_clients",
+          "expr": "conduit_announcing",
           "refId": "A"
         }
       ],
-      "title": "Max Clients",
+      "title": "Announcing",
       "type": "stat"
     },
     {
@@ -435,13 +763,13 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 3,
+        "w": 3,
+        "x": 7,
         "y": 3
       },
       "id": 4,
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
@@ -468,7 +796,73 @@
           "refId": "A"
         }
       ],
-      "title": "Total Upload",
+      "title": "U/L",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 10,
+        "y": 3
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_uploaded[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "U/L Rate",
       "type": "stat"
     },
     {
@@ -498,13 +892,13 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 7,
+        "w": 3,
+        "x": 14,
         "y": 3
       },
       "id": 21,
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
@@ -517,6 +911,9 @@
           "values": false
         },
         "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
         "textMode": "auto",
         "wideLayout": true
       },
@@ -528,11 +925,11 @@
             "uid": "prometheus"
           },
           "expr": "sum(conduit_bytes_uploaded_lifetime)",
-          "legendFormat": "Lifetime Upload",
+          "legendFormat": "Lifetime U/L",
           "refId": "A"
         }
       ],
-      "title": "Lifetime Upload",
+      "title": "Lifetime U/L",
       "type": "stat"
     },
     {
@@ -550,32 +947,105 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
                 "color": "orange",
-                "value": 100
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Session High ${client_state_total:text}"
               }
             ]
           }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 17,
+        "y": 3
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "titleSize": 11,
+          "valueSize": 28
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max_over_time($client_state_total[72h:] @ end())",
+          "refId": "A"
+        }
+      ],
+      "title": "Session High",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "dtdurations"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 20,
+        "w": 3,
+        "x": 21,
         "y": 3
       },
-      "id": 1,
+      "id": 23,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "percentChangeColorMode": "standard",
@@ -597,11 +1067,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(conduit_connected_clients)",
+          "expr": "conduit_uptime_seconds",
           "refId": "A"
         }
       ],
-      "title": "Connected",
+      "title": "Uptime",
       "type": "stat"
     },
     {
@@ -659,11 +1129,81 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connecting"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF0000",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Announcing"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#32CD32",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Connected"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 11,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 6
       },
@@ -704,6 +1244,15 @@
           "expr": "sum(conduit_connecting_clients)",
           "legendFormat": "Connecting",
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_announcing)",
+          "legendFormat": "Announcing",
+          "refId": "C"
         }
       ],
       "title": "Client Connections",
@@ -728,7 +1277,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 20,
+            "fillOpacity": 15,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
@@ -762,18 +1311,74 @@
                 "value": 0
               }
             ]
-          },
-          "unit": "Bps"
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IR"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9e3809",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MM"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "DE",
+                  "IR",
+                  "AZ"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 11,
-        "w": 12,
-        "x": 12,
-        "y": 6
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 17
       },
-      "id": 8,
+      "id": 27,
       "options": {
         "legend": {
           "calcs": [
@@ -783,7 +1388,9 @@
           ],
           "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": true
         },
         "tooltip": {
           "hideZeros": false,
@@ -798,21 +1405,341 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(conduit_bytes_downloaded[5m]))",
-          "legendFormat": "Download",
+          "expr": "$client_state and on (region) topk(5, avg_over_time($client_state[$__range] @ end()))",
+          "legendFormat": "{{region}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 5 Regions by ${client_state:text}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Limited (broker backoff)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ICE Timeouts"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF0000",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Broker Resets"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#32CD32",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "No Match"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFFFFF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "expr": "rate(conduit_log_events_total{type=\"limited\"}[5m])*60",
+          "legendFormat": "Limited (broker backoff)",
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(conduit_bytes_uploaded[5m]))",
-          "legendFormat": "Upload",
+          "expr": "rate(conduit_log_events_total{type=\"ice_timeout\"}[5m])*60",
+          "legendFormat": "ICE Timeouts",
           "refId": "B"
+        },
+        {
+          "expr": "rate(conduit_log_events_total{type=\"broker_reset\"}[5m])*60",
+          "legendFormat": "Broker Resets",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(conduit_log_events_total{type=\"no_match\"}[5m])*60",
+          "legendFormat": "No Match",
+          "refId": "D"
         }
       ],
-      "title": "Bandwidth Rate",
+      "title": "Conduit Log Event Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Invalid IP Packet"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other DoS attack"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF0000",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Policy (filtersets, etc.)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#32CD32",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFFFFF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "expr": "sum(rate(router_log_events_total[60m])*60) by (reason)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Router Log Event Rates (by reason)",
       "type": "timeseries"
     },
     {
@@ -871,13 +1798,44 @@
           },
           "unit": "decbytes"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF0000",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 12,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 17
+        "y": 56
       },
       "id": 9,
       "options": {
@@ -918,6 +1876,1327 @@
       ],
       "title": "Total Bandwidth Over Time",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF0000",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 56
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_downloaded[5m]))",
+          "legendFormat": "Download",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_uploaded[5m]))",
+          "legendFormat": "Upload",
+          "refId": "B"
+        }
+      ],
+      "title": "Bandwidth Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current connected clients and cumulative traffic per region",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "AD": {
+                  "index": 0,
+                  "text": "AD: Andorra"
+                },
+                "AE": {
+                  "index": 1,
+                  "text": "AE: United Arab Emirates"
+                },
+                "AF": {
+                  "index": 2,
+                  "text": "AF: Afghanistan"
+                },
+                "AG": {
+                  "index": 3,
+                  "text": "AG: Antigua and Barbuda"
+                },
+                "AI": {
+                  "index": 4,
+                  "text": "AI: Anguilla"
+                },
+                "AL": {
+                  "index": 5,
+                  "text": "AL: Albania"
+                },
+                "AM": {
+                  "index": 6,
+                  "text": "AM: Armenia"
+                },
+                "AO": {
+                  "index": 7,
+                  "text": "AO: Angola"
+                },
+                "AQ": {
+                  "index": 8,
+                  "text": "AQ: Antarctica"
+                },
+                "AR": {
+                  "index": 9,
+                  "text": "AR: Argentina"
+                },
+                "AS": {
+                  "index": 10,
+                  "text": "AS: American Samoa"
+                },
+                "AT": {
+                  "index": 11,
+                  "text": "AT: Austria"
+                },
+                "AU": {
+                  "index": 12,
+                  "text": "AU: Australia"
+                },
+                "AW": {
+                  "index": 13,
+                  "text": "AW: Aruba"
+                },
+                "AX": {
+                  "index": 14,
+                  "text": "AX: \u00c5land Islands"
+                },
+                "AZ": {
+                  "index": 15,
+                  "text": "AZ: Azerbaijan"
+                },
+                "BA": {
+                  "index": 16,
+                  "text": "BA: Bosnia and Herzegovina"
+                },
+                "BB": {
+                  "index": 17,
+                  "text": "BB: Barbados"
+                },
+                "BD": {
+                  "index": 18,
+                  "text": "BD: Bangladesh"
+                },
+                "BE": {
+                  "index": 19,
+                  "text": "BE: Belgium"
+                },
+                "BF": {
+                  "index": 20,
+                  "text": "BF: Burkina Faso"
+                },
+                "BG": {
+                  "index": 21,
+                  "text": "BG: Bulgaria"
+                },
+                "BH": {
+                  "index": 22,
+                  "text": "BH: Bahrain"
+                },
+                "BI": {
+                  "index": 23,
+                  "text": "BI: Burundi"
+                },
+                "BJ": {
+                  "index": 24,
+                  "text": "BJ: Benin"
+                },
+                "BL": {
+                  "index": 25,
+                  "text": "BL: Saint Barth\u00e9lemy"
+                },
+                "BM": {
+                  "index": 26,
+                  "text": "BM: Bermuda"
+                },
+                "BN": {
+                  "index": 27,
+                  "text": "BN: Brunei Darussalam"
+                },
+                "BO": {
+                  "index": 28,
+                  "text": "BO: Bolivia, Plurinational State of"
+                },
+                "BQ": {
+                  "index": 29,
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba"
+                },
+                "BR": {
+                  "index": 30,
+                  "text": "BR: Brazil"
+                },
+                "BS": {
+                  "index": 31,
+                  "text": "BS: Bahamas"
+                },
+                "BT": {
+                  "index": 32,
+                  "text": "BT: Bhutan"
+                },
+                "BV": {
+                  "index": 33,
+                  "text": "BV: Bouvet Island"
+                },
+                "BW": {
+                  "index": 34,
+                  "text": "BW: Botswana"
+                },
+                "BY": {
+                  "index": 35,
+                  "text": "BY: Belarus"
+                },
+                "BZ": {
+                  "index": 36,
+                  "text": "BZ: Belize"
+                },
+                "CA": {
+                  "index": 37,
+                  "text": "CA: Canada"
+                },
+                "CC": {
+                  "index": 38,
+                  "text": "CC: Cocos (Keeling) Islands"
+                },
+                "CD": {
+                  "index": 39,
+                  "text": "CD: Congo, The Democratic Republic of the"
+                },
+                "CF": {
+                  "index": 40,
+                  "text": "CF: Central African Republic"
+                },
+                "CG": {
+                  "index": 41,
+                  "text": "CG: Congo"
+                },
+                "CH": {
+                  "index": 42,
+                  "text": "CH: Switzerland"
+                },
+                "CI": {
+                  "index": 43,
+                  "text": "CI: C\u00f4te d'Ivoire"
+                },
+                "CK": {
+                  "index": 44,
+                  "text": "CK: Cook Islands"
+                },
+                "CL": {
+                  "index": 45,
+                  "text": "CL: Chile"
+                },
+                "CM": {
+                  "index": 46,
+                  "text": "CM: Cameroon"
+                },
+                "CN": {
+                  "index": 47,
+                  "text": "CN: China"
+                },
+                "CO": {
+                  "index": 48,
+                  "text": "CO: Colombia"
+                },
+                "CR": {
+                  "index": 49,
+                  "text": "CR: Costa Rica"
+                },
+                "CU": {
+                  "index": 50,
+                  "text": "CU: Cuba"
+                },
+                "CV": {
+                  "index": 51,
+                  "text": "CV: Cabo Verde"
+                },
+                "CW": {
+                  "index": 52,
+                  "text": "CW: Cura\u00e7ao"
+                },
+                "CX": {
+                  "index": 53,
+                  "text": "CX: Christmas Island"
+                },
+                "CY": {
+                  "index": 54,
+                  "text": "CY: Cyprus"
+                },
+                "CZ": {
+                  "index": 55,
+                  "text": "CZ: Czechia"
+                },
+                "DE": {
+                  "index": 56,
+                  "text": "DE: Germany"
+                },
+                "DJ": {
+                  "index": 57,
+                  "text": "DJ: Djibouti"
+                },
+                "DK": {
+                  "index": 58,
+                  "text": "DK: Denmark"
+                },
+                "DM": {
+                  "index": 59,
+                  "text": "DM: Dominica"
+                },
+                "DO": {
+                  "index": 60,
+                  "text": "DO: Dominican Republic"
+                },
+                "DZ": {
+                  "index": 61,
+                  "text": "DZ: Algeria"
+                },
+                "EC": {
+                  "index": 62,
+                  "text": "EC: Ecuador"
+                },
+                "EE": {
+                  "index": 63,
+                  "text": "EE: Estonia"
+                },
+                "EG": {
+                  "index": 64,
+                  "text": "EG: Egypt"
+                },
+                "EH": {
+                  "index": 65,
+                  "text": "EH: Western Sahara"
+                },
+                "ER": {
+                  "index": 66,
+                  "text": "ER: Eritrea"
+                },
+                "ES": {
+                  "index": 67,
+                  "text": "ES: Spain"
+                },
+                "ET": {
+                  "index": 68,
+                  "text": "ET: Ethiopia"
+                },
+                "FI": {
+                  "index": 69,
+                  "text": "FI: Finland"
+                },
+                "FJ": {
+                  "index": 70,
+                  "text": "FJ: Fiji"
+                },
+                "FK": {
+                  "index": 71,
+                  "text": "FK: Falkland Islands (Malvinas)"
+                },
+                "FM": {
+                  "index": 72,
+                  "text": "FM: Micronesia, Federated States of"
+                },
+                "FO": {
+                  "index": 73,
+                  "text": "FO: Faroe Islands"
+                },
+                "FR": {
+                  "index": 74,
+                  "text": "FR: France"
+                },
+                "GA": {
+                  "index": 75,
+                  "text": "GA: Gabon"
+                },
+                "GB": {
+                  "index": 76,
+                  "text": "GB: United Kingdom"
+                },
+                "GD": {
+                  "index": 77,
+                  "text": "GD: Grenada"
+                },
+                "GE": {
+                  "index": 78,
+                  "text": "GE: Georgia"
+                },
+                "GF": {
+                  "index": 79,
+                  "text": "GF: French Guiana"
+                },
+                "GG": {
+                  "index": 80,
+                  "text": "GG: Guernsey"
+                },
+                "GH": {
+                  "index": 81,
+                  "text": "GH: Ghana"
+                },
+                "GI": {
+                  "index": 82,
+                  "text": "GI: Gibraltar"
+                },
+                "GL": {
+                  "index": 83,
+                  "text": "GL: Greenland"
+                },
+                "GM": {
+                  "index": 84,
+                  "text": "GM: Gambia"
+                },
+                "GN": {
+                  "index": 85,
+                  "text": "GN: Guinea"
+                },
+                "GP": {
+                  "index": 86,
+                  "text": "GP: Guadeloupe"
+                },
+                "GQ": {
+                  "index": 87,
+                  "text": "GQ: Equatorial Guinea"
+                },
+                "GR": {
+                  "index": 88,
+                  "text": "GR: Greece"
+                },
+                "GS": {
+                  "index": 89,
+                  "text": "GS: South Georgia and the South Sandwich Islands"
+                },
+                "GT": {
+                  "index": 90,
+                  "text": "GT: Guatemala"
+                },
+                "GU": {
+                  "index": 91,
+                  "text": "GU: Guam"
+                },
+                "GW": {
+                  "index": 92,
+                  "text": "GW: Guinea-Bissau"
+                },
+                "GY": {
+                  "index": 93,
+                  "text": "GY: Guyana"
+                },
+                "HK": {
+                  "index": 94,
+                  "text": "HK: Hong Kong"
+                },
+                "HM": {
+                  "index": 95,
+                  "text": "HM: Heard Island and McDonald Islands"
+                },
+                "HN": {
+                  "index": 96,
+                  "text": "HN: Honduras"
+                },
+                "HR": {
+                  "index": 97,
+                  "text": "HR: Croatia"
+                },
+                "HT": {
+                  "index": 98,
+                  "text": "HT: Haiti"
+                },
+                "HU": {
+                  "index": 99,
+                  "text": "HU: Hungary"
+                },
+                "ID": {
+                  "index": 100,
+                  "text": "ID: Indonesia"
+                },
+                "IE": {
+                  "index": 101,
+                  "text": "IE: Ireland"
+                },
+                "IL": {
+                  "index": 102,
+                  "text": "IL: Israel"
+                },
+                "IM": {
+                  "index": 103,
+                  "text": "IM: Isle of Man"
+                },
+                "IN": {
+                  "index": 104,
+                  "text": "IN: India"
+                },
+                "IO": {
+                  "index": 105,
+                  "text": "IO: British Indian Ocean Territory"
+                },
+                "IQ": {
+                  "index": 106,
+                  "text": "IQ: Iraq"
+                },
+                "IR": {
+                  "index": 107,
+                  "text": "IR: Iran, Islamic Republic of"
+                },
+                "IS": {
+                  "index": 108,
+                  "text": "IS: Iceland"
+                },
+                "IT": {
+                  "index": 109,
+                  "text": "IT: Italy"
+                },
+                "JE": {
+                  "index": 110,
+                  "text": "JE: Jersey"
+                },
+                "JM": {
+                  "index": 111,
+                  "text": "JM: Jamaica"
+                },
+                "JO": {
+                  "index": 112,
+                  "text": "JO: Jordan"
+                },
+                "JP": {
+                  "index": 113,
+                  "text": "JP: Japan"
+                },
+                "KE": {
+                  "index": 114,
+                  "text": "KE: Kenya"
+                },
+                "KG": {
+                  "index": 115,
+                  "text": "KG: Kyrgyzstan"
+                },
+                "KH": {
+                  "index": 116,
+                  "text": "KH: Cambodia"
+                },
+                "KI": {
+                  "index": 117,
+                  "text": "KI: Kiribati"
+                },
+                "KM": {
+                  "index": 118,
+                  "text": "KM: Comoros"
+                },
+                "KN": {
+                  "index": 119,
+                  "text": "KN: Saint Kitts and Nevis"
+                },
+                "KP": {
+                  "index": 120,
+                  "text": "KP: Korea, Democratic People's Republic of"
+                },
+                "KR": {
+                  "index": 121,
+                  "text": "KR: Korea, Republic of"
+                },
+                "KW": {
+                  "index": 122,
+                  "text": "KW: Kuwait"
+                },
+                "KY": {
+                  "index": 123,
+                  "text": "KY: Cayman Islands"
+                },
+                "KZ": {
+                  "index": 124,
+                  "text": "KZ: Kazakhstan"
+                },
+                "LA": {
+                  "index": 125,
+                  "text": "LA: Lao People's Democratic Republic"
+                },
+                "LB": {
+                  "index": 126,
+                  "text": "LB: Lebanon"
+                },
+                "LC": {
+                  "index": 127,
+                  "text": "LC: Saint Lucia"
+                },
+                "LI": {
+                  "index": 128,
+                  "text": "LI: Liechtenstein"
+                },
+                "LK": {
+                  "index": 129,
+                  "text": "LK: Sri Lanka"
+                },
+                "LR": {
+                  "index": 130,
+                  "text": "LR: Liberia"
+                },
+                "LS": {
+                  "index": 131,
+                  "text": "LS: Lesotho"
+                },
+                "LT": {
+                  "index": 132,
+                  "text": "LT: Lithuania"
+                },
+                "LU": {
+                  "index": 133,
+                  "text": "LU: Luxembourg"
+                },
+                "LV": {
+                  "index": 134,
+                  "text": "LV: Latvia"
+                },
+                "LY": {
+                  "index": 135,
+                  "text": "LY: Libya"
+                },
+                "MA": {
+                  "index": 136,
+                  "text": "MA: Morocco"
+                },
+                "MC": {
+                  "index": 137,
+                  "text": "MC: Monaco"
+                },
+                "MD": {
+                  "index": 138,
+                  "text": "MD: Moldova, Republic of"
+                },
+                "ME": {
+                  "index": 139,
+                  "text": "ME: Montenegro"
+                },
+                "MF": {
+                  "index": 140,
+                  "text": "MF: Saint Martin (French part)"
+                },
+                "MG": {
+                  "index": 141,
+                  "text": "MG: Madagascar"
+                },
+                "MH": {
+                  "index": 142,
+                  "text": "MH: Marshall Islands"
+                },
+                "MK": {
+                  "index": 143,
+                  "text": "MK: North Macedonia"
+                },
+                "ML": {
+                  "index": 144,
+                  "text": "ML: Mali"
+                },
+                "MM": {
+                  "index": 145,
+                  "text": "MM: Myanmar"
+                },
+                "MN": {
+                  "index": 146,
+                  "text": "MN: Mongolia"
+                },
+                "MO": {
+                  "index": 147,
+                  "text": "MO: Macao"
+                },
+                "MP": {
+                  "index": 148,
+                  "text": "MP: Northern Mariana Islands"
+                },
+                "MQ": {
+                  "index": 149,
+                  "text": "MQ: Martinique"
+                },
+                "MR": {
+                  "index": 150,
+                  "text": "MR: Mauritania"
+                },
+                "MS": {
+                  "index": 151,
+                  "text": "MS: Montserrat"
+                },
+                "MT": {
+                  "index": 152,
+                  "text": "MT: Malta"
+                },
+                "MU": {
+                  "index": 153,
+                  "text": "MU: Mauritius"
+                },
+                "MV": {
+                  "index": 154,
+                  "text": "MV: Maldives"
+                },
+                "MW": {
+                  "index": 155,
+                  "text": "MW: Malawi"
+                },
+                "MX": {
+                  "index": 156,
+                  "text": "MX: Mexico"
+                },
+                "MY": {
+                  "index": 157,
+                  "text": "MY: Malaysia"
+                },
+                "MZ": {
+                  "index": 158,
+                  "text": "MZ: Mozambique"
+                },
+                "NA": {
+                  "index": 159,
+                  "text": "NA: Namibia"
+                },
+                "NC": {
+                  "index": 160,
+                  "text": "NC: New Caledonia"
+                },
+                "NE": {
+                  "index": 161,
+                  "text": "NE: Niger"
+                },
+                "NF": {
+                  "index": 162,
+                  "text": "NF: Norfolk Island"
+                },
+                "NG": {
+                  "index": 163,
+                  "text": "NG: Nigeria"
+                },
+                "NI": {
+                  "index": 164,
+                  "text": "NI: Nicaragua"
+                },
+                "NL": {
+                  "index": 165,
+                  "text": "NL: Netherlands"
+                },
+                "NO": {
+                  "index": 166,
+                  "text": "NO: Norway"
+                },
+                "NP": {
+                  "index": 167,
+                  "text": "NP: Nepal"
+                },
+                "NR": {
+                  "index": 168,
+                  "text": "NR: Nauru"
+                },
+                "NU": {
+                  "index": 169,
+                  "text": "NU: Niue"
+                },
+                "NZ": {
+                  "index": 170,
+                  "text": "NZ: New Zealand"
+                },
+                "OM": {
+                  "index": 171,
+                  "text": "OM: Oman"
+                },
+                "PA": {
+                  "index": 172,
+                  "text": "PA: Panama"
+                },
+                "PE": {
+                  "index": 173,
+                  "text": "PE: Peru"
+                },
+                "PF": {
+                  "index": 174,
+                  "text": "PF: French Polynesia"
+                },
+                "PG": {
+                  "index": 175,
+                  "text": "PG: Papua New Guinea"
+                },
+                "PH": {
+                  "index": 176,
+                  "text": "PH: Philippines"
+                },
+                "PK": {
+                  "index": 177,
+                  "text": "PK: Pakistan"
+                },
+                "PL": {
+                  "index": 178,
+                  "text": "PL: Poland"
+                },
+                "PM": {
+                  "index": 179,
+                  "text": "PM: Saint Pierre and Miquelon"
+                },
+                "PN": {
+                  "index": 180,
+                  "text": "PN: Pitcairn"
+                },
+                "PR": {
+                  "index": 181,
+                  "text": "PR: Puerto Rico"
+                },
+                "PS": {
+                  "index": 182,
+                  "text": "PS: Palestine, State of"
+                },
+                "PT": {
+                  "index": 183,
+                  "text": "PT: Portugal"
+                },
+                "PW": {
+                  "index": 184,
+                  "text": "PW: Palau"
+                },
+                "PY": {
+                  "index": 185,
+                  "text": "PY: Paraguay"
+                },
+                "QA": {
+                  "index": 186,
+                  "text": "QA: Qatar"
+                },
+                "RE": {
+                  "index": 187,
+                  "text": "RE: R\u00e9union"
+                },
+                "RO": {
+                  "index": 188,
+                  "text": "RO: Romania"
+                },
+                "RS": {
+                  "index": 189,
+                  "text": "RS: Serbia"
+                },
+                "RU": {
+                  "index": 190,
+                  "text": "RU: Russian Federation"
+                },
+                "RW": {
+                  "index": 191,
+                  "text": "RW: Rwanda"
+                },
+                "SA": {
+                  "index": 192,
+                  "text": "SA: Saudi Arabia"
+                },
+                "SB": {
+                  "index": 193,
+                  "text": "SB: Solomon Islands"
+                },
+                "SC": {
+                  "index": 194,
+                  "text": "SC: Seychelles"
+                },
+                "SD": {
+                  "index": 195,
+                  "text": "SD: Sudan"
+                },
+                "SE": {
+                  "index": 196,
+                  "text": "SE: Sweden"
+                },
+                "SG": {
+                  "index": 197,
+                  "text": "SG: Singapore"
+                },
+                "SH": {
+                  "index": 198,
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha"
+                },
+                "SI": {
+                  "index": 199,
+                  "text": "SI: Slovenia"
+                },
+                "SJ": {
+                  "index": 200,
+                  "text": "SJ: Svalbard and Jan Mayen"
+                },
+                "SK": {
+                  "index": 201,
+                  "text": "SK: Slovakia"
+                },
+                "SL": {
+                  "index": 202,
+                  "text": "SL: Sierra Leone"
+                },
+                "SM": {
+                  "index": 203,
+                  "text": "SM: San Marino"
+                },
+                "SN": {
+                  "index": 204,
+                  "text": "SN: Senegal"
+                },
+                "SO": {
+                  "index": 205,
+                  "text": "SO: Somalia"
+                },
+                "SR": {
+                  "index": 206,
+                  "text": "SR: Suriname"
+                },
+                "SS": {
+                  "index": 207,
+                  "text": "SS: South Sudan"
+                },
+                "ST": {
+                  "index": 208,
+                  "text": "ST: Sao Tome and Principe"
+                },
+                "SV": {
+                  "index": 209,
+                  "text": "SV: El Salvador"
+                },
+                "SX": {
+                  "index": 210,
+                  "text": "SX: Sint Maarten (Dutch part)"
+                },
+                "SY": {
+                  "index": 211,
+                  "text": "SY: Syrian Arab Republic"
+                },
+                "SZ": {
+                  "index": 212,
+                  "text": "SZ: Eswatini"
+                },
+                "TC": {
+                  "index": 213,
+                  "text": "TC: Turks and Caicos Islands"
+                },
+                "TD": {
+                  "index": 214,
+                  "text": "TD: Chad"
+                },
+                "TF": {
+                  "index": 215,
+                  "text": "TF: French Southern Territories"
+                },
+                "TG": {
+                  "index": 216,
+                  "text": "TG: Togo"
+                },
+                "TH": {
+                  "index": 217,
+                  "text": "TH: Thailand"
+                },
+                "TJ": {
+                  "index": 218,
+                  "text": "TJ: Tajikistan"
+                },
+                "TK": {
+                  "index": 219,
+                  "text": "TK: Tokelau"
+                },
+                "TL": {
+                  "index": 220,
+                  "text": "TL: Timor-Leste"
+                },
+                "TM": {
+                  "index": 221,
+                  "text": "TM: Turkmenistan"
+                },
+                "TN": {
+                  "index": 222,
+                  "text": "TN: Tunisia"
+                },
+                "TO": {
+                  "index": 223,
+                  "text": "TO: Tonga"
+                },
+                "TR": {
+                  "index": 224,
+                  "text": "TR: T\u00fcrkiye"
+                },
+                "TT": {
+                  "index": 225,
+                  "text": "TT: Trinidad and Tobago"
+                },
+                "TV": {
+                  "index": 226,
+                  "text": "TV: Tuvalu"
+                },
+                "TW": {
+                  "index": 227,
+                  "text": "TW: Taiwan, Province of China"
+                },
+                "TZ": {
+                  "index": 228,
+                  "text": "TZ: Tanzania, United Republic of"
+                },
+                "UA": {
+                  "index": 229,
+                  "text": "UA: Ukraine"
+                },
+                "UG": {
+                  "index": 230,
+                  "text": "UG: Uganda"
+                },
+                "UM": {
+                  "index": 231,
+                  "text": "UM: United States Minor Outlying Islands"
+                },
+                "US": {
+                  "index": 232,
+                  "text": "US: United States"
+                },
+                "UY": {
+                  "index": 233,
+                  "text": "UY: Uruguay"
+                },
+                "UZ": {
+                  "index": 234,
+                  "text": "UZ: Uzbekistan"
+                },
+                "VA": {
+                  "index": 235,
+                  "text": "VA: Holy See (Vatican City State)"
+                },
+                "VC": {
+                  "index": 236,
+                  "text": "VC: Saint Vincent and the Grenadines"
+                },
+                "VE": {
+                  "index": 237,
+                  "text": "VE: Venezuela, Bolivarian Republic of"
+                },
+                "VG": {
+                  "index": 238,
+                  "text": "VG: Virgin Islands, British"
+                },
+                "VI": {
+                  "index": 239,
+                  "text": "VI: Virgin Islands, U.S."
+                },
+                "VN": {
+                  "index": 240,
+                  "text": "VN: Viet Nam"
+                },
+                "VU": {
+                  "index": 241,
+                  "text": "VU: Vanuatu"
+                },
+                "WF": {
+                  "index": 242,
+                  "text": "WF: Wallis and Futuna"
+                },
+                "WS": {
+                  "index": 243,
+                  "text": "WS: Samoa"
+                },
+                "YE": {
+                  "index": 244,
+                  "text": "YE: Yemen"
+                },
+                "YT": {
+                  "index": 245,
+                  "text": "YT: Mayotte"
+                },
+                "ZA": {
+                  "index": 246,
+                  "text": "ZA: South Africa"
+                },
+                "ZM": {
+                  "index": 247,
+                  "text": "ZM: Zambia"
+                },
+                "ZW": {
+                  "index": 248,
+                  "text": "ZW: Zimbabwe"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Region"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 223
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "include",
+                "names": [
+                  "Connected",
+                  "Download",
+                  "Upload"
+                ]
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.footer.reducers",
+                "value": [
+                  "sum"
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connected"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 117
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 62,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "id": 13,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Connected"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "format": "table",
+          "instant": true,
+          "refId": "Connected"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (increase(conduit_region_bytes_downloaded[1h]))",
+          "format": "table",
+          "instant": true,
+          "refId": "Download"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (increase(conduit_region_bytes_uploaded[1h]))",
+          "format": "table",
+          "instant": true,
+          "refId": "Upload"
+        }
+      ],
+      "title": "Traffic by Region",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "region"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
+            "renameByName": {
+              "Value #Connected": "Connected",
+              "Value #Download": "Download",
+              "Value #Upload": "Upload",
+              "region": "Region"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "datasource": {
@@ -4968,18 +7247,22 @@
         ]
       },
       "gridPos": {
-        "h": 16,
+        "h": 25,
         "w": 12,
         "x": 12,
-        "y": 17
+        "y": 65
       },
       "id": 12,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "hidden",
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
@@ -4994,1197 +7277,13 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "expr": "conduit_region_connected_clients and on (region) topk(15, avg_over_time(conduit_region_connected_clients[$__range] @ end()))",
           "legendFormat": "{{region}}",
           "refId": "A"
         }
       ],
       "title": "Connected Clients by Region",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Current connected clients and cumulative traffic per region",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "mappings": [
-            {
-              "options": {
-                "AD": {
-                  "index": 0,
-                  "text": "AD: Andorra"
-                },
-                "AE": {
-                  "index": 1,
-                  "text": "AE: United Arab Emirates"
-                },
-                "AF": {
-                  "index": 2,
-                  "text": "AF: Afghanistan"
-                },
-                "AG": {
-                  "index": 3,
-                  "text": "AG: Antigua and Barbuda"
-                },
-                "AI": {
-                  "index": 4,
-                  "text": "AI: Anguilla"
-                },
-                "AL": {
-                  "index": 5,
-                  "text": "AL: Albania"
-                },
-                "AM": {
-                  "index": 6,
-                  "text": "AM: Armenia"
-                },
-                "AO": {
-                  "index": 7,
-                  "text": "AO: Angola"
-                },
-                "AQ": {
-                  "index": 8,
-                  "text": "AQ: Antarctica"
-                },
-                "AR": {
-                  "index": 9,
-                  "text": "AR: Argentina"
-                },
-                "AS": {
-                  "index": 10,
-                  "text": "AS: American Samoa"
-                },
-                "AT": {
-                  "index": 11,
-                  "text": "AT: Austria"
-                },
-                "AU": {
-                  "index": 12,
-                  "text": "AU: Australia"
-                },
-                "AW": {
-                  "index": 13,
-                  "text": "AW: Aruba"
-                },
-                "AX": {
-                  "index": 14,
-                  "text": "AX: \u00c5land Islands"
-                },
-                "AZ": {
-                  "index": 15,
-                  "text": "AZ: Azerbaijan"
-                },
-                "BA": {
-                  "index": 16,
-                  "text": "BA: Bosnia and Herzegovina"
-                },
-                "BB": {
-                  "index": 17,
-                  "text": "BB: Barbados"
-                },
-                "BD": {
-                  "index": 18,
-                  "text": "BD: Bangladesh"
-                },
-                "BE": {
-                  "index": 19,
-                  "text": "BE: Belgium"
-                },
-                "BF": {
-                  "index": 20,
-                  "text": "BF: Burkina Faso"
-                },
-                "BG": {
-                  "index": 21,
-                  "text": "BG: Bulgaria"
-                },
-                "BH": {
-                  "index": 22,
-                  "text": "BH: Bahrain"
-                },
-                "BI": {
-                  "index": 23,
-                  "text": "BI: Burundi"
-                },
-                "BJ": {
-                  "index": 24,
-                  "text": "BJ: Benin"
-                },
-                "BL": {
-                  "index": 25,
-                  "text": "BL: Saint Barth\u00e9lemy"
-                },
-                "BM": {
-                  "index": 26,
-                  "text": "BM: Bermuda"
-                },
-                "BN": {
-                  "index": 27,
-                  "text": "BN: Brunei Darussalam"
-                },
-                "BO": {
-                  "index": 28,
-                  "text": "BO: Bolivia, Plurinational State of"
-                },
-                "BQ": {
-                  "index": 29,
-                  "text": "BQ: Bonaire, Sint Eustatius and Saba"
-                },
-                "BR": {
-                  "index": 30,
-                  "text": "BR: Brazil"
-                },
-                "BS": {
-                  "index": 31,
-                  "text": "BS: Bahamas"
-                },
-                "BT": {
-                  "index": 32,
-                  "text": "BT: Bhutan"
-                },
-                "BV": {
-                  "index": 33,
-                  "text": "BV: Bouvet Island"
-                },
-                "BW": {
-                  "index": 34,
-                  "text": "BW: Botswana"
-                },
-                "BY": {
-                  "index": 35,
-                  "text": "BY: Belarus"
-                },
-                "BZ": {
-                  "index": 36,
-                  "text": "BZ: Belize"
-                },
-                "CA": {
-                  "index": 37,
-                  "text": "CA: Canada"
-                },
-                "CC": {
-                  "index": 38,
-                  "text": "CC: Cocos (Keeling) Islands"
-                },
-                "CD": {
-                  "index": 39,
-                  "text": "CD: Congo, The Democratic Republic of the"
-                },
-                "CF": {
-                  "index": 40,
-                  "text": "CF: Central African Republic"
-                },
-                "CG": {
-                  "index": 41,
-                  "text": "CG: Congo"
-                },
-                "CH": {
-                  "index": 42,
-                  "text": "CH: Switzerland"
-                },
-                "CI": {
-                  "index": 43,
-                  "text": "CI: C\u00f4te d'Ivoire"
-                },
-                "CK": {
-                  "index": 44,
-                  "text": "CK: Cook Islands"
-                },
-                "CL": {
-                  "index": 45,
-                  "text": "CL: Chile"
-                },
-                "CM": {
-                  "index": 46,
-                  "text": "CM: Cameroon"
-                },
-                "CN": {
-                  "index": 47,
-                  "text": "CN: China"
-                },
-                "CO": {
-                  "index": 48,
-                  "text": "CO: Colombia"
-                },
-                "CR": {
-                  "index": 49,
-                  "text": "CR: Costa Rica"
-                },
-                "CU": {
-                  "index": 50,
-                  "text": "CU: Cuba"
-                },
-                "CV": {
-                  "index": 51,
-                  "text": "CV: Cabo Verde"
-                },
-                "CW": {
-                  "index": 52,
-                  "text": "CW: Cura\u00e7ao"
-                },
-                "CX": {
-                  "index": 53,
-                  "text": "CX: Christmas Island"
-                },
-                "CY": {
-                  "index": 54,
-                  "text": "CY: Cyprus"
-                },
-                "CZ": {
-                  "index": 55,
-                  "text": "CZ: Czechia"
-                },
-                "DE": {
-                  "index": 56,
-                  "text": "DE: Germany"
-                },
-                "DJ": {
-                  "index": 57,
-                  "text": "DJ: Djibouti"
-                },
-                "DK": {
-                  "index": 58,
-                  "text": "DK: Denmark"
-                },
-                "DM": {
-                  "index": 59,
-                  "text": "DM: Dominica"
-                },
-                "DO": {
-                  "index": 60,
-                  "text": "DO: Dominican Republic"
-                },
-                "DZ": {
-                  "index": 61,
-                  "text": "DZ: Algeria"
-                },
-                "EC": {
-                  "index": 62,
-                  "text": "EC: Ecuador"
-                },
-                "EE": {
-                  "index": 63,
-                  "text": "EE: Estonia"
-                },
-                "EG": {
-                  "index": 64,
-                  "text": "EG: Egypt"
-                },
-                "EH": {
-                  "index": 65,
-                  "text": "EH: Western Sahara"
-                },
-                "ER": {
-                  "index": 66,
-                  "text": "ER: Eritrea"
-                },
-                "ES": {
-                  "index": 67,
-                  "text": "ES: Spain"
-                },
-                "ET": {
-                  "index": 68,
-                  "text": "ET: Ethiopia"
-                },
-                "FI": {
-                  "index": 69,
-                  "text": "FI: Finland"
-                },
-                "FJ": {
-                  "index": 70,
-                  "text": "FJ: Fiji"
-                },
-                "FK": {
-                  "index": 71,
-                  "text": "FK: Falkland Islands (Malvinas)"
-                },
-                "FM": {
-                  "index": 72,
-                  "text": "FM: Micronesia, Federated States of"
-                },
-                "FO": {
-                  "index": 73,
-                  "text": "FO: Faroe Islands"
-                },
-                "FR": {
-                  "index": 74,
-                  "text": "FR: France"
-                },
-                "GA": {
-                  "index": 75,
-                  "text": "GA: Gabon"
-                },
-                "GB": {
-                  "index": 76,
-                  "text": "GB: United Kingdom"
-                },
-                "GD": {
-                  "index": 77,
-                  "text": "GD: Grenada"
-                },
-                "GE": {
-                  "index": 78,
-                  "text": "GE: Georgia"
-                },
-                "GF": {
-                  "index": 79,
-                  "text": "GF: French Guiana"
-                },
-                "GG": {
-                  "index": 80,
-                  "text": "GG: Guernsey"
-                },
-                "GH": {
-                  "index": 81,
-                  "text": "GH: Ghana"
-                },
-                "GI": {
-                  "index": 82,
-                  "text": "GI: Gibraltar"
-                },
-                "GL": {
-                  "index": 83,
-                  "text": "GL: Greenland"
-                },
-                "GM": {
-                  "index": 84,
-                  "text": "GM: Gambia"
-                },
-                "GN": {
-                  "index": 85,
-                  "text": "GN: Guinea"
-                },
-                "GP": {
-                  "index": 86,
-                  "text": "GP: Guadeloupe"
-                },
-                "GQ": {
-                  "index": 87,
-                  "text": "GQ: Equatorial Guinea"
-                },
-                "GR": {
-                  "index": 88,
-                  "text": "GR: Greece"
-                },
-                "GS": {
-                  "index": 89,
-                  "text": "GS: South Georgia and the South Sandwich Islands"
-                },
-                "GT": {
-                  "index": 90,
-                  "text": "GT: Guatemala"
-                },
-                "GU": {
-                  "index": 91,
-                  "text": "GU: Guam"
-                },
-                "GW": {
-                  "index": 92,
-                  "text": "GW: Guinea-Bissau"
-                },
-                "GY": {
-                  "index": 93,
-                  "text": "GY: Guyana"
-                },
-                "HK": {
-                  "index": 94,
-                  "text": "HK: Hong Kong"
-                },
-                "HM": {
-                  "index": 95,
-                  "text": "HM: Heard Island and McDonald Islands"
-                },
-                "HN": {
-                  "index": 96,
-                  "text": "HN: Honduras"
-                },
-                "HR": {
-                  "index": 97,
-                  "text": "HR: Croatia"
-                },
-                "HT": {
-                  "index": 98,
-                  "text": "HT: Haiti"
-                },
-                "HU": {
-                  "index": 99,
-                  "text": "HU: Hungary"
-                },
-                "ID": {
-                  "index": 100,
-                  "text": "ID: Indonesia"
-                },
-                "IE": {
-                  "index": 101,
-                  "text": "IE: Ireland"
-                },
-                "IL": {
-                  "index": 102,
-                  "text": "IL: Israel"
-                },
-                "IM": {
-                  "index": 103,
-                  "text": "IM: Isle of Man"
-                },
-                "IN": {
-                  "index": 104,
-                  "text": "IN: India"
-                },
-                "IO": {
-                  "index": 105,
-                  "text": "IO: British Indian Ocean Territory"
-                },
-                "IQ": {
-                  "index": 106,
-                  "text": "IQ: Iraq"
-                },
-                "IR": {
-                  "index": 107,
-                  "text": "IR: Iran, Islamic Republic of"
-                },
-                "IS": {
-                  "index": 108,
-                  "text": "IS: Iceland"
-                },
-                "IT": {
-                  "index": 109,
-                  "text": "IT: Italy"
-                },
-                "JE": {
-                  "index": 110,
-                  "text": "JE: Jersey"
-                },
-                "JM": {
-                  "index": 111,
-                  "text": "JM: Jamaica"
-                },
-                "JO": {
-                  "index": 112,
-                  "text": "JO: Jordan"
-                },
-                "JP": {
-                  "index": 113,
-                  "text": "JP: Japan"
-                },
-                "KE": {
-                  "index": 114,
-                  "text": "KE: Kenya"
-                },
-                "KG": {
-                  "index": 115,
-                  "text": "KG: Kyrgyzstan"
-                },
-                "KH": {
-                  "index": 116,
-                  "text": "KH: Cambodia"
-                },
-                "KI": {
-                  "index": 117,
-                  "text": "KI: Kiribati"
-                },
-                "KM": {
-                  "index": 118,
-                  "text": "KM: Comoros"
-                },
-                "KN": {
-                  "index": 119,
-                  "text": "KN: Saint Kitts and Nevis"
-                },
-                "KP": {
-                  "index": 120,
-                  "text": "KP: Korea, Democratic People's Republic of"
-                },
-                "KR": {
-                  "index": 121,
-                  "text": "KR: Korea, Republic of"
-                },
-                "KW": {
-                  "index": 122,
-                  "text": "KW: Kuwait"
-                },
-                "KY": {
-                  "index": 123,
-                  "text": "KY: Cayman Islands"
-                },
-                "KZ": {
-                  "index": 124,
-                  "text": "KZ: Kazakhstan"
-                },
-                "LA": {
-                  "index": 125,
-                  "text": "LA: Lao People's Democratic Republic"
-                },
-                "LB": {
-                  "index": 126,
-                  "text": "LB: Lebanon"
-                },
-                "LC": {
-                  "index": 127,
-                  "text": "LC: Saint Lucia"
-                },
-                "LI": {
-                  "index": 128,
-                  "text": "LI: Liechtenstein"
-                },
-                "LK": {
-                  "index": 129,
-                  "text": "LK: Sri Lanka"
-                },
-                "LR": {
-                  "index": 130,
-                  "text": "LR: Liberia"
-                },
-                "LS": {
-                  "index": 131,
-                  "text": "LS: Lesotho"
-                },
-                "LT": {
-                  "index": 132,
-                  "text": "LT: Lithuania"
-                },
-                "LU": {
-                  "index": 133,
-                  "text": "LU: Luxembourg"
-                },
-                "LV": {
-                  "index": 134,
-                  "text": "LV: Latvia"
-                },
-                "LY": {
-                  "index": 135,
-                  "text": "LY: Libya"
-                },
-                "MA": {
-                  "index": 136,
-                  "text": "MA: Morocco"
-                },
-                "MC": {
-                  "index": 137,
-                  "text": "MC: Monaco"
-                },
-                "MD": {
-                  "index": 138,
-                  "text": "MD: Moldova, Republic of"
-                },
-                "ME": {
-                  "index": 139,
-                  "text": "ME: Montenegro"
-                },
-                "MF": {
-                  "index": 140,
-                  "text": "MF: Saint Martin (French part)"
-                },
-                "MG": {
-                  "index": 141,
-                  "text": "MG: Madagascar"
-                },
-                "MH": {
-                  "index": 142,
-                  "text": "MH: Marshall Islands"
-                },
-                "MK": {
-                  "index": 143,
-                  "text": "MK: North Macedonia"
-                },
-                "ML": {
-                  "index": 144,
-                  "text": "ML: Mali"
-                },
-                "MM": {
-                  "index": 145,
-                  "text": "MM: Myanmar"
-                },
-                "MN": {
-                  "index": 146,
-                  "text": "MN: Mongolia"
-                },
-                "MO": {
-                  "index": 147,
-                  "text": "MO: Macao"
-                },
-                "MP": {
-                  "index": 148,
-                  "text": "MP: Northern Mariana Islands"
-                },
-                "MQ": {
-                  "index": 149,
-                  "text": "MQ: Martinique"
-                },
-                "MR": {
-                  "index": 150,
-                  "text": "MR: Mauritania"
-                },
-                "MS": {
-                  "index": 151,
-                  "text": "MS: Montserrat"
-                },
-                "MT": {
-                  "index": 152,
-                  "text": "MT: Malta"
-                },
-                "MU": {
-                  "index": 153,
-                  "text": "MU: Mauritius"
-                },
-                "MV": {
-                  "index": 154,
-                  "text": "MV: Maldives"
-                },
-                "MW": {
-                  "index": 155,
-                  "text": "MW: Malawi"
-                },
-                "MX": {
-                  "index": 156,
-                  "text": "MX: Mexico"
-                },
-                "MY": {
-                  "index": 157,
-                  "text": "MY: Malaysia"
-                },
-                "MZ": {
-                  "index": 158,
-                  "text": "MZ: Mozambique"
-                },
-                "NA": {
-                  "index": 159,
-                  "text": "NA: Namibia"
-                },
-                "NC": {
-                  "index": 160,
-                  "text": "NC: New Caledonia"
-                },
-                "NE": {
-                  "index": 161,
-                  "text": "NE: Niger"
-                },
-                "NF": {
-                  "index": 162,
-                  "text": "NF: Norfolk Island"
-                },
-                "NG": {
-                  "index": 163,
-                  "text": "NG: Nigeria"
-                },
-                "NI": {
-                  "index": 164,
-                  "text": "NI: Nicaragua"
-                },
-                "NL": {
-                  "index": 165,
-                  "text": "NL: Netherlands"
-                },
-                "NO": {
-                  "index": 166,
-                  "text": "NO: Norway"
-                },
-                "NP": {
-                  "index": 167,
-                  "text": "NP: Nepal"
-                },
-                "NR": {
-                  "index": 168,
-                  "text": "NR: Nauru"
-                },
-                "NU": {
-                  "index": 169,
-                  "text": "NU: Niue"
-                },
-                "NZ": {
-                  "index": 170,
-                  "text": "NZ: New Zealand"
-                },
-                "OM": {
-                  "index": 171,
-                  "text": "OM: Oman"
-                },
-                "PA": {
-                  "index": 172,
-                  "text": "PA: Panama"
-                },
-                "PE": {
-                  "index": 173,
-                  "text": "PE: Peru"
-                },
-                "PF": {
-                  "index": 174,
-                  "text": "PF: French Polynesia"
-                },
-                "PG": {
-                  "index": 175,
-                  "text": "PG: Papua New Guinea"
-                },
-                "PH": {
-                  "index": 176,
-                  "text": "PH: Philippines"
-                },
-                "PK": {
-                  "index": 177,
-                  "text": "PK: Pakistan"
-                },
-                "PL": {
-                  "index": 178,
-                  "text": "PL: Poland"
-                },
-                "PM": {
-                  "index": 179,
-                  "text": "PM: Saint Pierre and Miquelon"
-                },
-                "PN": {
-                  "index": 180,
-                  "text": "PN: Pitcairn"
-                },
-                "PR": {
-                  "index": 181,
-                  "text": "PR: Puerto Rico"
-                },
-                "PS": {
-                  "index": 182,
-                  "text": "PS: Palestine, State of"
-                },
-                "PT": {
-                  "index": 183,
-                  "text": "PT: Portugal"
-                },
-                "PW": {
-                  "index": 184,
-                  "text": "PW: Palau"
-                },
-                "PY": {
-                  "index": 185,
-                  "text": "PY: Paraguay"
-                },
-                "QA": {
-                  "index": 186,
-                  "text": "QA: Qatar"
-                },
-                "RE": {
-                  "index": 187,
-                  "text": "RE: R\u00e9union"
-                },
-                "RO": {
-                  "index": 188,
-                  "text": "RO: Romania"
-                },
-                "RS": {
-                  "index": 189,
-                  "text": "RS: Serbia"
-                },
-                "RU": {
-                  "index": 190,
-                  "text": "RU: Russian Federation"
-                },
-                "RW": {
-                  "index": 191,
-                  "text": "RW: Rwanda"
-                },
-                "SA": {
-                  "index": 192,
-                  "text": "SA: Saudi Arabia"
-                },
-                "SB": {
-                  "index": 193,
-                  "text": "SB: Solomon Islands"
-                },
-                "SC": {
-                  "index": 194,
-                  "text": "SC: Seychelles"
-                },
-                "SD": {
-                  "index": 195,
-                  "text": "SD: Sudan"
-                },
-                "SE": {
-                  "index": 196,
-                  "text": "SE: Sweden"
-                },
-                "SG": {
-                  "index": 197,
-                  "text": "SG: Singapore"
-                },
-                "SH": {
-                  "index": 198,
-                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha"
-                },
-                "SI": {
-                  "index": 199,
-                  "text": "SI: Slovenia"
-                },
-                "SJ": {
-                  "index": 200,
-                  "text": "SJ: Svalbard and Jan Mayen"
-                },
-                "SK": {
-                  "index": 201,
-                  "text": "SK: Slovakia"
-                },
-                "SL": {
-                  "index": 202,
-                  "text": "SL: Sierra Leone"
-                },
-                "SM": {
-                  "index": 203,
-                  "text": "SM: San Marino"
-                },
-                "SN": {
-                  "index": 204,
-                  "text": "SN: Senegal"
-                },
-                "SO": {
-                  "index": 205,
-                  "text": "SO: Somalia"
-                },
-                "SR": {
-                  "index": 206,
-                  "text": "SR: Suriname"
-                },
-                "SS": {
-                  "index": 207,
-                  "text": "SS: South Sudan"
-                },
-                "ST": {
-                  "index": 208,
-                  "text": "ST: Sao Tome and Principe"
-                },
-                "SV": {
-                  "index": 209,
-                  "text": "SV: El Salvador"
-                },
-                "SX": {
-                  "index": 210,
-                  "text": "SX: Sint Maarten (Dutch part)"
-                },
-                "SY": {
-                  "index": 211,
-                  "text": "SY: Syrian Arab Republic"
-                },
-                "SZ": {
-                  "index": 212,
-                  "text": "SZ: Eswatini"
-                },
-                "TC": {
-                  "index": 213,
-                  "text": "TC: Turks and Caicos Islands"
-                },
-                "TD": {
-                  "index": 214,
-                  "text": "TD: Chad"
-                },
-                "TF": {
-                  "index": 215,
-                  "text": "TF: French Southern Territories"
-                },
-                "TG": {
-                  "index": 216,
-                  "text": "TG: Togo"
-                },
-                "TH": {
-                  "index": 217,
-                  "text": "TH: Thailand"
-                },
-                "TJ": {
-                  "index": 218,
-                  "text": "TJ: Tajikistan"
-                },
-                "TK": {
-                  "index": 219,
-                  "text": "TK: Tokelau"
-                },
-                "TL": {
-                  "index": 220,
-                  "text": "TL: Timor-Leste"
-                },
-                "TM": {
-                  "index": 221,
-                  "text": "TM: Turkmenistan"
-                },
-                "TN": {
-                  "index": 222,
-                  "text": "TN: Tunisia"
-                },
-                "TO": {
-                  "index": 223,
-                  "text": "TO: Tonga"
-                },
-                "TR": {
-                  "index": 224,
-                  "text": "TR: T\u00fcrkiye"
-                },
-                "TT": {
-                  "index": 225,
-                  "text": "TT: Trinidad and Tobago"
-                },
-                "TV": {
-                  "index": 226,
-                  "text": "TV: Tuvalu"
-                },
-                "TW": {
-                  "index": 227,
-                  "text": "TW: Taiwan, Province of China"
-                },
-                "TZ": {
-                  "index": 228,
-                  "text": "TZ: Tanzania, United Republic of"
-                },
-                "UA": {
-                  "index": 229,
-                  "text": "UA: Ukraine"
-                },
-                "UG": {
-                  "index": 230,
-                  "text": "UG: Uganda"
-                },
-                "UM": {
-                  "index": 231,
-                  "text": "UM: United States Minor Outlying Islands"
-                },
-                "US": {
-                  "index": 232,
-                  "text": "US: United States"
-                },
-                "UY": {
-                  "index": 233,
-                  "text": "UY: Uruguay"
-                },
-                "UZ": {
-                  "index": 234,
-                  "text": "UZ: Uzbekistan"
-                },
-                "VA": {
-                  "index": 235,
-                  "text": "VA: Holy See (Vatican City State)"
-                },
-                "VC": {
-                  "index": 236,
-                  "text": "VC: Saint Vincent and the Grenadines"
-                },
-                "VE": {
-                  "index": 237,
-                  "text": "VE: Venezuela, Bolivarian Republic of"
-                },
-                "VG": {
-                  "index": 238,
-                  "text": "VG: Virgin Islands, British"
-                },
-                "VI": {
-                  "index": 239,
-                  "text": "VI: Virgin Islands, U.S."
-                },
-                "VN": {
-                  "index": 240,
-                  "text": "VN: Viet Nam"
-                },
-                "VU": {
-                  "index": 241,
-                  "text": "VU: Vanuatu"
-                },
-                "WF": {
-                  "index": 242,
-                  "text": "WF: Wallis and Futuna"
-                },
-                "WS": {
-                  "index": 243,
-                  "text": "WS: Samoa"
-                },
-                "YE": {
-                  "index": 244,
-                  "text": "YE: Yemen"
-                },
-                "YT": {
-                  "index": 245,
-                  "text": "YT: Mayotte"
-                },
-                "ZA": {
-                  "index": 246,
-                  "text": "ZA: South Africa"
-                },
-                "ZM": {
-                  "index": 247,
-                  "text": "ZM: Zambia"
-                },
-                "ZW": {
-                  "index": 248,
-                  "text": "ZW: Zimbabwe"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Region"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 223
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Download"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "decbytes"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Upload"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "decbytes"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "include",
-                "names": [
-                  "Connected",
-                  "Download",
-                  "Upload"
-                ]
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.footer.reducers",
-                "value": [
-                  "sum"
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Connected"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 117
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 19,
-        "w": 12,
-        "x": 0,
-        "y": 29
-      },
-      "id": 13,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Connected"
-          }
-        ]
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum by (region) (conduit_region_connected_clients)",
-          "format": "table",
-          "instant": true,
-          "refId": "Connected"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum by (region) (conduit_region_bytes_downloaded)",
-          "format": "table",
-          "instant": true,
-          "refId": "Download"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum by (region) (conduit_region_bytes_uploaded)",
-          "format": "table",
-          "instant": true,
-          "refId": "Upload"
-        }
-      ],
-      "title": "Traffic by Region",
-      "transformations": [
-        {
-          "id": "seriesToColumns",
-          "options": {
-            "byField": "region"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true
-            },
-            "renameByName": {
-              "Value #Connected": "Connected",
-              "Value #Download": "Download",
-              "Value #Upload": "Upload",
-              "region": "Region"
-            }
-          }
-        }
-      ],
-      "type": "table"
     },
     {
       "datasource": {
@@ -7236,10 +8335,10 @@
         ]
       },
       "gridPos": {
-        "h": 15,
+        "h": 37,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 90
       },
       "id": 14,
       "options": {
@@ -7299,7 +8398,28 @@
     "psiphon"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Client State",
+        "name": "client_state",
+        "options": [],
+        "query": "Connected : conduit_region_connected_clients,Connecting : conduit_region_connecting_clients",
+        "type": "custom",
+        "valuesFormat": "csv"
+      },
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Client State (Total)",
+        "name": "client_state_total",
+        "options": [],
+        "query": "Connected : conduit_connected_clients,Connecting : conduit_connecting_clients",
+        "type": "custom",
+        "valuesFormat": "csv"
+      }
+    ]
   },
   "time": {
     "from": "now-30m",
@@ -7308,6 +8428,6 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "MoaV - Conduit",
-  "weekStart": "",
-  "uid": "moav-conduit"
+  "uid": "moav-conduit",
+  "weekStart": ""
 }

--- a/configs/monitoring/grafana/provisioning/dashboards/conduit.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/conduit.json
@@ -963,7 +963,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Session High ${client_state_total:text}"
+                "value": "Session High ${client_state_session_high:text}"
               }
             ]
           }
@@ -1004,7 +1004,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max_over_time($client_state_total[72h:] @ end())",
+          "expr": "$client_state_session_high",
           "refId": "A"
         }
       ],
@@ -1208,6 +1208,7 @@
         "y": 6
       },
       "id": 7,
+      "maxDataPoints": 3000,
       "options": {
         "legend": {
           "calcs": [
@@ -1266,7 +1267,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "palette-classic-by-name"
           },
           "custom": {
             "axisBorderShow": false,
@@ -3206,7 +3207,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "palette-classic-by-name"
           },
           "custom": {
             "axisBorderShow": false,
@@ -8416,6 +8417,16 @@
         "name": "client_state_total",
         "options": [],
         "query": "Connected : conduit_connected_clients,Connecting : conduit_connecting_clients",
+        "type": "custom",
+        "valuesFormat": "csv"
+      },
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Client State (Session High)",
+        "name": "client_state_session_high",
+        "options": [],
+        "query": "Connected : conduit_session_high_connected_clients,Connecting : conduit_session_high_connecting_clients",
         "type": "custom",
         "valuesFormat": "csv"
       }

--- a/contrib/log-metrics-exporter/README.md
+++ b/contrib/log-metrics-exporter/README.md
@@ -1,0 +1,71 @@
+# log-metrics-exporter
+
+A tiny Prometheus exporter that turns notable text patterns in
+`conduit.log` into real, graphable metrics — no dependencies beyond
+Python 3's standard library.
+
+## Why this exists
+
+Conduit logs things like a broker "limited" backoff response, an
+ICE-negotiation timeout, or a "no match" result as plain text lines. On
+their own, that's only visible by grepping the log after the fact. This
+exporter tails `conduit.log` incrementally (a byte-offset cursor, same
+approach used elsewhere for log rotation handling) and counts a small,
+fixed set of patterns, so they can be graphed on the same timeline as
+Connected/Connecting/Announcing:
+
+| Metric label | Matches |
+|---|---|
+| `limited` | Broker rate/entry-limit backoff response |
+| `ice_timeout` | `context deadline exceeded` (ICE negotiation timing out) |
+| `no_match` | Broker "no match" response |
+| `broker_reset` | `connection reset by peer` on the broker connection |
+
+All four are exposed as a single counter, `conduit_log_events_total`,
+labeled by `type`.
+
+**Trade-off**: like any log-tailing approach, it only sees what's in
+`conduit.log` from whenever it starts — no backfill from before that.
+
+## What it needs
+
+Nothing to install. Reads `conduit.log` from wherever Conduit is
+writing it, and serves the derived counter on its own `/metrics`
+endpoint for Prometheus to scrape.
+
+Configuration is via environment variables (all optional):
+
+| Variable | Default |
+|---|---|
+| `CONDUIT_LOG_PATH` | `~/conduit.log` |
+| `LOG_METRICS_OFFSET_FILE` | `~/.log-metrics-offset` |
+| `LOG_METRICS_LISTEN_HOST` | `127.0.0.1` |
+| `LOG_METRICS_LISTEN_PORT` | `9200` |
+| `LOG_METRICS_POLL_INTERVAL` | `10` (seconds) |
+
+## Wiring it into Prometheus + Grafana
+
+Add a scrape target for wherever it's listening (default `127.0.0.1:9200`):
+
+```yaml
+  - job_name: 'log_events'
+    static_configs:
+      - targets: ['127.0.0.1:9200']
+```
+
+The dashboard's Log Event Rate panel queries
+`increase(conduit_log_events_total[1h])` by `type` directly.
+
+If this exporter isn't deployed, that panel will show "No data" rather
+than erroring — deploying it is optional, the rest of the dashboard
+doesn't depend on it.
+
+## Note on router-side log metrics
+
+An earlier version of this exporter also parsed a home router's own
+event log for DoS/filter events (`router_log_events_total` in some
+dashboard revisions). That part is tied to one specific router's log
+format and isn't something that generalizes to other operators' setups,
+so it's deliberately left out of this contribution. If your dashboard
+still references `router_log_events_total`, that panel will simply show
+"No data" unless you build an equivalent exporter for your own router.

--- a/contrib/log-metrics-exporter/log-metrics-exporter.py
+++ b/contrib/log-metrics-exporter/log-metrics-exporter.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Prometheus exporter that turns notable conduit.log text patterns into
+real, graphable metrics. Things like the broker's "limited" backoff
+response, ICE-negotiation timeouts, and "no match" results only ever
+existed as text a human had to grep for after the fact — this tails
+conduit.log incrementally (byte-offset cursor, so a restart doesn't
+re-count already-seen content) and serves counts at /metrics for
+Prometheus to scrape, so they can be graphed on the same timeline as
+Connected/Connecting/Announcing.
+
+Counters reset to 0 on exporter restart — this is normal, expected
+Prometheus counter behavior, and rate()/increase() in Grafana handle a
+counter reset correctly on their own. What must never happen is
+re-counting already-seen log content after a restart, which is why the
+byte offset (not the counts) is the thing persisted across restarts.
+"""
+
+import os
+import re
+import time
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from collections import defaultdict
+
+CONDUIT_LOG = os.environ.get('CONDUIT_LOG_PATH', os.path.expanduser('~/conduit.log'))
+OFFSET_FILE = os.environ.get('LOG_METRICS_OFFSET_FILE', os.path.expanduser('~/.log-metrics-offset'))
+LISTEN_HOST = os.environ.get('LOG_METRICS_LISTEN_HOST', '127.0.0.1')
+LISTEN_PORT = int(os.environ.get('LOG_METRICS_LISTEN_PORT', '9200'))
+POLL_INTERVAL = float(os.environ.get('LOG_METRICS_POLL_INTERVAL', '10'))
+
+PATTERNS = {
+    'limited': re.compile(r'\blimited\b'),
+    'ice_timeout': re.compile(r'context deadline exceeded'),
+    'no_match': re.compile(r'\bno match\b', re.IGNORECASE),
+    'broker_reset': re.compile(r'connection reset by peer'),
+}
+
+lock = threading.Lock()
+counts = defaultdict(int)
+
+
+def read_offset():
+    try:
+        with open(OFFSET_FILE) as f:
+            return int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        return 0
+
+
+def write_offset(offset):
+    with open(OFFSET_FILE, 'w') as f:
+        f.write(str(offset))
+
+
+def read_new_content():
+    try:
+        size = os.path.getsize(CONDUIT_LOG)
+    except FileNotFoundError:
+        return ''
+    offset = read_offset()
+    if offset > size:
+        offset = 0  # log rotated/truncated
+    with open(CONDUIT_LOG, 'rb') as f:
+        f.seek(offset)
+        data = f.read()
+    write_offset(size)
+    return data.decode('utf-8', errors='replace')
+
+
+def scan():
+    content = read_new_content()
+    if not content:
+        return
+    # Do the (potentially slow, for a large first-scan backlog) regex work
+    # OUTSIDE the lock, so a long scan can't block /metrics from being
+    # served in the meantime. Only the final dict update needs the lock.
+    deltas = {}
+    for name, pattern in PATTERNS.items():
+        n = len(pattern.findall(content))
+        if n:
+            deltas[name] = n
+    if deltas:
+        with lock:
+            for name, n in deltas.items():
+                counts[name] += n
+
+
+def poll_loop():
+    while True:
+        try:
+            scan()
+        except Exception as e:
+            print(f'{time.strftime("%Y-%m-%d %H:%M:%S")} ERROR in poll_loop: {e}', flush=True)
+        time.sleep(POLL_INTERVAL)
+
+
+def render_metrics():
+    lines = []
+    lines.append('# HELP conduit_log_events_total Counts of notable patterns seen in conduit.log since exporter start')
+    lines.append('# TYPE conduit_log_events_total counter')
+    with lock:
+        for name, count in sorted(counts.items()):
+            lines.append(f'conduit_log_events_total{{type="{name}"}} {count}')
+    return '\n'.join(lines) + '\n'
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != '/metrics':
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = render_metrics().encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain; version=0.0.4')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        pass  # quiet — Prometheus scrapes every 10-15s, no need to log each one
+
+
+if __name__ == '__main__':
+    t = threading.Thread(target=poll_loop, daemon=True)
+    t.start()
+    print(f'{time.strftime("%Y-%m-%d %H:%M:%S")} log-metrics-exporter listening on {LISTEN_HOST}:{LISTEN_PORT}, tailing {CONDUIT_LOG}', flush=True)
+    server = HTTPServer((LISTEN_HOST, LISTEN_PORT), Handler)
+    server.serve_forever()

--- a/contrib/session-high-exporter/README.md
+++ b/contrib/session-high-exporter/README.md
@@ -1,0 +1,84 @@
+# session-high-exporter
+
+A tiny Prometheus exporter that maintains a *true* running maximum of a
+Conduit station's connected/connecting client counts since the current
+process started ("session high").
+
+## Why this exists
+
+The obvious way to show "highest value this session" in Grafana is a
+PromQL query like `max_over_time(conduit_connected_clients[72h])`. That
+works, but has two real costs:
+
+1. **Accuracy at wide time ranges.** Prometheus caps any single query at
+   11,000 samples per series. Over many days, that forces a coarser
+   sampling interval than the metric's actual scrape rate, which can
+   silently under-count a brief spike between samples.
+2. **Repeated cost.** Every dashboard refresh re-runs the *entire*
+   historical scan from scratch — even on a 5-second refresh, where 99%+
+   of a 7-day window is identical to 5 seconds ago. Neither Prometheus
+   nor Grafana caches or incrementally extends this by default.
+
+This exporter sidesteps both: it polls Conduit's own `/metrics` on the
+same cadence Prometheus already scrapes at, updates an in-memory running
+maximum only when a new value beats the record, and serves that single
+number. A running max updated on every real sample is mathematically
+identical to the true max — no sampling loss, and querying it costs
+nothing (one gauge, no historical scan) regardless of refresh rate or how
+long the session has run.
+
+**Trade-off**: it can't backfill. It only starts tracking from whenever
+it's first started, not retroactively from earlier history.
+
+## What it needs
+
+Nothing beyond Python 3's standard library — no dependencies to install.
+Reads Conduit's own `/metrics` endpoint (must expose
+`conduit_connected_clients`, `conduit_connecting_clients`, and the
+standard Go `process_start_time_seconds`, all present by default), writes
+a small JSON state file so its own restarts don't lose the record, and
+serves the two derived gauges on its own `/metrics` endpoint for
+Prometheus to scrape.
+
+Configuration is via environment variables (all optional):
+
+| Variable | Default |
+|---|---|
+| `CONDUIT_METRICS_URL` | `http://127.0.0.1:9090/metrics` |
+| `SESSION_HIGH_STATE_FILE` | `~/.session-high-state.json` |
+| `SESSION_HIGH_LISTEN_HOST` | `127.0.0.1` |
+| `SESSION_HIGH_LISTEN_PORT` | `9201` |
+| `SESSION_HIGH_POLL_INTERVAL` | `15` (seconds) |
+
+## Running it persistently
+
+- **Linux**: `session-high-exporter.service` (systemd unit, included) —
+  verified under a real systemd container (Debian + Docker/Colima):
+  starts correctly, persists state across its own restarts via a
+  `DynamicUser`-sandboxed `StateDirectory`, correctly tracks a rising
+  max, and correctly resets when Conduit's own `process_start_time`
+  changes (i.e. when Conduit itself restarts).
+- **macOS**: `com.conduit.session-high-exporter.plist.template` (LaunchAgent
+  template, included) — fill in the real paths, `launchctl bootstrap
+  gui/$(id -u) <path>`.
+- **Windows**: see `windows-service-setup.md` (NSSM-based, included) —
+  written from NSSM's documented behavior, not yet verified against a
+  real Windows machine.
+
+## Wiring it into Prometheus + Grafana
+
+Add a scrape target for wherever it's listening (default `127.0.0.1:9201`):
+
+```yaml
+  - job_name: 'session_high'
+    static_configs:
+      - targets: ['127.0.0.1:9201']
+```
+
+Then point a Stat panel's query at `conduit_session_high_connected_clients`
+/ `conduit_session_high_connecting_clients` directly — no PromQL
+aggregation needed, it's already the final number.
+
+If this exporter isn't deployed, a panel querying these metrics will show
+"No data" rather than erroring — deploying it is optional, the rest of
+the dashboard doesn't depend on it.

--- a/contrib/session-high-exporter/com.conduit.session-high-exporter.plist.template
+++ b/contrib/session-high-exporter/com.conduit.session-high-exporter.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.conduit.session-high-exporter</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>/path/to/session-high-exporter.py</string>
+    </array>
+    <!-- Optional: override defaults (127.0.0.1:9090 metrics source,
+         ~/.session-high-state.json, 127.0.0.1:9201 listen address) -->
+    <!--
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CONDUIT_METRICS_URL</key>
+        <string>http://127.0.0.1:9090/metrics</string>
+        <key>SESSION_HIGH_STATE_FILE</key>
+        <string>/path/to/session-high-state.json</string>
+    </dict>
+    -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/path/to/session-high-exporter.log</string>
+    <key>StandardErrorPath</key>
+    <string>/path/to/session-high-exporter.log</string>
+</dict>
+</plist>

--- a/contrib/session-high-exporter/session-high-exporter.py
+++ b/contrib/session-high-exporter/session-high-exporter.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Prometheus exporter maintaining a true running maximum of Conduit's
+connected/connecting client counts since the current process started.
+
+Unlike querying "max_over_time(...) over the last N hours" from Grafana,
+this never re-scans history — it polls Conduit's own /metrics endpoint on
+the same 15s cadence Prometheus already uses, updates an in-memory running
+max only when a new value beats the record, and serves that single number.
+No resolution/point-limit tradeoffs, no repeated historical query cost,
+exact by construction (a running max updated on every real sample is
+identical to the true max, unlike windowed/sampled approximations).
+
+Session boundary detection: process_start_time_seconds (from Conduit's own
+/metrics, a standard Go process-collector gauge) only changes when Conduit
+restarts. When it changes, both running maxes reset to the session's first
+observed value.
+
+State (the running max + the process_start_time it belongs to) is
+persisted to a small JSON file so restarting *this* exporter doesn't lose
+the record — only a genuine Conduit restart resets it.
+
+Configuration is via environment variables (all optional, defaults shown
+below) so the same script runs unmodified on any host/user/deployment
+rather than needing hardcoded local paths.
+
+REVISION HISTORY (newest first):
+  260819 - Initial version.
+"""
+
+import json
+import os
+import threading
+import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+CONDUIT_METRICS_URL = os.environ.get('CONDUIT_METRICS_URL', 'http://127.0.0.1:9090/metrics')
+STATE_FILE = os.environ.get('SESSION_HIGH_STATE_FILE', os.path.expanduser('~/.session-high-state.json'))
+LISTEN_HOST = os.environ.get('SESSION_HIGH_LISTEN_HOST', '127.0.0.1')
+LISTEN_PORT = int(os.environ.get('SESSION_HIGH_LISTEN_PORT', '9201'))
+LISTEN_ADDR = (LISTEN_HOST, LISTEN_PORT)
+POLL_INTERVAL_SECONDS = int(os.environ.get('SESSION_HIGH_POLL_INTERVAL', '15'))
+
+lock = threading.Lock()
+state = {
+    'process_start_time': None,
+    'session_high_connected': 0,
+    'session_high_connecting': 0,
+}
+
+
+def load_state():
+    try:
+        with open(STATE_FILE) as f:
+            loaded = json.load(f)
+        state.update(loaded)
+    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+        pass
+
+
+def save_state():
+    with open(STATE_FILE, 'w') as f:
+        json.dump(state, f)
+
+
+def parse_conduit_metrics(text):
+    values = {}
+    for line in text.splitlines():
+        if line.startswith('#') or not line.strip():
+            continue
+        if line.startswith('conduit_connected_clients '):
+            values['connected'] = float(line.split()[-1])
+        elif line.startswith('conduit_connecting_clients '):
+            values['connecting'] = float(line.split()[-1])
+        elif line.startswith('process_start_time_seconds'):
+            values['start_time'] = float(line.split()[-1])
+    return values
+
+
+def poll_once():
+    with urllib.request.urlopen(CONDUIT_METRICS_URL, timeout=10) as r:
+        text = r.read().decode('utf-8', errors='replace')
+    values = parse_conduit_metrics(text)
+    if not {'connected', 'connecting', 'start_time'} <= values.keys():
+        return  # incomplete scrape (e.g. Conduit mid-restart) -- skip this cycle
+
+    with lock:
+        if state['process_start_time'] != values['start_time']:
+            # New session (or first run ever) -- reset to this cycle's own values
+            state['process_start_time'] = values['start_time']
+            state['session_high_connected'] = values['connected']
+            state['session_high_connecting'] = values['connecting']
+        else:
+            if values['connected'] > state['session_high_connected']:
+                state['session_high_connected'] = values['connected']
+            if values['connecting'] > state['session_high_connecting']:
+                state['session_high_connecting'] = values['connecting']
+        save_state()
+
+
+def poll_loop():
+    while True:
+        try:
+            poll_once()
+        except Exception as e:
+            print(f'{time.strftime("%Y-%m-%d %H:%M:%S")} ERROR in poll_loop: {e}', flush=True)
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def render_metrics():
+    with lock:
+        connected = state['session_high_connected']
+        connecting = state['session_high_connecting']
+    lines = [
+        '# HELP conduit_session_high_connected_clients True running maximum of connected clients since Conduit process start',
+        '# TYPE conduit_session_high_connected_clients gauge',
+        f'conduit_session_high_connected_clients {connected}',
+        '# HELP conduit_session_high_connecting_clients True running maximum of connecting clients since Conduit process start',
+        '# TYPE conduit_session_high_connecting_clients gauge',
+        f'conduit_session_high_connecting_clients {connecting}',
+    ]
+    return '\n'.join(lines) + '\n'
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != '/metrics':
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = render_metrics().encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain; version=0.0.4')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        pass  # quiet -- Prometheus scrapes every 15s, no need to log each one
+
+
+if __name__ == '__main__':
+    load_state()
+    t = threading.Thread(target=poll_loop, daemon=True)
+    t.start()
+    print(f'{time.strftime("%Y-%m-%d %H:%M:%S")} session-high-exporter listening on {LISTEN_ADDR[0]}:{LISTEN_ADDR[1]}', flush=True)
+    server = HTTPServer(LISTEN_ADDR, Handler)
+    server.serve_forever()

--- a/contrib/session-high-exporter/session-high-exporter.service
+++ b/contrib/session-high-exporter/session-high-exporter.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Conduit session-high Prometheus exporter
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /opt/conduit/session-high-exporter.py
+Restart=always
+RestartSec=5
+Environment=SESSION_HIGH_STATE_FILE=/var/lib/conduit/session-high-state.json
+# Uncomment and adjust if Conduit's metrics endpoint isn't on the default:
+# Environment=CONDUIT_METRICS_URL=http://127.0.0.1:9090/metrics
+DynamicUser=yes
+StateDirectory=conduit
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/session-high-exporter/windows-service-setup.md
+++ b/contrib/session-high-exporter/windows-service-setup.md
@@ -1,0 +1,89 @@
+# Running session-high-exporter.py as a Windows service
+
+Untested against a real Windows machine as of writing this — written from
+NSSM's well-established, standard documentation, same confidence level the
+systemd unit had *before* it got verified under real Linux. Test this for
+real the first time it's actually needed, the same way the Linux version
+was verified before being trusted.
+
+`session-high-exporter.py` itself needs no changes — it's plain Python
+standard library, already cross-platform. Only the "run this persistently
+as a background service" part is OS-specific.
+
+## Option A: NSSM (recommended — closest match to launchd/systemd behavior)
+
+NSSM ("the Non-Sucking Service Manager") wraps an arbitrary executable as
+a real Windows Service: proper start/stop via `services.msc` or
+`sc`/`net`, automatic restart on crash, stdout/stderr redirected to a log
+file. This is the same kind of persistent-background-service behavior
+`KeepAlive`/`Restart=always` give on Mac/Linux.
+
+1. Download NSSM from https://nssm.cc/download (a small, standalone
+   `.exe`, no installer) and place `nssm.exe` somewhere on PATH, e.g.
+   `C:\Tools\nssm.exe`.
+2. Confirm Python 3 is installed and on PATH (`python --version`).
+3. Run `install-windows-service.ps1` (below) as Administrator — it wraps
+   the `nssm install`/`nssm set` calls needed to register and configure
+   the service.
+4. Verify: `Get-Service session-high-exporter` should show `Running`.
+   `curl http://127.0.0.1:9201/metrics` should return the two gauges.
+
+To uninstall later: `nssm remove session-high-exporter confirm`.
+
+### install-windows-service.ps1
+
+```powershell
+# Run as Administrator. Adjust $PythonExe/$ScriptPath if needed.
+$ServiceName = "session-high-exporter"
+$PythonExe   = (Get-Command python).Source
+$ScriptPath  = "$PSScriptRoot\session-high-exporter.py"
+$StateFile   = "$env:ProgramData\ConduitCLI\session-high-state.json"
+$LogDir      = "$env:ProgramData\ConduitCLI\logs"
+
+New-Item -ItemType Directory -Force -Path (Split-Path $StateFile) | Out-Null
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+nssm install $ServiceName $PythonExe $ScriptPath
+nssm set $ServiceName AppDirectory (Split-Path $ScriptPath)
+nssm set $ServiceName AppStdout "$LogDir\session-high-exporter.log"
+nssm set $ServiceName AppStderr "$LogDir\session-high-exporter.log"
+nssm set $ServiceName AppRotateFiles 1
+nssm set $ServiceName AppRotateBytes 10485760   # 10 MB, matches conduit.log rotation elsewhere in this project
+nssm set $ServiceName AppEnvironmentExtra "SESSION_HIGH_STATE_FILE=$StateFile"
+nssm set $ServiceName Start SERVICE_AUTO_START
+# Matches Restart=always / KeepAlive=true on the other two platforms:
+nssm set $ServiceName AppExit Default Restart
+nssm set $ServiceName AppRestartDelay 5000      # 5s, matches RestartSec=5 in the systemd unit
+
+nssm start $ServiceName
+Write-Host "Installed and started '$ServiceName'. Check with: Get-Service $ServiceName"
+```
+
+If Conduit's own metrics endpoint isn't on the default `127.0.0.1:9090`,
+add before `nssm start`:
+```powershell
+nssm set $ServiceName AppEnvironmentExtra "SESSION_HIGH_STATE_FILE=$StateFile`nCONDUIT_METRICS_URL=http://127.0.0.1:9090/metrics"
+```
+(NSSM's `AppEnvironmentExtra` takes one `KEY=VALUE` pair per line,
+separated by `` `n `` in PowerShell string literals.)
+
+## Option B: Task Scheduler (no third-party tool, weaker restart semantics)
+
+If avoiding a third-party binary matters more than clean service
+semantics: a Scheduled Task triggered "At log on" or "At startup",
+running `pythonw.exe session-high-exporter.py`, with "Restart if the
+task fails" configured (Task Scheduler supports up to a fixed retry
+count/interval, not true indefinite `Restart=always`). Simpler to set
+up via the Task Scheduler GUI, but less robust than a real service if
+the machine is meant to run unattended for long stretches — for a
+station meant to stay up continuously (the same reason Conduit itself
+runs via a real service, not a login script), NSSM is the better fit.
+
+## Not yet done
+
+- Real verification on an actual Windows machine (this doc is written
+  from NSSM's documented behavior, not tested the way the systemd path
+  was tested under Colima).
+- Confirming Python's `http.server`/`urllib` behave identically on
+  Windows (expected to, since neither uses anything POSIX-specific, but
+  "expected to" isn't "verified" — same caveat as above).


### PR DESCRIPTION
Follow-up to #91, with several more months of accumulated dashboard improvements:

- **Window Max** panel: highest connected/connecting count within the currently selected time window, plus the exact timestamp it occurred. Dynamically follows the existing Connected/Connecting toggle.
- **Session High** panel: highest value seen in roughly the last 72 hours.
- A live vertical-line annotation on the Client Connections graph marking exactly when the current window's peak occurred.
- **Connected Clients by Region**: limited to the top 15 regions by traffic instead of plotting every region ever seen (previously 50+ overlapping lines with no legend to isolate any of them -- now has a working, clickable legend too).
- Several smaller additions: Lifetime D/L, Lifetime U/L, U/L Rate, Uptime, Announcing stats, Conduit Log Event Rates, Router Log Event Rates, and a Connected/Connecting-aware Top 5 Regions panel.

Happy to adjust anything -- this reflects what has actually proven useful running a real station.