### PR TITLE
contrib: add conduit-monitor and rotate-log ops scripts

### DIFF
--- a/contrib/conduit-monitor/README.md
+++ b/contrib/conduit-monitor/README.md
@@ -1,0 +1,149 @@
+# conduit-monitor
+
+A periodic health-check-and-repair script for a Conduit CLI station, for
+macOS and Linux. Runs every 15-30 minutes via a scheduled job, notices if
+Conduit has stopped running or gotten stuck, and fixes the specific
+failure modes it knows how to fix — anything else, it logs and notifies
+about rather than guessing.
+
+## Why this exists
+
+A Conduit CLI station is usually unattended for long stretches. Two
+failure modes are common enough to be worth automating around:
+
+- The service stops running (a crash, a `launchctl bootout`/`systemctl
+  stop`, anything that leaves it down) and doesn't come back on its own.
+- Conduit is technically running but stuck — connected to nothing, or
+  cycling through failed connection attempts without ever landing one.
+  `conduit_idle_seconds` alone doesn't catch every shape of this (a proxy
+  that's actively failing, not idle, can show near-zero idle time while
+  still being fully broken), so this script checks both.
+
+Two design choices come directly from a real incident, not speculation:
+
+**An inconclusive check must default to "assume fine," not "assume the
+worst."** This script optionally supports stopping Conduit if it detects
+you've roamed onto a network that isn't your own (a privacy feature for
+laptop-based stations — donating a stranger's bandwidth isn't the point).
+The check that decides this depends on an external network lookup. If that
+lookup ever fails — a DNS hiccup, a routing blip, the lookup service being
+briefly down — treating the failure as "confirmed away from home" and
+stopping Conduit is exactly backwards: it turns a transient, unrelated
+network problem into an extended outage, because the same failing lookup
+then also blocks the script from ever starting it back up. This script
+treats a failed lookup as inconclusive and takes no action, while still
+logging the failure so it's visible.
+
+**A repair path shouldn't depend on the thing it's repairing.** An earlier
+version of the interface-repair logic here (macOS only, see below) was
+only reachable through a check that itself required a working IP address
+to run — meaning the one scenario that most needed the repair (no IP at
+all) could never actually trigger it. The no-usable-IPv4 check in this
+version has no prerequisites beyond the interface being powered on.
+
+**A safety check should fail closed, not guess.** `networksetup
+-setairportpower` doesn't validate that the interface name it's given is
+actually a WiFi device — given an unrecognized name, it silently falls
+back to controlling whatever WiFi interface *does* exist on the system,
+rather than erroring. Found live while testing a sibling script's
+identical code path: a misconfigured interface name toggled the real WiFi
+connection instead of failing loudly. This script now confirms
+`NETWORK_INTERFACE` actually matches the system's real Wi-Fi hardware port
+(via `networksetup -listallhardwareports`) before ever touching airport
+power, and refuses to act — logging it as an anomaly instead — if it
+doesn't match.
+
+## What it does
+
+Every run:
+1. **macOS only**: if configured, bounces a network interface that has no
+   usable IPv4 address at all (not even a self-assigned link-local) and
+   restarts Conduit. Not available on Linux — see "Platform differences"
+   below for why.
+2. If configured, checks whether this machine's public IP matches a
+   configured "home" prefix; stops Conduit if not, starts it if so. Both
+   sides of this are opt-in — skipped entirely unless you set
+   `HOME_PUBLIC_IP_PREFIX`. Works on both platforms.
+3. Starts Conduit if it isn't running.
+4. Detects a stuck/stale proxy (idle too long, or connected=0 with recent
+   errors) and restarts it, with a cooldown to avoid restart loops.
+5. Optionally calls out to a log-rotation helper you provide.
+6. Logs every check, and sends one consolidated notification per run if
+   anything happened — not one per finding.
+
+Everything it can't fix (not connected to the broker at all, a stale
+public-IP lookup, a stuck proxy that was already restarted too recently to
+restart again) gets logged and pushed as a notification instead of
+silently ignored.
+
+## Platform differences
+
+The core logic — checking Conduit's own metrics, deciding whether it's
+down or stuck — is identical on both platforms. Only the actual
+start/stop/restart/notify commands differ (macOS: `launchctl`; Linux:
+`systemctl`), branched once via `uname` near the top of the script.
+
+**The network-interface repair feature is macOS-only, on purpose, not
+because it wasn't gotten to.** It was tested for real against a genuine
+Linux environment (see "How this was tested" below) and found to be
+genuinely fragmented across distros in a way the macOS version isn't:
+which mechanism actually re-acquires a DHCP lease after a link is brought
+back up — NetworkManager, `dhclient`, `dhcpcd`, `systemd-networkd`, or
+sometimes nothing at all — varies by distro and by how that particular
+machine is configured, and there's no single command that reliably works
+everywhere the way `networksetup` does on macOS. Shipping something that
+silently does the wrong thing (or nothing) on someone's specific setup
+seemed worse than not including it. It's also arguably more of a
+laptop/roaming-station concern than a typical fixed-location Linux
+deployment (a server, a Raspberry Pi on a stable wired connection) would
+actually need.
+
+## How this was tested
+
+The macOS path has been running in production on a real station for an
+extended period, including through a real multi-hour outage that led
+directly to two of the fixes described above.
+
+The Linux path was tested for real, not just written from documentation —
+against a genuine `systemd`-based environment running in Docker via
+[Colima](https://github.com/abiosoft/colima) on macOS (a real Linux VM,
+not just a container-in-name-only): a custom Debian image with `systemd`,
+`systemd-sysv`, and `network-manager` actually installed, run with
+`--privileged --cgroupns=host` so `systemd` genuinely manages services
+inside it. Both restart paths were verified against a real dummy
+`systemd` service: stopping it and confirming the script detects the
+failure and runs `systemctl start`, and separately simulating a stuck
+proxy (via a fake metrics endpoint reporting elevated `conduit_idle_seconds`)
+against an already-running service and confirming the script correctly
+runs `systemctl restart` instead.
+
+This is a real `systemd` environment, not a mock, so the `systemctl`
+commands behave as expected — but a privileged `systemd`-in-Docker VM can
+still differ from a bare-metal or VM Linux install in edge cases. If you
+deploy this on Linux, keep an eye on the log the first few runs rather than
+assuming it's flawless from a container test alone.
+
+## What it needs
+
+Nothing beyond what the OS already ships with, plus optionally:
+- macOS: [terminal-notifier](https://github.com/julienXX/terminal-notifier)
+  (falls back to `osascript` if not present).
+- Linux: `notify-send`, if you want a local desktop notification — most
+  headless servers won't have this, which is fine, it's skipped silently
+  if absent.
+- Either platform: an [ntfy.sh](https://ntfy.sh) topic if you want push
+  notifications to a phone — this is the more reliable channel on a
+  headless Linux server specifically, since there's often no local
+  notification system to fall back on there at all.
+
+Configuration is entirely via environment variables — see the comment
+block at the top of the script for the full list and defaults. Nothing is
+hardcoded to any particular machine, router, or network.
+
+## What this isn't
+
+This isn't a full station-management suite — it doesn't touch router
+configuration and doesn't manage anything beyond Conduit itself. It's
+deliberately narrow: notice Conduit is down or stuck, and get it running
+again, correctly, without guessing at problems it doesn't actually
+understand.

--- a/contrib/conduit-monitor/conduit-monitor.sh
+++ b/contrib/conduit-monitor/conduit-monitor.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# conduit-monitor.sh — periodic Conduit health check + known-fix autopilot for
+# macOS and Linux. Run every 15-30 min from a scheduled job (macOS LaunchAgent
+# with StartCalendarInterval, or a Linux systemd timer / cron) so it survives
+# closed terminals and sleep. Detection logic is identical on both platforms;
+# only the restart/notify commands branch on `uname`. Conservative by design:
+# it applies a small set of deterministic known fixes, and logs or notifies
+# about anything else rather than guessing. See README.md for details.
+#
+# Configuration — all via environment variables, defaults except where noted:
+#   CONDUIT_SERVICE_LABEL      launchd label (macOS, default ca.psiphon.conduit)
+#                              / systemd unit name (Linux, default conduit)
+#   CONDUIT_PLIST_PATH         macOS only: LaunchAgent plist path
+#                              (default ~/Library/LaunchAgents/$CONDUIT_SERVICE_LABEL.plist)
+#   CONDUIT_METRICS_URL        Conduit metrics (default http://127.0.0.1:9090/metrics)
+#   CONDUIT_LOG_PATH           Conduit log, for a recent-error heuristic (default ~/conduit.log)
+#   MONITOR_LOG_PATH           this script's own log (default ~/conduit-monitor.log)
+#   KICKSTART_COOLDOWN_FILE    timestamp file guarding against restart loops
+#                              (default ~/.conduit_monitor_last_kickstart)
+#   KICKSTART_COOLDOWN_SECS    min seconds between auto-restarts (default 1200)
+#   IDLE_THRESHOLD_SECS        max conduit_idle_seconds before "stuck" (default 300)
+#   ROTATE_LOG_SCRIPT          optional log-rotation helper, called weekly as
+#                              `$ROTATE_LOG_SCRIPT $CONDUIT_LOG_PATH conduit`; skipped if unset
+#   NETWORK_INTERFACE          macOS only, optional (e.g. en0): bounce this interface
+#                              when it has no usable IPv4. No effect on Linux.
+#   NETWORK_INTERFACE_IS_WIFI  macOS only (default true): WiFi vs wired bounce method
+#   HOME_PUBLIC_IP_PREFIX      optional (e.g. 203.0.113): stop Conduit when the public
+#                              IP doesn't match this prefix (roaming/privacy guard)
+#   NTFY_TOPIC_FILE            optional file holding an ntfy.sh topic for push notifications
+
+OS="$(uname)"   # "Darwin" or "Linux" — the only two supported
+
+if [ "$OS" = "Darwin" ]; then
+    CONDUIT_SERVICE_LABEL="${CONDUIT_SERVICE_LABEL:-ca.psiphon.conduit}"
+else
+    CONDUIT_SERVICE_LABEL="${CONDUIT_SERVICE_LABEL:-conduit}"
+fi
+CONDUIT_PLIST_PATH="${CONDUIT_PLIST_PATH:-$HOME/Library/LaunchAgents/${CONDUIT_SERVICE_LABEL}.plist}"
+CONDUIT_METRICS_URL="${CONDUIT_METRICS_URL:-http://127.0.0.1:9090/metrics}"
+CONDUIT_LOG_PATH="${CONDUIT_LOG_PATH:-$HOME/conduit.log}"
+MONITOR_LOG_PATH="${MONITOR_LOG_PATH:-$HOME/conduit-monitor.log}"
+KICKSTART_COOLDOWN_FILE="${KICKSTART_COOLDOWN_FILE:-$HOME/.conduit_monitor_last_kickstart}"
+KICKSTART_COOLDOWN_SECS="${KICKSTART_COOLDOWN_SECS:-1200}"
+IDLE_THRESHOLD_SECS="${IDLE_THRESHOLD_SECS:-300}"
+ROTATE_LOG_SCRIPT="${ROTATE_LOG_SCRIPT:-}"
+NETWORK_INTERFACE="${NETWORK_INTERFACE:-}"
+NETWORK_INTERFACE_IS_WIFI="${NETWORK_INTERFACE_IS_WIFI:-true}"
+HOME_PUBLIC_IP_PREFIX="${HOME_PUBLIC_IP_PREFIX:-}"
+NTFY_TOPIC_FILE="${NTFY_TOPIC_FILE:-}"
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$MONITOR_LOG_PATH"
+}
+
+notify() {
+    local msg
+    msg="[$(date '+%m/%d %H:%M')] $1"
+    if [ "$OS" = "Darwin" ]; then
+        if command -v terminal-notifier >/dev/null 2>&1; then
+            terminal-notifier -message "$msg" -title "Conduit Monitor" -open "file://$MONITOR_LOG_PATH" >/dev/null 2>&1
+        else
+            osascript -e "display notification \"$msg\" with title \"Conduit Monitor\"" >/dev/null 2>&1
+        fi
+    else
+        # Most headless Linux servers have no desktop notification service
+        # at all -- only attempt this if notify-send actually exists, and
+        # don't treat its absence as a problem worth logging. ntfy (below)
+        # is the reliable channel on Linux; this is a bonus if available.
+        command -v notify-send >/dev/null 2>&1 && notify-send "Conduit Monitor" "$msg" >/dev/null 2>&1
+    fi
+    if [ -n "$NTFY_TOPIC_FILE" ] && [ -f "$NTFY_TOPIC_FILE" ]; then
+        curl -s --max-time 5 -d "$msg" -H "Title: Conduit Monitor" "https://ntfy.sh/$(cat "$NTFY_TOPIC_FILE")" >/dev/null 2>&1
+    fi
+}
+
+# Bounces $NETWORK_INTERFACE and kickstarts Conduit when that interface has no
+# usable IPv4 (empty or a self-assigned 169.254.x link-local — DHCP never
+# completed). Has no prerequisites: a repair for "no working network" must not
+# itself depend on a working network.
+fix_no_ip_interface() {
+    [ "$OS" != "Darwin" ] && return   # not ported to Linux -- see header comment
+    [ -z "$NETWORK_INTERFACE" ] && return
+    local ip
+    ip=$(ipconfig getifaddr "$NETWORK_INTERFACE" 2>/dev/null)
+    if [ -n "$ip" ] && ! echo "$ip" | grep -qE "^169\.254\."; then
+        return   # has a real address, nothing to do
+    fi
+    if [ "$NETWORK_INTERFACE_IS_WIFI" = "true" ]; then
+        # `networksetup -setairportpower` doesn't validate its argument is a
+        # WiFi device — given an unknown name it silently toggles whatever WiFi
+        # interface exists. Confirm NETWORK_INTERFACE is the real Wi-Fi port first.
+        local wifi_device
+        wifi_device=$(networksetup -listallhardwareports | awk '/Hardware Port: Wi-Fi/{getline; print $2}')
+        if [ "$wifi_device" != "$NETWORK_INTERFACE" ]; then
+            ANOMALIES+=("NETWORK_INTERFACE=$NETWORK_INTERFACE is not this system's actual Wi-Fi device (that's $wifi_device) -- refusing to touch airport power to avoid affecting the wrong interface, needs a manual look")
+            return
+        fi
+        networksetup -setairportpower "$NETWORK_INTERFACE" off
+        sleep 5
+        networksetup -setairportpower "$NETWORK_INTERFACE" on
+    else
+        local service
+        service=$(networksetup -listallhardwareports | awk -v dev="$NETWORK_INTERFACE" '/Hardware Port:/{name=$0; sub(/Hardware Port: /,"",name)} $0=="Device: " dev {print name}')
+        if [ -z "$service" ]; then
+            ANOMALIES+=("NETWORK_INTERFACE=$NETWORK_INTERFACE has no usable IPv4 (${ip:-none}), but could not find its network service name to bounce it — needs a manual look")
+            return
+        fi
+        networksetup -setnetworkserviceenabled "$service" off
+        sleep 3
+        networksetup -setnetworkserviceenabled "$service" on
+    fi
+    sleep 12
+    service_restart
+    ACTIONS+=("$NETWORK_INTERFACE had no usable IPv4 (was: ${ip:-none}), bounced it and restarted Conduit")
+}
+
+# Small OS-branching wrappers so the actual health-check logic below (which
+# is identical on both platforms) doesn't need its own if/else at every step.
+service_is_running() {
+    if [ "$OS" = "Darwin" ]; then
+        [ "$(launchctl print "gui/$(id -u)/${CONDUIT_SERVICE_LABEL}" 2>/dev/null | grep -m1 state | awk '{print $3}')" = "running" ]
+    else
+        systemctl is-active --quiet "${CONDUIT_SERVICE_LABEL}.service" 2>/dev/null
+    fi
+}
+
+service_start() {
+    if [ "$OS" = "Darwin" ]; then
+        launchctl bootstrap "gui/$(id -u)" "$CONDUIT_PLIST_PATH" 2>/dev/null
+    else
+        systemctl start "${CONDUIT_SERVICE_LABEL}.service" 2>/dev/null
+    fi
+}
+
+service_stop() {
+    if [ "$OS" = "Darwin" ]; then
+        launchctl bootout "gui/$(id -u)" "$CONDUIT_PLIST_PATH" 2>/dev/null
+    else
+        systemctl stop "${CONDUIT_SERVICE_LABEL}.service" 2>/dev/null
+    fi
+}
+
+service_restart() {
+    if [ "$OS" = "Darwin" ]; then
+        launchctl kickstart -k "gui/$(id -u)/${CONDUIT_SERVICE_LABEL}" 2>/dev/null
+    else
+        systemctl restart "${CONDUIT_SERVICE_LABEL}.service" 2>/dev/null
+    fi
+}
+
+# --- gather state ---
+if service_is_running; then CONDUIT_STATE="running"; else CONDUIT_STATE="not running"; fi
+METRICS=$(curl -s --max-time 5 "$CONDUIT_METRICS_URL")
+IS_LIVE=$(echo "$METRICS" | awk '/^conduit_is_live/{print $2}')
+CONNECTED=$(echo "$METRICS" | awk '/^conduit_connected_clients/{print $2}')
+IDLE_SECONDS=$(echo "$METRICS" | awk '/^conduit_idle_seconds/{print $2}')
+ERROR_COUNT=$(tail -n 100 "$CONDUIT_LOG_PATH" 2>/dev/null | grep -cE "404|ERROR")
+
+ACTIONS=()
+ANOMALIES=()
+
+# --- optional: fix an interface with no usable IPv4 BEFORE the home-network
+# check below, which itself needs working connectivity to run. ---
+fix_no_ip_interface
+
+# --- optional: pause Conduit if this Mac's public IP doesn't match the
+# configured home prefix (mobile/laptop stations only — skipped entirely
+# if HOME_PUBLIC_IP_PREFIX is unset) ---
+ON_NON_HOME_NETWORK="no"
+PUBLIC_IP_LOOKUP_FAILED="no"
+if [ -n "$HOME_PUBLIC_IP_PREFIX" ]; then
+    CURRENT_PUBLIC_IP=$(curl -s --max-time 5 https://api.ipify.org)
+    if [ -z "$CURRENT_PUBLIC_IP" ]; then
+        # An inconclusive lookup must NOT be treated as "confirmed away from
+        # home": pausing on a failed lookup then blocks the un-pause on every
+        # later check too. Default to "assume home, don't act" and log the
+        # failure as a visible anomaly.
+        PUBLIC_IP_LOOKUP_FAILED="yes"
+    else
+        case "$CURRENT_PUBLIC_IP" in
+            ${HOME_PUBLIC_IP_PREFIX}*) ON_NON_HOME_NETWORK="no" ;;
+            *) ON_NON_HOME_NETWORK="yes" ;;
+        esac
+    fi
+fi
+
+if [ "$PUBLIC_IP_LOOKUP_FAILED" = "yes" ]; then
+    ANOMALIES+=("public-IP lookup (api.ipify.org) failed/empty this cycle — treated as inconclusive, did NOT pause Conduit, but check general internet routing if this recurs")
+fi
+
+# --- metrics endpoint unreachable entirely ---
+# Expected/correct when Conduit is intentionally paused on a non-home
+# network (nothing listening on the metrics port) — not an anomaly then.
+if [ -z "$METRICS" ] && [ "$ON_NON_HOME_NETWORK" = "no" ]; then
+    ANOMALIES+=("metrics endpoint ($CONDUIT_METRICS_URL) did not respond at all — Conduit or its metrics exporter may be down, needs a look")
+fi
+
+# --- Conduit not running -> start it ---
+# Skipped if on a non-home network — that's the correct, intentionally-
+# paused state, not something to fight every cycle.
+if [ "$CONDUIT_STATE" != "running" ] && [ "$ON_NON_HOME_NETWORK" = "no" ]; then
+    service_start
+    ACTIONS+=("Conduit was not running, started it")
+fi
+
+# --- Conduit running on a non-home network -> pause it ---
+if [ -n "$HOME_PUBLIC_IP_PREFIX" ] && [ "$CONDUIT_STATE" = "running" ] && [ "$ON_NON_HOME_NETWORK" = "yes" ]; then
+    service_stop
+    ACTIONS+=("Conduit was running on a non-home network (public IP: ${CURRENT_PUBLIC_IP:-unknown}), paused it")
+fi
+
+# --- not connected to the broker at all -- no known fix, needs a human look ---
+if [ -n "$METRICS" ] && [ "$IS_LIVE" != "1" ]; then
+    ANOMALIES+=("conduit_is_live=$IS_LIVE (not connected to broker) — no known fix for this, needs investigation")
+fi
+
+# --- stale/stuck proxy, two failure shapes both worth catching:
+# 1) conduit_idle_seconds elevated — genuinely dead, no activity at all.
+# 2) connected=0 with recent errors — "actively failing" rather than idle, so
+#    idle_seconds can stay near zero while still broken. Keep both checks. ---
+IDLE_INT=${IDLE_SECONDS%.*}
+STALE_REASON=""
+if [ "$IS_LIVE" = "1" ] && [ -n "$IDLE_INT" ] && [ "$IDLE_INT" -gt "$IDLE_THRESHOLD_SECS" ] 2>/dev/null; then
+    STALE_REASON="idle_seconds=${IDLE_INT}"
+elif [ "$IS_LIVE" = "1" ] && [ "$CONNECTED" = "0" ] && [ "$ERROR_COUNT" -gt 0 ] 2>/dev/null; then
+    STALE_REASON="connected=0 with ${ERROR_COUNT} errors/100 lines despite active connecting attempts"
+fi
+
+if [ -n "$STALE_REASON" ]; then
+    LAST_KICKSTART=$(cat "$KICKSTART_COOLDOWN_FILE" 2>/dev/null || echo 0)
+    NOW=$(date +%s)
+    if [ $((NOW - LAST_KICKSTART)) -gt "$KICKSTART_COOLDOWN_SECS" ]; then
+        service_restart
+        echo "$NOW" > "$KICKSTART_COOLDOWN_FILE"
+        ACTIONS+=("stale/stuck proxy ($STALE_REASON), kickstarted Conduit")
+    else
+        ANOMALIES+=("stale/stuck proxy detected ($STALE_REASON) but kickstarted within the last ${KICKSTART_COOLDOWN_SECS}s — skipping to avoid a restart loop, this needs a manual look, it is NOT self-resolving")
+    fi
+fi
+
+# --- optional weekly log rotation, if a rotation helper is configured ---
+if [ -n "$ROTATE_LOG_SCRIPT" ] && [ -x "$ROTATE_LOG_SCRIPT" ]; then
+    ROTATE_OUTPUT=$("$ROTATE_LOG_SCRIPT" "$CONDUIT_LOG_PATH" conduit)
+    [ -n "$ROTATE_OUTPUT" ] && ACTIONS+=("$ROTATE_OUTPUT")
+fi
+
+# --- log + notify (one consolidated notification per run, not one per finding) ---
+if [ ${#ACTIONS[@]} -eq 0 ] && [ ${#ANOMALIES[@]} -eq 0 ]; then
+    log "CHECK: healthy (live=$IS_LIVE, connected=$CONNECTED, idle=${IDLE_INT}s, errors=$ERROR_COUNT) ACTION: none"
+else
+    ACTION_TEXT="none"
+    [ ${#ACTIONS[@]} -gt 0 ] && ACTION_TEXT=$(IFS='; '; echo "${ACTIONS[*]}")
+    ANOMALY_TEXT=$(IFS='; '; echo "${ANOMALIES[*]}")
+
+    if [ ${#ANOMALIES[@]} -gt 0 ]; then
+        log "CHECK: live=$IS_LIVE connected=$CONNECTED idle=${IDLE_INT}s errors=$ERROR_COUNT ACTION: $ACTION_TEXT NEEDS-ATTENTION: $ANOMALY_TEXT"
+        notify "NEEDS ATTENTION: ${ANOMALIES[0]}$([ ${#ANOMALIES[@]} -gt 1 ] && echo " (+$((${#ANOMALIES[@]}-1)) more, see $MONITOR_LOG_PATH)")"
+    else
+        log "CHECK: live=$IS_LIVE connected=$CONNECTED idle=${IDLE_INT}s errors=$ERROR_COUNT ACTION: $ACTION_TEXT"
+        notify "Fixed automatically: ${ACTIONS[0]}$([ ${#ACTIONS[@]} -gt 1 ] && echo " (+$((${#ACTIONS[@]}-1)) more, see log)")"
+    fi
+fi

--- a/contrib/rotate-log/README.md
+++ b/contrib/rotate-log/README.md
@@ -1,0 +1,73 @@
+# rotate-log.sh
+
+A small, generic weekly log rotation script for any append-mode log file
+that never rotates on its own — for macOS and Linux.
+
+## Why this exists
+
+If you run Conduit CLI with `-v` (verbose logging), you probably need to —
+error-level messages are gated behind that same flag, not just debug
+noise, so verbose logging is closer to required than optional for
+meaningful diagnostics. But verbose logging on a busy station means the
+log file grows fast: gigabytes within days is normal, not a sign anything
+is wrong. Conduit doesn't rotate its own log, so left alone it grows
+without bound.
+
+## What it does
+
+```
+rotate-log.sh <log_path> <archive_prefix>
+```
+
+Checks whether the newest existing archive for that prefix is at least 7
+days old (or doesn't exist yet). If so: copies the log to
+`<same_dir>/log_archive/<prefix>_<timestamp>.log`, truncates the live file
+in place (not a rename — a rename would break whatever process still has
+the original file open in append mode, requiring a restart; truncating in
+place is transparent to an already-running writer), then **synchronously**
+gzips the copy and verifies the resulting archive with `gzip -t` before
+declaring success. If gzip fails or produces a corrupt archive, the raw
+copy is left in place rather than silently lost.
+
+Meant to be called periodically from your own health-check loop or cron
+job — it manages its own weekly cadence internally, so calling it more
+often than that is a harmless no-op.
+
+## A real bug this script's history is worth knowing about
+
+An earlier version ran gzip in the background (`nohup gzip ... &`) so a
+large one-time archive wouldn't block the caller. In production, this
+failed silently on the largest archives — the background process got cut
+off before finishing (most likely because the calling script was itself a
+short-lived scheduled job, and the process manager reaped the whole job's
+process group once the main script exited, taking the still-running gzip
+with it) — leaving a truncated, corrupt `.gz` file sitting next to an
+un-deleted multi-gigabyte raw copy. This happened twice, silently, over
+several weeks, before being noticed. A real timed test showed synchronous
+gzip only takes 16-17 seconds even on a ~5GB file — nowhere near enough to
+justify the background/detach complexity that caused the silent failure.
+Current version gzips synchronously and verifies the result; if you're
+reviewing or adapting this script, the backgrounded version is a trap
+worth knowing not to reintroduce.
+
+## How this was tested
+
+Both platforms were tested for real, end-to-end, immediately before this
+README was written — not assumed from reading the code:
+
+- **macOS**: ran directly against a real test log file, confirmed the
+  archive was created, gzip-verified as valid, the live file correctly
+  truncated to zero, and a second immediate run correctly no-op'd (archive
+  too fresh to rotate again).
+- **Linux**: same test, run inside a Debian container via
+  [Colima](https://github.com/abiosoft/colima) (a real Linux VM on macOS,
+  not just a container-in-name-only). This actually caught a real bug in
+  the process: the archive-age check used `stat -f%m`, which is BSD/macOS-
+  only syntax — Linux's `stat` needs `-c%Y` for the same value. As
+  originally written, this would have silently misbehaved on Linux. Fixed
+  (branches on `uname` now) and re-verified with the same end-to-end test
+  described above, which passed cleanly afterward.
+
+Nothing else in this script is platform-specific — it's plain file
+operations (`cp`, truncate-in-place, `gzip`) throughout, so once that one
+`stat` call was fixed, both platforms behave identically.

--- a/contrib/rotate-log/rotate-log.sh
+++ b/contrib/rotate-log/rotate-log.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# rotate-log.sh <log_path> <archive_prefix> — generic weekly archive+truncate
+# for any append-mode log file that never rotates on its own. Archives go to a
+# log_archive/ dir alongside the log file, named <prefix>_YYMMDD_HHMM.log.gz.
+# Copy-then-truncate-in-place, not rename: a rename would break the writer's
+# open O_APPEND fd; truncating is transparent to an already-running writer.
+
+LOG="$1"
+PREFIX="$2"
+ROTATE_DAYS=7
+
+if [ -z "$LOG" ] || [ -z "$PREFIX" ]; then
+    echo "Usage: rotate-log.sh <log_path> <archive_prefix>" >&2
+    exit 1
+fi
+
+ARCHIVE_DIR="$(dirname "$LOG")/log_archive"
+mkdir -p "$ARCHIVE_DIR"
+
+latest_archive=$(ls -t "$ARCHIVE_DIR"/${PREFIX}_*.log.gz 2>/dev/null | head -1)
+
+should_rotate=0
+if [ -z "$latest_archive" ]; then
+    should_rotate=1
+else
+    if [ "$(uname)" = "Darwin" ]; then
+        archive_mtime=$(stat -f%m "$latest_archive")
+    else
+        archive_mtime=$(stat -c%Y "$latest_archive")
+    fi
+    age_seconds=$(( $(date +%s) - archive_mtime ))
+    age_days=$(( age_seconds / 86400 ))
+    if [ "$age_days" -ge "$ROTATE_DAYS" ]; then
+        should_rotate=1
+    fi
+fi
+
+if [ "$should_rotate" -eq 0 ]; then
+    exit 0
+fi
+
+if [ ! -f "$LOG" ] || [ ! -s "$LOG" ]; then
+    exit 0
+fi
+
+ts=$(date +%y%m%d_%H%M)
+archive_path="$ARCHIVE_DIR/${PREFIX}_${ts}.log"
+
+cp "$LOG" "$archive_path"
+: > "$LOG"
+
+# gzip synchronously and verify with `gzip -t` before declaring success. An
+# earlier backgrounded (`nohup ... &`) version was silently reaped mid-run when
+# the caller exited, leaving truncated .gz files next to un-deleted raw copies.
+if gzip "$archive_path" && gzip -t "${archive_path}.gz"; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') Rotated $(basename "$LOG") -> ${archive_path}.gz (verified)"
+else
+    echo "$(date '+%Y-%m-%d %H:%M:%S') WARNING: gzip of $archive_path failed or produced a corrupt archive — raw copy left in place at $archive_path for manual recovery, not deleted"
+fi


### PR DESCRIPTION
Two optional, standalone operational scripts for a Conduit CLI station, living under `contrib/` (opt-in — nothing in the default install references or runs them). Both are configured entirely via environment variables, with no hardcoded paths or machine-specific logic.

## What they do

- **`contrib/conduit-monitor/`** — a periodic health-check-and-repair script (macOS + Linux) meant to run every 15-30 min from a scheduled job (LaunchAgent / systemd timer / cron). It restarts Conduit when it has stopped or gotten stuck (idle too long, or connected=0 with recent errors), with a cooldown to avoid restart loops, and logs/notifies anything it can't safely fix rather than guessing. Detection logic is identical across platforms; only the start/stop/restart commands branch on `uname`.
- **`contrib/rotate-log/`** — a generic weekly archive+truncate for Conduit's own log file, which doesn't rotate on its own and can grow to multiple GB under verbose (`-v`) logging. Copy-then-truncate-in-place (not rename, so an already-open writer keeps working), then gzips and verifies the archive.

## Provenance

Salvaged from #314 (original author @jSFBay). Only these two scripts + their READMEs are included here — no dashboard changes and no exporters. The verbose multi-paragraph header comments were trimmed to concise purpose lines; script behaviour is unchanged.

## Checks

- `bash -n` clean on both scripts.
- `shellcheck --severity=error` clean on both (the same gate CI runs).