### PR TITLE
feat(bundle): emit moav:// compact subscription (E1 server side)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: xargs shellcheck --severity=error < /tmp/shfiles
       - name: share-link golden test
         run: bash tests/singbox-links-test.sh
+      - name: moav:// bundle emitter golden test
+        run: bash tests/moav-bundle-test.sh
       - name: peer-IP allocator unit test
         run: bash tests/net-alloc-test.sh
       - name: strict-mode regression test

--- a/docs/MOAV_BUNDLE.md
+++ b/docs/MOAV_BUNDLE.md
@@ -1,0 +1,74 @@
+# `moav://` compact bundle
+
+Every user bundle's `subscription.txt` (the base64 V2Ray subscription) now
+carries one extra line: a **`moav://` compact bundle** that encodes the user's
+entire enabled proxy surface in a single URL. The legacy per-protocol URIs
+(`vless://`, `trojan://`, …) stay exactly as before — the `moav://` line is
+additive.
+
+- **[moav-client](https://github.com/MotherofallVPNs/moav-client)** recognizes
+  the line, expands it back into one endpoint per protocol, and **dedups it
+  against the legacy URIs** (by protocol + address), so importing the
+  subscription yields each server once, not twice.
+- Every other client ignores the unknown `moav://` scheme and uses the legacy
+  URIs. Nothing regresses.
+
+Why: a MoaV subscription is N URIs that repeat the same host, UUID, Reality
+keypair, and passwords. The `moav://` form factors the shared parts out once, so
+it's far smaller and a shared-credential rotation is a one-line change.
+
+## Where it comes from
+
+`scripts/lib/moav-bundle.sh` → `moav_bundle_link <label> <host>` builds the URL
+from the same environment the per-protocol share-link builders use
+(`USER_UUID`, `USER_PASSWORD`, `REALITY_*`, `DOMAIN`, `CDN_*`,
+`HYSTERIA2_OBFS_PASSWORD`, `SS_*`, `PORT_*`, `ENABLE_*`). `generate-user.sh`
+calls it after building the per-protocol links, writes `moav-bundle.txt`, and
+`bundle_readme.py` appends the line to `subscription.txt`. Golden test:
+`tests/moav-bundle-test.sh`; the parse/round-trip contract is pinned in the
+moav-client repo (`proxy-core/subscription/moavbundle_test.go`).
+
+## Format
+
+```
+moav://<uuid>@<server-host>?<shared>&p=<record>&p=<record>…#<label>
+```
+
+- **`<uuid>`** (userinfo) — the VLESS UUID; applies to every `vless-*` record.
+- **`<shared>`** — flat query params common to multiple protocols, each value
+  percent-encoded: `pw`, `pbk`, `sid`, `sni_default`, `fp`, `ss_method`,
+  `ss_pw`, `obfs_pw`.
+- **`p=<record>`** — one per enabled protocol: `p=<name>,<port>[,k=v…]`. The
+  commas and `=` inside a record are structural; sub-values are percent-encoded
+  (the client url-decodes the whole record before splitting).
+
+### Per-protocol records (gated by `ENABLE_*`, ports match the legacy links)
+
+| Protocol | Record | Credentials read (shared) |
+|---|---|---|
+| Reality | `p=reality,443,sni=<REALITY_TARGET_HOST>,flow=xtls-rprx-vision` | `pbk`, `sid` |
+| XHTTP | `p=vless-xhttp,<PORT_XHTTP>,sni=<xhttp target>,fp=chrome` | `pbk`, `sid` |
+| CDN | `p=vless-ws` **or** `p=vless-httpupgrade` (per `CDN_TRANSPORT`) `,443,host=<CDN_ADDRESS>,path=<CDN_WS_PATH>,sni=<CDN_SNI>,alpn=http/1.1` | — |
+| Trojan | `p=trojan,8443` | `pw`, `sni_default` |
+| AnyTLS | `p=anytls,<PORT_ANYTLS>` | `pw`, `sni_default` |
+| Hysteria2 | `p=hy2,443,obfs=salamander` | `pw`, `sni_default`, `obfs_pw` |
+| Shadowsocks-2022 | `p=ss,<SS_PORT>` | `ss_method`, `ss_pw` (`server_psk:user_psk`) |
+
+CDN's `host=` is the connection/fronting address; moav-client defaults the WS/
+httpupgrade **Host header** to it, which is correct for the common case where
+`CDN_ADDRESS == CDN_DOMAIN`.
+
+### Encoding note
+
+Values are percent-encoded so URL-specials survive — the reality `pbk` is base64
+(`+`, `/`, `=`) and would otherwise corrupt. Structural separators (`?`, `&`,
+`#`, the record commas, and each `key=`) are never encoded.
+
+## Not driven by `data/protocols.json`
+
+The emitter is a bash builder alongside the existing `singbox_*_link` /
+`xray_*_link` share-link builders (the established single source for links),
+rather than a `protocols.json`-driven generator — for consistency with those
+builders and to keep the per-protocol credential mapping in one readable place.
+Adding a protocol is one `if [[ "$ENABLE_X" ]]` block, mirroring how a protocol
+gets its `singbox_x_link`.

--- a/scripts/generate-user.sh
+++ b/scripts/generate-user.sh
@@ -16,6 +16,7 @@ source /app/lib/masterdns.sh
 source /app/lib/gooserelay.sh
 source /app/lib/telemt.sh
 source /app/lib/sing-box.sh
+source /app/lib/moav-bundle.sh
 source /app/lib/trusttunnel.sh
 source /app/lib/xray.sh
 source /app/lib/bundle-readme.sh
@@ -643,6 +644,17 @@ if [[ "${ENABLE_XDNS:-false}" == "true" ]] && [[ -n "${DOMAIN:-}" ]]; then
             log_info "  - XDNS configs generated"
         fi
     fi
+fi
+
+# -----------------------------------------------------------------------------
+# Emit the compact moav:// bundle — one URL covering every enabled proxy
+# protocol, alongside the legacy per-protocol URIs. moav-client expands + dedups
+# it; other clients ignore the unknown scheme. See docs/MOAV_BUNDLE.md.
+# -----------------------------------------------------------------------------
+MOAV_BUNDLE=$(moav_bundle_link "$USER_ID" "$SERVER_IP")
+if [[ -n "$MOAV_BUNDLE" ]]; then
+    echo "$MOAV_BUNDLE" > "$OUTPUT_DIR/moav-bundle.txt"
+    log_info "  - moav:// compact bundle generated"
 fi
 
 # -----------------------------------------------------------------------------

--- a/scripts/lib/bundle_readme.py
+++ b/scripts/lib/bundle_readme.py
@@ -105,6 +105,16 @@ for stem in SUB_FILES:
             uris.append(line)
             break
 
+# Append the compact moav:// bundle (one URL for every enabled proxy) so
+# moav-client receives it in the subscription too; it expands + dedups it
+# against the legacy URIs above. Other clients ignore the unknown scheme.
+_moav = _read("moav-bundle.txt")
+if _moav:
+    for _line in _moav.replace("\r", "").splitlines():
+        if _line.startswith("moav://"):
+            uris.append(_line)
+            break
+
 sub_b64 = base64.b64encode(("\n".join(uris) + "\n").encode()).decode() if uris else ""
 # Unconditional: the bundle always carries subscription.txt (empty if no links).
 with open(os.path.join(OUT, "subscription.txt"), "w", encoding="utf-8") as f:

--- a/scripts/lib/moav-bundle.sh
+++ b/scripts/lib/moav-bundle.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# lib/moav-bundle.sh — emit a compact moav:// bundle URL from a user's ENABLED
+# proxy protocols. The compact form factors shared credentials (the UUID rides
+# in the userinfo; pw / reality pbk+sid / ss+obfs secrets / default SNI go in
+# shared query params) out of the N per-protocol URIs into one URL that
+# moav-client's ParseMoaVBundle expands back into endpoints. Grammar +
+# round-trip contract: docs/MOAV_BUNDLE.md and the moav-client repo.
+#
+# Reads the same environment the singbox_/xray_ share-link builders use
+# (USER_UUID, USER_PASSWORD, REALITY_*, DOMAIN, CDN_*, HYSTERIA2_OBFS_PASSWORD,
+# SS_*, PORT_*, ENABLE_*) plus moav_name_prefix. Definitions only.
+
+# Percent-encode a value (RFC3986 unreserved kept). Applied to every shared
+# query value AND every p= record sub-value; moav-client url-decodes the whole
+# record before the structural comma/`=` split, so encoding sub-values is safe
+# and the structural separators (which we never encode) survive.
+_moav_urlencode() {
+    local s="$1" out="" c i
+    for (( i=0; i<${#s}; i++ )); do
+        c="${s:i:1}"
+        case "$c" in
+            [a-zA-Z0-9.~_-]) out+="$c" ;;
+            *) printf -v c '%%%02X' "'$c"; out+="$c" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
+# moav_bundle_link <label> <host> — print the moav:// URL, or nothing when no
+# proxy protocol is enabled / the user has no UUID. <host> is the default
+# connection host (SERVER_IP); CDN overrides it per-record via host=.
+moav_bundle_link() {
+    local label="$1" host="$2"
+    [[ -n "${USER_UUID:-}" ]] || return 0
+    local shared=() precords=()
+
+    # Shared credentials (the UUID is the userinfo, so it is not repeated here).
+    [[ -n "${USER_PASSWORD:-}" ]]      && shared+=("pw=$(_moav_urlencode "$USER_PASSWORD")")
+    [[ -n "${REALITY_PUBLIC_KEY:-}" ]] && shared+=("pbk=$(_moav_urlencode "$REALITY_PUBLIC_KEY")")
+    [[ -n "${REALITY_SHORT_ID:-}" ]]   && shared+=("sid=$(_moav_urlencode "$REALITY_SHORT_ID")")
+    [[ -n "${DOMAIN:-}" ]]             && shared+=("sni_default=$(_moav_urlencode "$DOMAIN")")
+    shared+=("fp=random")
+
+    # Per-protocol records, gated by the same ENABLE_* flags + ports as the
+    # per-protocol .txt builders, so the moav:// bundle matches the legacy URIs.
+    if [[ "${ENABLE_REALITY:-true}" == "true" ]]; then
+        precords+=("p=reality,443,sni=$(_moav_urlencode "${REALITY_TARGET_HOST:-}"),flow=xtls-rprx-vision")
+    fi
+    if [[ "${ENABLE_XHTTP:-true}" == "true" ]]; then
+        local _xt="${XHTTP_REALITY_TARGET:-${REALITY_TARGET:-dl.google.com:443}}"
+        precords+=("p=vless-xhttp,${PORT_XHTTP:-2096},sni=$(_moav_urlencode "${_xt%%:*}"),fp=chrome")
+    fi
+    if [[ "${ENABLE_CDN:-false}" == "true" && -n "${CDN_ADDRESS:-}" ]]; then
+        local _cdn="vless-httpupgrade"
+        [[ "${CDN_TRANSPORT:-httpupgrade}" == "ws" ]] && _cdn="vless-ws"
+        precords+=("p=${_cdn},443,host=$(_moav_urlencode "$CDN_ADDRESS"),path=$(_moav_urlencode "${CDN_WS_PATH:-/ws}"),sni=$(_moav_urlencode "${CDN_SNI:-}"),alpn=http/1.1")
+    fi
+    if [[ "${ENABLE_TROJAN:-true}" == "true" ]]; then
+        precords+=("p=trojan,8443")
+    fi
+    if [[ "${ENABLE_ANYTLS:-false}" == "true" ]]; then
+        precords+=("p=anytls,${PORT_ANYTLS:-8445}")
+    fi
+    if [[ "${ENABLE_HYSTERIA2:-true}" == "true" ]]; then
+        [[ -n "${HYSTERIA2_OBFS_PASSWORD:-}" ]] && shared+=("obfs_pw=$(_moav_urlencode "$HYSTERIA2_OBFS_PASSWORD")")
+        precords+=("p=hy2,443,obfs=salamander")
+    fi
+    if [[ "${ENABLE_SS:-false}" == "true" && -n "${SS_SERVER_PSK_LOCAL:-}" && -n "${SS_USER_PSK:-}" ]]; then
+        shared+=("ss_method=$(_moav_urlencode "${SS_METHOD_LOCAL:-2022-blake3-aes-128-gcm}")")
+        shared+=("ss_pw=$(_moav_urlencode "${SS_SERVER_PSK_LOCAL}:${SS_USER_PSK}")")
+        precords+=("p=ss,${SS_PORT:-8388}")
+    fi
+
+    (( ${#precords[@]} )) || return 0
+
+    local all=("${shared[@]}" "${precords[@]}") query
+    query=$(IFS='&'; printf '%s' "${all[*]}")
+    printf 'moav://%s@%s?%s#%s%s\n' "$USER_UUID" "$host" "$query" "$(moav_name_prefix)" "$label"
+}

--- a/tests/moav-bundle-test.sh
+++ b/tests/moav-bundle-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Golden test for the moav:// bundle emitter (scripts/lib/moav-bundle.sh):
+# enabled protocols become p= records, disabled ones don't, credentials go in
+# shared params, and base64 values (reality pbk) are percent-encoded. The
+# round-trip (moav-client ParseMoaVBundle) is pinned in the moav-client repo.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+has()  { case "$1" in *"$2"*) ok "$3";; *) bad "$3 (missing: $2)";; esac; }
+lacks(){ case "$1" in *"$2"*) bad "$3 (unexpected: $2)";; *) ok "$3";; esac; }
+
+moav_name_prefix() { echo "MoaV-test-"; }
+# shellcheck source=/dev/null
+source "$ROOT/scripts/lib/moav-bundle.sh"
+
+# Common credentials for all cases.
+setup_creds() {
+    export USER_UUID="a3fcdcc0-5751-4b76-b45c-e38d8f0693ed" USER_PASSWORD="pw123"
+    export REALITY_PUBLIC_KEY="RmVQ0abc+Def/Ghi=" REALITY_SHORT_ID="deadbeef" REALITY_TARGET_HOST="update.example.com"
+    export DOMAIN="vpn.example.com" HYSTERIA2_OBFS_PASSWORD="obfspw"
+    export PORT_XHTTP=2096 XHTTP_REALITY_TARGET="dl.google.com:443" PORT_ANYTLS=8445 SS_PORT=8388
+    export SS_SERVER_PSK_LOCAL="srvpsk" SS_USER_PSK="userpsk" SS_METHOD_LOCAL="2022-blake3-aes-128-gcm"
+}
+disable_all() { for v in REALITY XHTTP CDN TROJAN ANYTLS HYSTERIA2 SS; do export "ENABLE_$v=false"; done; }
+
+echo "moav:// emitter: enabled -> p= records, base64 pbk encoded, disabled omitted"
+
+# --- all proxies enabled ---
+setup_creds; disable_all
+export ENABLE_REALITY=true ENABLE_XHTTP=true ENABLE_TROJAN=true ENABLE_ANYTLS=true ENABLE_HYSTERIA2=true ENABLE_SS=true
+export ENABLE_CDN=true CDN_ADDRESS="cdn.example.com" CDN_TRANSPORT=httpupgrade CDN_WS_PATH="/ws" CDN_SNI="cdn.example.com"
+url=$(moav_bundle_link "alice" "203.0.113.9")
+has "$url" "moav://a3fcdcc0-5751-4b76-b45c-e38d8f0693ed@203.0.113.9?" "starts with uuid@host"
+has "$url" "pbk=RmVQ0abc%2BDef%2FGhi%3D"       "reality pbk is percent-encoded"
+has "$url" "p=reality,443,sni=update.example.com,flow=xtls-rprx-vision" "reality record"
+has "$url" "p=vless-xhttp,2096,sni=dl.google.com,fp=chrome" "xhttp record"
+has "$url" "p=vless-httpupgrade,443,host=cdn.example.com" "CDN httpupgrade record"
+has "$url" "p=trojan,8443"  "trojan record"
+has "$url" "p=anytls,8445"  "anytls record"
+has "$url" "p=hy2,443,obfs=salamander" "hy2 record"
+has "$url" "p=ss,8388"      "ss record"
+has "$url" "#MoaV-test-alice" "label fragment"
+
+# --- CDN over ws -> vless-ws (not httpupgrade) ---
+export CDN_TRANSPORT=ws
+url=$(moav_bundle_link "alice" "203.0.113.9")
+has   "$url" "p=vless-ws,443,host=cdn.example.com" "CDN ws record"
+lacks "$url" "p=vless-httpupgrade" "no httpupgrade record when transport=ws"
+
+# --- only reality + trojan ---
+setup_creds; disable_all; export ENABLE_REALITY=true ENABLE_TROJAN=true
+url=$(moav_bundle_link "bob" "198.51.100.7")
+has   "$url" "p=reality,443" "reality present"
+has   "$url" "p=trojan,8443" "trojan present"
+lacks "$url" "p=hy2"         "hy2 omitted when disabled"
+lacks "$url" "p=ss,"         "ss omitted when disabled"
+lacks "$url" "p=vless-xhttp" "xhttp omitted when disabled"
+
+# --- no proxies enabled -> empty ---
+setup_creds; disable_all
+url=$(moav_bundle_link "nobody" "203.0.113.9")
+[ -z "$url" ] && ok "emits nothing when no proxy is enabled" || bad "expected empty, got: $url"
+
+echo ""
+if [ "$fail" -gt 0 ]; then echo "FAILED ($fail failed, $pass passed)"; exit 1; fi
+echo "PASSED ($pass checks)"


### PR DESCRIPTION
Closes the E1 card and the moav:// loop — the server now **emits** the compact bundle that moav-client already parses.

## What
Each user's `subscription.txt` gains one `moav://` line encoding the whole enabled proxy surface in a single URL (shared credentials factored out; one `p=` record per protocol). The legacy per-protocol URIs stay — the line is additive. moav-client expands + dedups it; other clients ignore the unknown scheme.

## How
- **`scripts/lib/moav-bundle.sh`** — `moav_bundle_link` builder, reading the same env as the `singbox_*_link` builders. Shared params (`pw`/`pbk`/`sid`/`sni_default`/`fp`/`ss_*`/`obfs_pw`) percent-encoded (reality `pbk` is base64); one `p=` record per enabled protocol; **CDN emits `vless-ws` or `vless-httpupgrade` per `CDN_TRANSPORT`**.
- `generate-user.sh` writes `moav-bundle.txt`; `bundle_readme.py` appends it to the base64 subscription.
- **Golden test** `tests/moav-bundle-test.sh` (registered in CI) + **`docs/MOAV_BUNDLE.md`**.

## Round-trip
Verified end-to-end: the emitter's output fed through moav-client `ParseMoaVBundle` yields all 7 protocols with correct transports/hosts/passwords, and base64 `pbk` survives intact. The parse contract is pinned in **moav-client PR #25** (CDN WS-Host default, `vless-httpupgrade` name, value re-escaping, protocol+address dedup).

## Design note
Implemented as a bash builder alongside the existing per-protocol link builders (the established single source), not a `data/protocols.json`-driven generator — for consistency and to keep the credential mapping readable. Adding a protocol is one `ENABLE_*` block. Rationale in `docs/MOAV_BUNDLE.md`.