### PR TITLE
feat(ux): conduit CPU-budget warning + self-signed cert note (fresh install)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
         run: bash tests/zombie-reaper-test.sh
       - name: doctor host (load/swap/zombies) + check wiring
         run: bash tests/hostload-test.sh
+      - name: self-signed TLS note (fresh-install cert warning)
+        run: bash tests/tls-note-test.sh
       - name: release footer generator
         run: bash tests/release-footer-test.sh
       - name: release footer links resolve (network)

--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -146,6 +146,9 @@ run_bootstrap() {
             if echo "$SELECTED_PROFILE_STRING" | grep -qE "monitoring"; then
                 echo -e "  ${CYAN}Grafana:${NC}         $(get_grafana_url)"
             fi
+            if echo "$SELECTED_PROFILE_STRING" | grep -qE "admin|monitoring|all"; then
+                print_tls_selfsigned_note
+            fi
             echo ""
         else
             echo ""

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -73,6 +73,17 @@ print_community_links() {
     echo -e "  ${DIM}Issues/bugs: ${MOAV_URL_GH}/issues${NC}"
 }
 
+# Without a DOMAIN the admin/Grafana TLS cert is self-signed, so browsers show
+# "not secure" / ERR_CERT_AUTHORITY_INVALID on first visit. That's expected on a
+# fresh install, not a bug — spell it out next to the URLs so operators don't
+# think something broke. No-op once a DOMAIN (browser-trusted cert) is set.
+print_tls_selfsigned_note() {
+    [[ -z "$(get_env_val "DOMAIN" .env "")" ]] || return 0
+    echo -e "  ${YELLOW}Note:${NC} the admin/Grafana cert is self-signed (no DOMAIN set), so your browser"
+    echo -e "        will warn \"not secure\" / ERR_CERT_AUTHORITY_INVALID on first visit — that's"
+    echo -e "        expected; click Advanced → Proceed. Set a DOMAIN for a trusted Let's Encrypt cert."
+}
+
 print_header() {
     # Only clear when stdout is a TTY (avoids "TERM not set" abort under setsid).
     if [[ -t 1 ]]; then

--- a/lib/service.sh
+++ b/lib/service.sh
@@ -988,6 +988,7 @@ start_services() {
         fi
 
         if echo "$profiles" | grep -qE "admin|monitoring|all"; then
+            print_tls_selfsigned_note
             echo ""
         fi
         show_log_help

--- a/scripts/conduit-entrypoint.sh
+++ b/scripts/conduit-entrypoint.sh
@@ -23,6 +23,28 @@ echo "[conduit] Max common clients: $CONDUIT_MAX_COMMON_CLIENTS"
 echo "[conduit] Metrics endpoint: $CONDUIT_METRICS_ADDR"
 echo "[conduit] Data directory: $CONDUIT_DATA_DIR"
 
+# Warn when the CPU allocation looks too small for the configured client load —
+# conduit relaying is CPU-bound (rough guideline ~200 clients per vCPU), and the
+# compose default caps this service at 0.5 CPU. Read the cgroup limit (v2 then
+# v1); "max"/unset means uncapped, so no warning.
+_cpu_q=""; _cpu_p=""
+if [ -r /sys/fs/cgroup/cpu.max ]; then
+    read -r _cpu_q _cpu_p < /sys/fs/cgroup/cpu.max
+elif [ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]; then
+    _cpu_q=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null)
+    _cpu_p=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null)
+fi
+if [ "$_cpu_q" != "max" ] && [ "${_cpu_q:-0}" -gt 0 ] 2>/dev/null && [ "${_cpu_p:-0}" -gt 0 ] 2>/dev/null; then
+    # clients per vCPU = clients / (quota/period) = clients*period/quota
+    if [ $(( CONDUIT_MAX_COMMON_CLIENTS * _cpu_p )) -gt $(( 200 * _cpu_q )) ]; then
+        echo "[conduit] WARNING: configured for ${CONDUIT_MAX_COMMON_CLIENTS} clients but limited to"
+        echo "[conduit]          ~$(( _cpu_q * 100 / _cpu_p ))% of one CPU core. Relaying is CPU-bound"
+        echo "[conduit]          (~200 clients/vCPU rule of thumb) — if you see high CPU or latency,"
+        echo "[conduit]          raise this service's 'cpus' in docker-compose.yml or lower"
+        echo "[conduit]          CONDUIT_MAX_COMMON_CLIENTS."
+    fi
+fi
+
 # Handle shutdown gracefully - use signal numbers for POSIX compatibility
 # 15 = SIGTERM, 2 = SIGINT
 cleanup() {

--- a/tests/tls-note-test.sh
+++ b/tests/tls-note-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Regression test: the self-signed-cert note prints when there's no DOMAIN
+# (fresh install → browsers warn ERR_CERT_AUTHORITY_INVALID, expected) and stays
+# silent once a DOMAIN (browser-trusted cert) is configured.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+# shellcheck source=/dev/null
+source "$ROOT/lib/common.sh"           # print_tls_selfsigned_note
+# shellcheck source=/dev/null
+source "$ROOT/scripts/lib/common.sh"   # get_env_val
+: "${YELLOW:=}" "${NC:=}"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+echo "tls self-signed note: shown when domainless, silent with a DOMAIN"
+
+printf 'DOMAIN=\n' > .env
+out=$(print_tls_selfsigned_note 2>&1)
+if printf '%s' "$out" | grep -q "ERR_CERT_AUTHORITY_INVALID"; then
+    ok "note is shown when no DOMAIN is set"
+else
+    bad "domainless: expected the note, got: ${out:-<empty>}"
+fi
+
+printf 'DOMAIN=vpn.example.com\n' > .env
+out=$(print_tls_selfsigned_note 2>&1)
+if [ -z "$out" ]; then
+    ok "note is silent once a DOMAIN is set"
+else
+    bad "with DOMAIN: expected silence, got: $out"
+fi
+
+echo ""
+if [ "$fail" -gt 0 ]; then echo "FAILED ($fail failed, $pass passed)"; exit 1; fi
+echo "PASSED ($pass checks)"


### PR DESCRIPTION
Two operator-UX cards from the correctness cluster.

**conduit: cpus 0.5, no warning** — conduit relaying is CPU-bound but the compose default caps it at 0.5 CPU, so a high `CONDUIT_MAX_COMMON_CLIENTS` silently over-subscribes it. The entrypoint now reads the cgroup CPU limit (v2 then v1; `max`/unset = uncapped → no warning) and warns when clients exceed ~200/vCPU. Default 100 clients @0.5 CPU stays quiet; 200 warns.

**bug: cert warning on fresh install** — without a `DOMAIN` the admin/Grafana cert is self-signed, so browsers show `ERR_CERT_AUTHORITY_INVALID`. That is expected, not a bug. A note now prints next to the URLs (start + bootstrap summaries) explaining it and how to get a trusted cert; silent once a `DOMAIN` is set. Regression test: `tests/tls-note-test.sh`.

Both verified locally; shellcheck + `bash -n` clean.