### PR TITLE
hardening: reject a malformed credentials.env (no broken bundles)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash tests/wg-keygen-fallback-test.sh
       - name: user UUID capture (no two-line double-capture)
         run: bash tests/uuid-capture-test.sh
+      - name: malformed credentials.env guard
+        run: bash tests/creds-valid-test.sh
       - name: config naming (server label + wg 15-char limit)
         run: bash tests/config-naming-test.sh
       - name: grafana branding non-fatal

--- a/scripts/generate-user.sh
+++ b/scripts/generate-user.sh
@@ -41,7 +41,18 @@ if [[ ! -f "$USER_CREDS_FILE" ]]; then
     exit 1
 fi
 
-source "$USER_CREDS_FILE"
+# A corrupt credentials.env (bash-unparseable) must not abort with an opaque
+# error, and a partial/malformed one must not silently emit broken bundles.
+if ! source "$USER_CREDS_FILE" 2>/dev/null; then
+    log_error "credentials.env for '$USER_ID' failed to parse (corrupt): $USER_CREDS_FILE"
+    log_error "Remove it and re-run 'moav user add $USER_ID' to regenerate."
+    exit 1
+fi
+if ! creds_valid "${USER_UUID:-}" "${USER_PASSWORD:-}"; then
+    log_error "credentials.env for '$USER_ID' is malformed — USER_UUID/USER_PASSWORD missing or invalid: $USER_CREDS_FILE"
+    log_error "Remove it and re-run 'moav user add $USER_ID' to regenerate."
+    exit 1
+fi
 
 # Load Reality keys whenever they exist. Deliberately NOT gated on
 # ENABLE_REALITY: XHTTP is VLESS+Reality-over-xhttp and needs the same keys, and

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -310,6 +310,16 @@ get_env_val() {
     echo "${val:-$default}"
 }
 
+# creds_valid <uuid> <password> — 0 iff both universal user credentials are
+# well-formed (UUID + non-empty password). Guards against a malformed or
+# partially-written credentials.env silently producing broken bundles.
+creds_valid() {
+    local uuid="${1:-}" password="${2:-}"
+    [[ "$uuid" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]] || return 1
+    [[ -n "$password" ]] || return 1
+    return 0
+}
+
 # Donate mode: restrict a user to the protocols in DONATE_ONLY_PROTOCOLS.
 # Reference, including how to add a protocol: docs/devdocs/DONATE-MODE.md
 #

--- a/tests/creds-valid-test.sh
+++ b/tests/creds-valid-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Regression test: generate-user.sh must reject a malformed credentials.env
+# (empty/invalid USER_UUID or empty USER_PASSWORD) instead of emitting broken
+# bundles. Unit-tests the creds_valid guard from scripts/lib/common.sh.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+# shellcheck source=/dev/null
+source "$ROOT/scripts/lib/common.sh"
+
+echo "creds_valid: accepts a well-formed pair, rejects malformed credentials.env"
+
+UUID="a3fcdcc0-5751-4b76-b45c-e38d8f0693ed"
+
+creds_valid "$UUID" "s3cret"        && ok "accepts valid UUID + password"        || bad "valid pair rejected"
+creds_valid ""      "s3cret"        && bad "empty UUID accepted"                 || ok "rejects empty UUID"
+creds_valid "not-a-uuid" "s3cret"   && bad "malformed UUID accepted"             || ok "rejects malformed UUID"
+creds_valid "$UUID" ""              && bad "empty password accepted"             || ok "rejects empty password"
+creds_valid ""      ""              && bad "empty pair accepted"                 || ok "rejects empty pair"
+# a truncated/partial UUID (e.g. from a partial write) must fail
+creds_valid "a3fcdcc0-5751-4b76"    "s3cret" && bad "truncated UUID accepted"    || ok "rejects truncated UUID"
+
+echo ""
+if [ "$fail" -gt 0 ]; then echo "FAILED ($fail failed, $pass passed)"; exit 1; fi
+echo "PASSED ($pass checks)"


### PR DESCRIPTION
Closes the "bootstrap/regenerate resilient to a malformed credentials.env" card.

`generate-user.sh` sources each user's `credentials.env` and builds every share link from it. Two failure modes were unhandled:
- **Corrupt (bash-unparseable)** → `source` failed under `set -euo pipefail` and the run aborted with an opaque error.
- **Partial/malformed** (empty or invalid `USER_UUID`/`USER_PASSWORD` from an aborted write / bad manual edit) → **silently emitted broken bundles**.

Now the `source` is guarded, and `creds_valid()` (new, in `scripts/lib/common.sh`) validates the two universal credentials up front — failing with a clear remediation hint (mirrors the existing `require_keys` pattern) instead of producing garbage. Exiting non-zero here matches the existing missing-creds / missing-keys behaviour. Unit test: `tests/creds-valid-test.sh` (registered in CI).