### PR TITLE
fix(users): regenerate-users must reload WireGuard + AmneziaWG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
         run: bash tests/wg-ip-collision-test.sh
       - name: AmneziaWG v3 params
         run: bash tests/amneziawg-v3-test.sh
+      - name: regenerate-users reloads WG/AWG
+        run: bash tests/regenerate-reload-test.sh
       - name: doctor CDN detection + scrape targets
         run: bash tests/doctor-cdn-test.sh
       - name: snowflake native metrics + dashboard (#183)

--- a/lib/users.sh
+++ b/lib/users.sh
@@ -559,6 +559,23 @@ cmd_regenerate_users() {
     # bundles THEN sync_server_users, always reaching the reconcile even if a
     # bundle failed). Reload the proxies so the re-inserted users take effect.
     docker compose restart sing-box xray >/dev/null 2>&1 || true
+
+    # WG/AWG were missing here: regenerate rebuilds wg0/awg0.conf on disk but the
+    # running servers keep stale peers until reloaded (moav user add already does).
+    if [[ "${enable_wireguard:-true}" == "true" ]] && [[ "$(docker inspect -f '{{.State.Running}}' moav-wireguard 2>/dev/null)" == "true" ]]; then
+        local wg_stripped
+        wg_stripped=$(docker exec -i moav-wireguard wg-quick strip wg0 2>/dev/null || true)  # never abort the caller under set -e
+        if [[ -n "$wg_stripped" ]]; then
+            printf '%s\n' "$wg_stripped" | docker exec -i moav-wireguard wg syncconf wg0 /dev/stdin >/dev/null 2>&1 \
+                || docker restart moav-wireguard >/dev/null 2>&1 || true
+        else
+            docker restart moav-wireguard >/dev/null 2>&1 || true
+        fi
+    fi
+    # AmneziaWG has no awg-quick; its entrypoint re-applies awg0.conf on start.
+    if [[ "${enable_amneziawg:-true}" == "true" ]] && [[ "$(docker inspect -f '{{.State.Running}}' moav-amneziawg 2>/dev/null)" == "true" ]]; then
+        docker restart moav-amneziawg >/dev/null 2>&1 || true
+    fi
     echo ""
 
     if [[ $user_count -gt 0 ]]; then

--- a/tests/regenerate-reload-test.sh
+++ b/tests/regenerate-reload-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Regression test: `moav regenerate-users` must reload the running WireGuard and
+# AmneziaWG servers, not just sing-box + xray.
+#
+# The bug (found live): regenerate rebuilds wg0.conf/awg0.conf on disk, but the
+# reload step only restarted `sing-box xray`. The WG/AWG containers kept their
+# old peer lists, so a freshly regenerated user's key was on disk yet unknown to
+# the running server — the tunnel handshook but the peer was never loaded.
+# `moav user add` already reloads WG/AWG; regenerate-users was the gap.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "regenerate-users: reloads WG + AWG so regenerated peers take effect"
+
+USERS="$ROOT/lib/users.sh"
+
+# The reload block: from the sing-box/xray restart down to the closing echo "".
+block=$(awk '/docker compose restart sing-box xray/,/^    echo ""$/' "$USERS")
+if [ -z "$block" ]; then
+    bad "could not locate the reload block in cmd_regenerate_users"
+else
+    if printf '%s' "$block" | grep -q 'moav-wireguard'; then
+        ok "WireGuard is reloaded (wg syncconf / restart)"
+    else
+        bad "WireGuard is NOT reloaded — regenerated WG peers stay stale on the running server"
+    fi
+    if printf '%s' "$block" | grep -q 'wg syncconf wg0'; then
+        ok "WireGuard peers are hot-synced (non-disruptive), not just restarted"
+    else
+        bad "no wg syncconf — existing WG tunnels would be dropped on every regenerate"
+    fi
+    if printf '%s' "$block" | grep -q 'moav-amneziawg'; then
+        ok "AmneziaWG is reloaded"
+    else
+        bad "AmneziaWG is NOT reloaded — regenerated AWG peers stay stale"
+    fi
+    # An empty stripped config fed to `wg syncconf` would wipe every peer; the
+    # code must guard against that and fall back to a restart.
+    if printf '%s' "$block" | grep -q 'if \[\[ -n "\$wg_stripped" \]\]'; then
+        ok "guards against an empty strip wiping all peers"
+    else
+        bad "no empty-config guard — a failed strip could remove every WG peer"
+    fi
+fi
+
+echo ""
+if [ "$fail" -gt 0 ]; then
+    echo "FAILED ($fail failed, $pass passed)"
+    exit 1
+fi
+echo "PASSED ($pass checks)"


### PR DESCRIPTION
Found while testing WireGuard connectivity end-to-end against a live server.

## The bug
`moav regenerate-users` rebuilds `wg0.conf`/`awg0.conf` on disk, but its reload step only restarted `sing-box xray`:

```bash
docker compose restart sing-box xray >/dev/null 2>&1 || true
```

So the running WireGuard/AmneziaWG containers kept their **old peer lists**. A freshly regenerated user’s key was on disk but unknown to the running server — the tunnel handshook, then the peer was never loaded and no traffic flowed. `moav user add` already reloads WG/AWG (`user-add.sh`); `regenerate-users` was the gap.

## The fix
- **WireGuard**: non-disruptive `wg syncconf wg0` (stripped config piped into the container via `/dev/stdin`), guarded so an empty strip can’t wipe every peer, with a `docker restart` fallback. Verified live: peers sync with existing tunnels untouched.
- **AmneziaWG**: no `awg-quick` in that image, so its entrypoint re-applies `awg0.conf` on restart — a `docker restart` is the reload (same as `user-add.sh`).
- Both gated on the service being enabled + running.

## Test
`tests/regenerate-reload-test.sh` (registered in CI) pins that the reload block covers WG + AWG, hot-syncs WG, and keeps the empty-config guard.

Also verified in the same session: WG tunnel capacity is 620–800 Mbit/s (well above the box’s uplink), and MTU 1280 is the right default (robust on constrained paths; raising it only risks fragmentation with no real-world speed gain).