### PR TITLE
security(admin): validate MahsaNet donate 'protocols' body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
         run: bash tests/admin-tls-test.sh
       - name: admin IP whitelist (CIDR) unit test
         run: python3 tests/admin-ip-whitelist-test.py
+      - name: MahsaNet donate protocols validation
+        run: python3 tests/mahsanet-protocols-test.py
       - name: refactor verification (static)
         run: bash tests/refactor-verify.sh
       - name: protocol-roster drift gate

--- a/admin/main.py
+++ b/admin/main.py
@@ -814,6 +814,21 @@ MAHSANET_PROTOCOLS = os.environ.get("MAHSANET_PROTOCOLS", "reality hysteria2").s
 MAHSANET_POOL = os.environ.get("MAHSANET_POOL", "mahsa")
 
 
+def validate_donate_protocols(protocols):
+    """Validate the /api/mahsanet/donate 'protocols' body field. Returns the
+    list, or raises ValueError. The values flow into DONATE_ONLY_PROTOCOLS ->
+    user-add.sh, so a non-list would crash the " ".join and stray values would
+    reach a shell env; keep it a bounded list of simple protocol tokens."""
+    if not isinstance(protocols, list) or not protocols:
+        raise ValueError("protocols must be a non-empty list")
+    if len(protocols) > 20:
+        raise ValueError("too many protocols (max 20)")
+    for p in protocols:
+        if not isinstance(p, str) or not re.match(r'^[a-z0-9_-]{1,32}$', p):
+            raise ValueError(f"invalid protocol: {p!r}")
+    return protocols
+
+
 def _mahsanet_ads_url() -> str:
     """The link MahsaNet shows next to a donated config.
 
@@ -940,13 +955,15 @@ async def mahsanet_donate(request: Request, _: str = Depends(verify_auth)):
     body = await request.json()
     count = int(body.get("count", 1))
     prefix = body.get("prefix", "mahsa").strip()
-    protocols = body.get("protocols", MAHSANET_PROTOCOLS)
-
     # Validate
     if count < 1 or count > 50:
         raise HTTPException(status_code=400, detail="Count must be 1-50")
     if not re.match(r'^[a-zA-Z0-9_-]+$', prefix):
         raise HTTPException(status_code=400, detail="Invalid prefix")
+    try:
+        protocols = validate_donate_protocols(body.get("protocols", MAHSANET_PROTOCOLS))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     # Generate users via user-add.sh
     if not USER_ADD_SCRIPT.exists():

--- a/tests/mahsanet-protocols-test.py
+++ b/tests/mahsanet-protocols-test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Regression: /api/mahsanet/donate must validate the 'protocols' body field.
+
+The endpoint validated count + prefix but passed 'protocols' from the request
+body straight into DONATE_ONLY_PROTOCOLS -> " ".join() -> user-add.sh. A non-list
+crashed the join (500) and stray values reached a shell env. This pins the
+validation. Extracts validate_donate_protocols from admin/main.py without
+importing the FastAPI app (same trick as admin-ip-whitelist-test.py).
+"""
+import os
+import re
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MAIN = os.path.join(HERE, "..", "admin", "main.py")
+src = open(MAIN).read()
+start = src.index("def validate_donate_protocols(")
+end = src.index("\n\n\n", start)
+ns = {"re": re}
+exec(compile(src[start:end], MAIN, "exec"), ns)  # noqa: S102
+validate = ns["validate_donate_protocols"]
+
+fails = 0
+
+
+def ok(cond, msg):
+    global fails
+    print(("  ok    " if cond else "  FAIL  ") + msg)
+    if not cond:
+        fails += 1
+
+
+ok(validate(["reality", "hysteria2"]) == ["reality", "hysteria2"], "accepts a valid list")
+
+for bad, label in [
+    ("reality", "a bare string (not a list)"),
+    ([], "an empty list"),
+    (["reality; rm -rf /"], "a shell-ish value"),
+    (["reality", 123], "a non-string element"),
+    ([f"x{i}" for i in range(21)], "too many protocols"),
+    (["Reality!"], "invalid characters"),
+]:
+    try:
+        validate(bad)
+        ok(False, f"rejects {label}")
+    except ValueError:
+        ok(True, f"rejects {label}")
+
+print("\n" + ("FAILED" if fails else "PASSED"))
+raise SystemExit(1 if fails else 0)


### PR DESCRIPTION
The `/api/mahsanet/donate` endpoint validated `count` and `prefix` but passed `protocols` from the request body straight into `DONATE_ONLY_PROTOCOLS` → `" ".join()` → `user-add.sh`.

Concrete failure it prevents: a non-list `protocols` crashes the `" ".join()` (500), and stray values reach a shell env. (Auth is required and it is env not a shell string, so not command injection — this is input hygiene.)

`validate_donate_protocols()` now requires a **bounded list of simple tokens** (`^[a-z0-9_-]{1,32}$`, ≤20). Extracted as a pure function so `tests/mahsanet-protocols-test.py` can exercise it without importing FastAPI (same trick as `admin-ip-whitelist-test.py`), registered in CI.