### PR TITLE
monitoring: Conduit ops scripts + dashboard panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ MoaV/
 ├── data/                # protocols.json — the protocol roster, source of truth
 ├── tests/               # the regression suite, named after the bug class each pins
 ├── docs/devdocs/        # contributor docs (the user docs live in moav-site)
+├── contrib/             # optional operator-contributed tools (opt-in, not core) — see contrib/README.md
 ├── docker-compose.yml
 └── .env.example         # annotated config reference; commonly-changed vars up top
 ```

--- a/configs/monitoring/grafana/provisioning/dashboards/conduit.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/conduit.json
@@ -1,13 +1,47 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "filter": {
+          "exclude": false,
+          "ids": [
+            7
+          ]
+        },
+        "hide": false,
+        "iconColor": "orange",
+        "name": "Mark Peak on Client Connections Graph",
+        "target": {
+          "expr": "conduit_connected_clients == max_over_time(conduit_connected_clients[$__range:$__interval] @ end())",
+          "interval": "15s",
+          "refId": "Anno"
+        },
+        "textFormat": "{{value}} connected clients",
+        "titleFormat": "Window Max"
+      }
+    ]
   },
-  "editable": false,
+  "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "datasource": {
@@ -24,74 +58,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
-                "color": "orange",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(conduit_connected_clients)",
-          "refId": "A"
-        }
-      ],
-      "title": "Connected",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
                 "color": "blue",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -99,17 +67,18 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 3,
+        "h": 3,
+        "w": 4,
+        "x": 0,
         "y": 0
       },
       "id": 2,
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -117,9 +86,14 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -148,26 +122,67 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "orange",
-                "value": null
+                "color": "purple",
+                "value": 0
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "-m"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "BW"
+              },
+              {
+                "id": "unit",
+                "value": "bps"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
-        "x": 6,
+        "x": 4,
         "y": 0
       },
-      "id": 10,
+      "id": 11,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -175,21 +190,33 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "text": {
+          "titleSize": 11,
+          "valueSize": 18
+        },
+        "textMode": "auto",
+        "wideLayout": false
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max_over_time(conduit_connected_clients[$__range])) + sum(max_over_time(conduit_connecting_clients[$__range]))",
+          "expr": "conduit_max_common_clients",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_bandwidth_limit_bytes_per_second * 8",
+          "refId": "B"
         }
       ],
-      "title": "Peak Clients",
-      "description": "Maximum concurrent clients (connected + connecting) in the selected time range",
       "type": "stat"
     },
     {
@@ -208,26 +235,27 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decbytes"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
-        "x": 9,
+        "x": 7,
         "y": 0
       },
       "id": 3,
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -235,9 +263,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -248,7 +278,140 @@
           "refId": "A"
         }
       ],
-      "title": "Total Download",
+      "title": "D/L",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 10,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_downloaded[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "D/L Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 14,
+        "y": 0
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_downloaded_lifetime)",
+          "legendFormat": "Lifetime D/L",
+          "refId": "A"
+        }
+      ],
+      "title": "Lifetime D/L",
       "type": "stat"
     },
     {
@@ -266,27 +429,61 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
-                "value": null
+                "color": "orange",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Max ${client_state_total:text}"
+              },
+              {
+                "id": "unit",
+                "value": "none"
               }
             ]
           },
-          "unit": "bytes"
-        },
-        "overrides": []
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Time"
+              },
+              {
+                "id": "unit",
+                "value": "time:YYYY-MM-DD HH:mm:ss"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 12,
+        "h": 3,
+        "w": 4,
+        "x": 17,
         "y": 0
       },
-      "id": 4,
+      "id": 28,
+      "maxDataPoints": 3000,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -294,20 +491,36 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "text": {
+          "titleSize": 11,
+          "valueSize": 14
+        },
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(conduit_bytes_uploaded)",
+          "expr": "$client_state_total == on() max_over_time($client_state_total[$__range:$__interval] @ end())",
+          "interval": "15s",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "timestamp($client_state_total == on() max_over_time($client_state_total[$__range:$__interval] @ end())) * 1000",
+          "interval": "15s",
+          "refId": "B"
         }
       ],
-      "title": "Total Upload",
+      "title": "Window Max - ${client_state_total:text}",
       "type": "stat"
     },
     {
@@ -340,7 +553,7 @@
             "steps": [
               {
                 "color": "red",
-                "value": null
+                "value": 0
               },
               {
                 "color": "green",
@@ -352,9 +565,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
-        "x": 15,
+        "x": 21,
         "y": 0
       },
       "id": 5,
@@ -363,6 +576,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -370,9 +584,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -402,26 +618,34 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "orange",
+                "value": 100
               }
             ]
-          },
-          "unit": "binBps"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 18,
-        "y": 0
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 3
       },
-      "id": 6,
+      "id": 1,
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -429,20 +653,88 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(conduit_bytes_downloaded[5m])) + sum(rate(conduit_bytes_uploaded[5m]))",
+          "expr": "sum(conduit_connected_clients)",
           "refId": "A"
         }
       ],
-      "title": "Current Rate",
+      "title": "Connected",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 4,
+        "y": 3
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_announcing",
+          "refId": "A"
+        }
+      ],
+      "title": "Announcing",
       "type": "stat"
     },
     {
@@ -460,26 +752,28 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "purple",
-                "value": null
+                "color": "blue",
+                "value": 0
               }
             ]
-          }
+          },
+          "unit": "decbytes"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
-        "x": 21,
-        "y": 0
+        "x": 7,
+        "y": 3
       },
-      "id": 11,
+      "id": 4,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
+        "colorMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -487,20 +781,298 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "conduit_max_common_clients",
+          "expr": "sum(conduit_bytes_uploaded)",
           "refId": "A"
         }
       ],
-      "title": "Max Clients",
+      "title": "U/L",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 10,
+        "y": 3
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_uploaded[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "U/L Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 14,
+        "y": 3
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 36
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_bytes_uploaded_lifetime)",
+          "legendFormat": "Lifetime U/L",
+          "refId": "A"
+        }
+      ],
+      "title": "Lifetime U/L",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Session High ${client_state_total:text}"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 17,
+        "y": 3
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "titleSize": 11,
+          "valueSize": 28
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max_over_time($client_state_total[24h])",
+          "refId": "A"
+        }
+      ],
+      "title": "Session High - ${client_state_total:text}",
+      "type": "stat",
+      "description": "Peak of the selected client-state gauge over the last 24h, computed with max_over_time (no external exporter)."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 21,
+        "y": 3
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "conduit_uptime_seconds",
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
       "type": "stat"
     },
     {
@@ -514,11 +1086,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 20,
             "gradientMode": "opacity",
@@ -527,6 +1101,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -534,6 +1109,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -549,20 +1125,91 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connecting"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF0000",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Announcing"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#32CD32",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Connected"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 11,
+        "w": 24,
         "x": 0,
-        "y": 8
+        "y": 6
       },
       "id": 7,
+      "maxDataPoints": 3000,
       "options": {
         "legend": {
           "calcs": [
@@ -575,11 +1222,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -598,6 +1246,15 @@
           "expr": "sum(conduit_connecting_clients)",
           "legendFormat": "Connecting",
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(conduit_announcing)",
+          "legendFormat": "Announcing",
+          "refId": "C"
         }
       ],
       "title": "Client Connections",
@@ -611,22 +1268,25 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "palette-classic-by-name"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 20,
+            "fillOpacity": 15,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -634,6 +1294,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -649,21 +1310,77 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IR"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9e3809",
+                  "mode": "fixed"
+                }
               }
             ]
           },
-          "unit": "binBps"
-        },
-        "overrides": []
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MM"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "DE",
+                  "IR",
+                  "AZ"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 17
       },
-      "id": 8,
+      "id": 27,
       "options": {
         "legend": {
           "calcs": [
@@ -673,35 +1390,29 @@
           ],
           "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(conduit_bytes_downloaded[5m]))",
-          "legendFormat": "Download",
+          "expr": "$client_state and on (region) topk(5, avg_over_time($client_state[$__range] @ end()))",
+          "legendFormat": "{{region}}",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(conduit_bytes_uploaded[5m]))",
-          "legendFormat": "Upload",
-          "refId": "B"
         }
       ],
-      "title": "Bandwidth Rate",
+      "title": "Top 5 Regions by ${client_state:text}",
       "type": "timeseries"
     },
     {
@@ -715,11 +1426,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 30,
             "gradientMode": "opacity",
@@ -728,6 +1441,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -735,6 +1449,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -750,19 +1465,50 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decbytes"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF0000",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 24,
+        "h": 9,
+        "w": 12,
         "x": 0,
-        "y": 16
+        "y": 56
       },
       "id": 9,
       "options": {
@@ -775,11 +1521,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -811,14 +1558,16 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic-by-name"
+            "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 20,
             "gradientMode": "opacity",
@@ -827,6 +1576,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -834,6 +1584,1328 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF0000",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 56
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_downloaded[5m]))",
+          "legendFormat": "Download",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(conduit_bytes_uploaded[5m]))",
+          "legendFormat": "Upload",
+          "refId": "B"
+        }
+      ],
+      "title": "Bandwidth Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current connected clients and cumulative traffic per region",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "AD": {
+                  "index": 0,
+                  "text": "AD: Andorra"
+                },
+                "AE": {
+                  "index": 1,
+                  "text": "AE: United Arab Emirates"
+                },
+                "AF": {
+                  "index": 2,
+                  "text": "AF: Afghanistan"
+                },
+                "AG": {
+                  "index": 3,
+                  "text": "AG: Antigua and Barbuda"
+                },
+                "AI": {
+                  "index": 4,
+                  "text": "AI: Anguilla"
+                },
+                "AL": {
+                  "index": 5,
+                  "text": "AL: Albania"
+                },
+                "AM": {
+                  "index": 6,
+                  "text": "AM: Armenia"
+                },
+                "AO": {
+                  "index": 7,
+                  "text": "AO: Angola"
+                },
+                "AQ": {
+                  "index": 8,
+                  "text": "AQ: Antarctica"
+                },
+                "AR": {
+                  "index": 9,
+                  "text": "AR: Argentina"
+                },
+                "AS": {
+                  "index": 10,
+                  "text": "AS: American Samoa"
+                },
+                "AT": {
+                  "index": 11,
+                  "text": "AT: Austria"
+                },
+                "AU": {
+                  "index": 12,
+                  "text": "AU: Australia"
+                },
+                "AW": {
+                  "index": 13,
+                  "text": "AW: Aruba"
+                },
+                "AX": {
+                  "index": 14,
+                  "text": "AX: Åland Islands"
+                },
+                "AZ": {
+                  "index": 15,
+                  "text": "AZ: Azerbaijan"
+                },
+                "BA": {
+                  "index": 16,
+                  "text": "BA: Bosnia and Herzegovina"
+                },
+                "BB": {
+                  "index": 17,
+                  "text": "BB: Barbados"
+                },
+                "BD": {
+                  "index": 18,
+                  "text": "BD: Bangladesh"
+                },
+                "BE": {
+                  "index": 19,
+                  "text": "BE: Belgium"
+                },
+                "BF": {
+                  "index": 20,
+                  "text": "BF: Burkina Faso"
+                },
+                "BG": {
+                  "index": 21,
+                  "text": "BG: Bulgaria"
+                },
+                "BH": {
+                  "index": 22,
+                  "text": "BH: Bahrain"
+                },
+                "BI": {
+                  "index": 23,
+                  "text": "BI: Burundi"
+                },
+                "BJ": {
+                  "index": 24,
+                  "text": "BJ: Benin"
+                },
+                "BL": {
+                  "index": 25,
+                  "text": "BL: Saint Barthélemy"
+                },
+                "BM": {
+                  "index": 26,
+                  "text": "BM: Bermuda"
+                },
+                "BN": {
+                  "index": 27,
+                  "text": "BN: Brunei Darussalam"
+                },
+                "BO": {
+                  "index": 28,
+                  "text": "BO: Bolivia, Plurinational State of"
+                },
+                "BQ": {
+                  "index": 29,
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba"
+                },
+                "BR": {
+                  "index": 30,
+                  "text": "BR: Brazil"
+                },
+                "BS": {
+                  "index": 31,
+                  "text": "BS: Bahamas"
+                },
+                "BT": {
+                  "index": 32,
+                  "text": "BT: Bhutan"
+                },
+                "BV": {
+                  "index": 33,
+                  "text": "BV: Bouvet Island"
+                },
+                "BW": {
+                  "index": 34,
+                  "text": "BW: Botswana"
+                },
+                "BY": {
+                  "index": 35,
+                  "text": "BY: Belarus"
+                },
+                "BZ": {
+                  "index": 36,
+                  "text": "BZ: Belize"
+                },
+                "CA": {
+                  "index": 37,
+                  "text": "CA: Canada"
+                },
+                "CC": {
+                  "index": 38,
+                  "text": "CC: Cocos (Keeling) Islands"
+                },
+                "CD": {
+                  "index": 39,
+                  "text": "CD: Congo, The Democratic Republic of the"
+                },
+                "CF": {
+                  "index": 40,
+                  "text": "CF: Central African Republic"
+                },
+                "CG": {
+                  "index": 41,
+                  "text": "CG: Congo"
+                },
+                "CH": {
+                  "index": 42,
+                  "text": "CH: Switzerland"
+                },
+                "CI": {
+                  "index": 43,
+                  "text": "CI: Côte d'Ivoire"
+                },
+                "CK": {
+                  "index": 44,
+                  "text": "CK: Cook Islands"
+                },
+                "CL": {
+                  "index": 45,
+                  "text": "CL: Chile"
+                },
+                "CM": {
+                  "index": 46,
+                  "text": "CM: Cameroon"
+                },
+                "CN": {
+                  "index": 47,
+                  "text": "CN: China"
+                },
+                "CO": {
+                  "index": 48,
+                  "text": "CO: Colombia"
+                },
+                "CR": {
+                  "index": 49,
+                  "text": "CR: Costa Rica"
+                },
+                "CU": {
+                  "index": 50,
+                  "text": "CU: Cuba"
+                },
+                "CV": {
+                  "index": 51,
+                  "text": "CV: Cabo Verde"
+                },
+                "CW": {
+                  "index": 52,
+                  "text": "CW: Curaçao"
+                },
+                "CX": {
+                  "index": 53,
+                  "text": "CX: Christmas Island"
+                },
+                "CY": {
+                  "index": 54,
+                  "text": "CY: Cyprus"
+                },
+                "CZ": {
+                  "index": 55,
+                  "text": "CZ: Czechia"
+                },
+                "DE": {
+                  "index": 56,
+                  "text": "DE: Germany"
+                },
+                "DJ": {
+                  "index": 57,
+                  "text": "DJ: Djibouti"
+                },
+                "DK": {
+                  "index": 58,
+                  "text": "DK: Denmark"
+                },
+                "DM": {
+                  "index": 59,
+                  "text": "DM: Dominica"
+                },
+                "DO": {
+                  "index": 60,
+                  "text": "DO: Dominican Republic"
+                },
+                "DZ": {
+                  "index": 61,
+                  "text": "DZ: Algeria"
+                },
+                "EC": {
+                  "index": 62,
+                  "text": "EC: Ecuador"
+                },
+                "EE": {
+                  "index": 63,
+                  "text": "EE: Estonia"
+                },
+                "EG": {
+                  "index": 64,
+                  "text": "EG: Egypt"
+                },
+                "EH": {
+                  "index": 65,
+                  "text": "EH: Western Sahara"
+                },
+                "ER": {
+                  "index": 66,
+                  "text": "ER: Eritrea"
+                },
+                "ES": {
+                  "index": 67,
+                  "text": "ES: Spain"
+                },
+                "ET": {
+                  "index": 68,
+                  "text": "ET: Ethiopia"
+                },
+                "FI": {
+                  "index": 69,
+                  "text": "FI: Finland"
+                },
+                "FJ": {
+                  "index": 70,
+                  "text": "FJ: Fiji"
+                },
+                "FK": {
+                  "index": 71,
+                  "text": "FK: Falkland Islands (Malvinas)"
+                },
+                "FM": {
+                  "index": 72,
+                  "text": "FM: Micronesia, Federated States of"
+                },
+                "FO": {
+                  "index": 73,
+                  "text": "FO: Faroe Islands"
+                },
+                "FR": {
+                  "index": 74,
+                  "text": "FR: France"
+                },
+                "GA": {
+                  "index": 75,
+                  "text": "GA: Gabon"
+                },
+                "GB": {
+                  "index": 76,
+                  "text": "GB: United Kingdom"
+                },
+                "GD": {
+                  "index": 77,
+                  "text": "GD: Grenada"
+                },
+                "GE": {
+                  "index": 78,
+                  "text": "GE: Georgia"
+                },
+                "GF": {
+                  "index": 79,
+                  "text": "GF: French Guiana"
+                },
+                "GG": {
+                  "index": 80,
+                  "text": "GG: Guernsey"
+                },
+                "GH": {
+                  "index": 81,
+                  "text": "GH: Ghana"
+                },
+                "GI": {
+                  "index": 82,
+                  "text": "GI: Gibraltar"
+                },
+                "GL": {
+                  "index": 83,
+                  "text": "GL: Greenland"
+                },
+                "GM": {
+                  "index": 84,
+                  "text": "GM: Gambia"
+                },
+                "GN": {
+                  "index": 85,
+                  "text": "GN: Guinea"
+                },
+                "GP": {
+                  "index": 86,
+                  "text": "GP: Guadeloupe"
+                },
+                "GQ": {
+                  "index": 87,
+                  "text": "GQ: Equatorial Guinea"
+                },
+                "GR": {
+                  "index": 88,
+                  "text": "GR: Greece"
+                },
+                "GS": {
+                  "index": 89,
+                  "text": "GS: South Georgia and the South Sandwich Islands"
+                },
+                "GT": {
+                  "index": 90,
+                  "text": "GT: Guatemala"
+                },
+                "GU": {
+                  "index": 91,
+                  "text": "GU: Guam"
+                },
+                "GW": {
+                  "index": 92,
+                  "text": "GW: Guinea-Bissau"
+                },
+                "GY": {
+                  "index": 93,
+                  "text": "GY: Guyana"
+                },
+                "HK": {
+                  "index": 94,
+                  "text": "HK: Hong Kong"
+                },
+                "HM": {
+                  "index": 95,
+                  "text": "HM: Heard Island and McDonald Islands"
+                },
+                "HN": {
+                  "index": 96,
+                  "text": "HN: Honduras"
+                },
+                "HR": {
+                  "index": 97,
+                  "text": "HR: Croatia"
+                },
+                "HT": {
+                  "index": 98,
+                  "text": "HT: Haiti"
+                },
+                "HU": {
+                  "index": 99,
+                  "text": "HU: Hungary"
+                },
+                "ID": {
+                  "index": 100,
+                  "text": "ID: Indonesia"
+                },
+                "IE": {
+                  "index": 101,
+                  "text": "IE: Ireland"
+                },
+                "IL": {
+                  "index": 102,
+                  "text": "IL: Israel"
+                },
+                "IM": {
+                  "index": 103,
+                  "text": "IM: Isle of Man"
+                },
+                "IN": {
+                  "index": 104,
+                  "text": "IN: India"
+                },
+                "IO": {
+                  "index": 105,
+                  "text": "IO: British Indian Ocean Territory"
+                },
+                "IQ": {
+                  "index": 106,
+                  "text": "IQ: Iraq"
+                },
+                "IR": {
+                  "index": 107,
+                  "text": "IR: Iran, Islamic Republic of"
+                },
+                "IS": {
+                  "index": 108,
+                  "text": "IS: Iceland"
+                },
+                "IT": {
+                  "index": 109,
+                  "text": "IT: Italy"
+                },
+                "JE": {
+                  "index": 110,
+                  "text": "JE: Jersey"
+                },
+                "JM": {
+                  "index": 111,
+                  "text": "JM: Jamaica"
+                },
+                "JO": {
+                  "index": 112,
+                  "text": "JO: Jordan"
+                },
+                "JP": {
+                  "index": 113,
+                  "text": "JP: Japan"
+                },
+                "KE": {
+                  "index": 114,
+                  "text": "KE: Kenya"
+                },
+                "KG": {
+                  "index": 115,
+                  "text": "KG: Kyrgyzstan"
+                },
+                "KH": {
+                  "index": 116,
+                  "text": "KH: Cambodia"
+                },
+                "KI": {
+                  "index": 117,
+                  "text": "KI: Kiribati"
+                },
+                "KM": {
+                  "index": 118,
+                  "text": "KM: Comoros"
+                },
+                "KN": {
+                  "index": 119,
+                  "text": "KN: Saint Kitts and Nevis"
+                },
+                "KP": {
+                  "index": 120,
+                  "text": "KP: Korea, Democratic People's Republic of"
+                },
+                "KR": {
+                  "index": 121,
+                  "text": "KR: Korea, Republic of"
+                },
+                "KW": {
+                  "index": 122,
+                  "text": "KW: Kuwait"
+                },
+                "KY": {
+                  "index": 123,
+                  "text": "KY: Cayman Islands"
+                },
+                "KZ": {
+                  "index": 124,
+                  "text": "KZ: Kazakhstan"
+                },
+                "LA": {
+                  "index": 125,
+                  "text": "LA: Lao People's Democratic Republic"
+                },
+                "LB": {
+                  "index": 126,
+                  "text": "LB: Lebanon"
+                },
+                "LC": {
+                  "index": 127,
+                  "text": "LC: Saint Lucia"
+                },
+                "LI": {
+                  "index": 128,
+                  "text": "LI: Liechtenstein"
+                },
+                "LK": {
+                  "index": 129,
+                  "text": "LK: Sri Lanka"
+                },
+                "LR": {
+                  "index": 130,
+                  "text": "LR: Liberia"
+                },
+                "LS": {
+                  "index": 131,
+                  "text": "LS: Lesotho"
+                },
+                "LT": {
+                  "index": 132,
+                  "text": "LT: Lithuania"
+                },
+                "LU": {
+                  "index": 133,
+                  "text": "LU: Luxembourg"
+                },
+                "LV": {
+                  "index": 134,
+                  "text": "LV: Latvia"
+                },
+                "LY": {
+                  "index": 135,
+                  "text": "LY: Libya"
+                },
+                "MA": {
+                  "index": 136,
+                  "text": "MA: Morocco"
+                },
+                "MC": {
+                  "index": 137,
+                  "text": "MC: Monaco"
+                },
+                "MD": {
+                  "index": 138,
+                  "text": "MD: Moldova, Republic of"
+                },
+                "ME": {
+                  "index": 139,
+                  "text": "ME: Montenegro"
+                },
+                "MF": {
+                  "index": 140,
+                  "text": "MF: Saint Martin (French part)"
+                },
+                "MG": {
+                  "index": 141,
+                  "text": "MG: Madagascar"
+                },
+                "MH": {
+                  "index": 142,
+                  "text": "MH: Marshall Islands"
+                },
+                "MK": {
+                  "index": 143,
+                  "text": "MK: North Macedonia"
+                },
+                "ML": {
+                  "index": 144,
+                  "text": "ML: Mali"
+                },
+                "MM": {
+                  "index": 145,
+                  "text": "MM: Myanmar"
+                },
+                "MN": {
+                  "index": 146,
+                  "text": "MN: Mongolia"
+                },
+                "MO": {
+                  "index": 147,
+                  "text": "MO: Macao"
+                },
+                "MP": {
+                  "index": 148,
+                  "text": "MP: Northern Mariana Islands"
+                },
+                "MQ": {
+                  "index": 149,
+                  "text": "MQ: Martinique"
+                },
+                "MR": {
+                  "index": 150,
+                  "text": "MR: Mauritania"
+                },
+                "MS": {
+                  "index": 151,
+                  "text": "MS: Montserrat"
+                },
+                "MT": {
+                  "index": 152,
+                  "text": "MT: Malta"
+                },
+                "MU": {
+                  "index": 153,
+                  "text": "MU: Mauritius"
+                },
+                "MV": {
+                  "index": 154,
+                  "text": "MV: Maldives"
+                },
+                "MW": {
+                  "index": 155,
+                  "text": "MW: Malawi"
+                },
+                "MX": {
+                  "index": 156,
+                  "text": "MX: Mexico"
+                },
+                "MY": {
+                  "index": 157,
+                  "text": "MY: Malaysia"
+                },
+                "MZ": {
+                  "index": 158,
+                  "text": "MZ: Mozambique"
+                },
+                "NA": {
+                  "index": 159,
+                  "text": "NA: Namibia"
+                },
+                "NC": {
+                  "index": 160,
+                  "text": "NC: New Caledonia"
+                },
+                "NE": {
+                  "index": 161,
+                  "text": "NE: Niger"
+                },
+                "NF": {
+                  "index": 162,
+                  "text": "NF: Norfolk Island"
+                },
+                "NG": {
+                  "index": 163,
+                  "text": "NG: Nigeria"
+                },
+                "NI": {
+                  "index": 164,
+                  "text": "NI: Nicaragua"
+                },
+                "NL": {
+                  "index": 165,
+                  "text": "NL: Netherlands"
+                },
+                "NO": {
+                  "index": 166,
+                  "text": "NO: Norway"
+                },
+                "NP": {
+                  "index": 167,
+                  "text": "NP: Nepal"
+                },
+                "NR": {
+                  "index": 168,
+                  "text": "NR: Nauru"
+                },
+                "NU": {
+                  "index": 169,
+                  "text": "NU: Niue"
+                },
+                "NZ": {
+                  "index": 170,
+                  "text": "NZ: New Zealand"
+                },
+                "OM": {
+                  "index": 171,
+                  "text": "OM: Oman"
+                },
+                "PA": {
+                  "index": 172,
+                  "text": "PA: Panama"
+                },
+                "PE": {
+                  "index": 173,
+                  "text": "PE: Peru"
+                },
+                "PF": {
+                  "index": 174,
+                  "text": "PF: French Polynesia"
+                },
+                "PG": {
+                  "index": 175,
+                  "text": "PG: Papua New Guinea"
+                },
+                "PH": {
+                  "index": 176,
+                  "text": "PH: Philippines"
+                },
+                "PK": {
+                  "index": 177,
+                  "text": "PK: Pakistan"
+                },
+                "PL": {
+                  "index": 178,
+                  "text": "PL: Poland"
+                },
+                "PM": {
+                  "index": 179,
+                  "text": "PM: Saint Pierre and Miquelon"
+                },
+                "PN": {
+                  "index": 180,
+                  "text": "PN: Pitcairn"
+                },
+                "PR": {
+                  "index": 181,
+                  "text": "PR: Puerto Rico"
+                },
+                "PS": {
+                  "index": 182,
+                  "text": "PS: Palestine, State of"
+                },
+                "PT": {
+                  "index": 183,
+                  "text": "PT: Portugal"
+                },
+                "PW": {
+                  "index": 184,
+                  "text": "PW: Palau"
+                },
+                "PY": {
+                  "index": 185,
+                  "text": "PY: Paraguay"
+                },
+                "QA": {
+                  "index": 186,
+                  "text": "QA: Qatar"
+                },
+                "RE": {
+                  "index": 187,
+                  "text": "RE: Réunion"
+                },
+                "RO": {
+                  "index": 188,
+                  "text": "RO: Romania"
+                },
+                "RS": {
+                  "index": 189,
+                  "text": "RS: Serbia"
+                },
+                "RU": {
+                  "index": 190,
+                  "text": "RU: Russian Federation"
+                },
+                "RW": {
+                  "index": 191,
+                  "text": "RW: Rwanda"
+                },
+                "SA": {
+                  "index": 192,
+                  "text": "SA: Saudi Arabia"
+                },
+                "SB": {
+                  "index": 193,
+                  "text": "SB: Solomon Islands"
+                },
+                "SC": {
+                  "index": 194,
+                  "text": "SC: Seychelles"
+                },
+                "SD": {
+                  "index": 195,
+                  "text": "SD: Sudan"
+                },
+                "SE": {
+                  "index": 196,
+                  "text": "SE: Sweden"
+                },
+                "SG": {
+                  "index": 197,
+                  "text": "SG: Singapore"
+                },
+                "SH": {
+                  "index": 198,
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha"
+                },
+                "SI": {
+                  "index": 199,
+                  "text": "SI: Slovenia"
+                },
+                "SJ": {
+                  "index": 200,
+                  "text": "SJ: Svalbard and Jan Mayen"
+                },
+                "SK": {
+                  "index": 201,
+                  "text": "SK: Slovakia"
+                },
+                "SL": {
+                  "index": 202,
+                  "text": "SL: Sierra Leone"
+                },
+                "SM": {
+                  "index": 203,
+                  "text": "SM: San Marino"
+                },
+                "SN": {
+                  "index": 204,
+                  "text": "SN: Senegal"
+                },
+                "SO": {
+                  "index": 205,
+                  "text": "SO: Somalia"
+                },
+                "SR": {
+                  "index": 206,
+                  "text": "SR: Suriname"
+                },
+                "SS": {
+                  "index": 207,
+                  "text": "SS: South Sudan"
+                },
+                "ST": {
+                  "index": 208,
+                  "text": "ST: Sao Tome and Principe"
+                },
+                "SV": {
+                  "index": 209,
+                  "text": "SV: El Salvador"
+                },
+                "SX": {
+                  "index": 210,
+                  "text": "SX: Sint Maarten (Dutch part)"
+                },
+                "SY": {
+                  "index": 211,
+                  "text": "SY: Syrian Arab Republic"
+                },
+                "SZ": {
+                  "index": 212,
+                  "text": "SZ: Eswatini"
+                },
+                "TC": {
+                  "index": 213,
+                  "text": "TC: Turks and Caicos Islands"
+                },
+                "TD": {
+                  "index": 214,
+                  "text": "TD: Chad"
+                },
+                "TF": {
+                  "index": 215,
+                  "text": "TF: French Southern Territories"
+                },
+                "TG": {
+                  "index": 216,
+                  "text": "TG: Togo"
+                },
+                "TH": {
+                  "index": 217,
+                  "text": "TH: Thailand"
+                },
+                "TJ": {
+                  "index": 218,
+                  "text": "TJ: Tajikistan"
+                },
+                "TK": {
+                  "index": 219,
+                  "text": "TK: Tokelau"
+                },
+                "TL": {
+                  "index": 220,
+                  "text": "TL: Timor-Leste"
+                },
+                "TM": {
+                  "index": 221,
+                  "text": "TM: Turkmenistan"
+                },
+                "TN": {
+                  "index": 222,
+                  "text": "TN: Tunisia"
+                },
+                "TO": {
+                  "index": 223,
+                  "text": "TO: Tonga"
+                },
+                "TR": {
+                  "index": 224,
+                  "text": "TR: Türkiye"
+                },
+                "TT": {
+                  "index": 225,
+                  "text": "TT: Trinidad and Tobago"
+                },
+                "TV": {
+                  "index": 226,
+                  "text": "TV: Tuvalu"
+                },
+                "TW": {
+                  "index": 227,
+                  "text": "TW: Taiwan, Province of China"
+                },
+                "TZ": {
+                  "index": 228,
+                  "text": "TZ: Tanzania, United Republic of"
+                },
+                "UA": {
+                  "index": 229,
+                  "text": "UA: Ukraine"
+                },
+                "UG": {
+                  "index": 230,
+                  "text": "UG: Uganda"
+                },
+                "UM": {
+                  "index": 231,
+                  "text": "UM: United States Minor Outlying Islands"
+                },
+                "US": {
+                  "index": 232,
+                  "text": "US: United States"
+                },
+                "UY": {
+                  "index": 233,
+                  "text": "UY: Uruguay"
+                },
+                "UZ": {
+                  "index": 234,
+                  "text": "UZ: Uzbekistan"
+                },
+                "VA": {
+                  "index": 235,
+                  "text": "VA: Holy See (Vatican City State)"
+                },
+                "VC": {
+                  "index": 236,
+                  "text": "VC: Saint Vincent and the Grenadines"
+                },
+                "VE": {
+                  "index": 237,
+                  "text": "VE: Venezuela, Bolivarian Republic of"
+                },
+                "VG": {
+                  "index": 238,
+                  "text": "VG: Virgin Islands, British"
+                },
+                "VI": {
+                  "index": 239,
+                  "text": "VI: Virgin Islands, U.S."
+                },
+                "VN": {
+                  "index": 240,
+                  "text": "VN: Viet Nam"
+                },
+                "VU": {
+                  "index": 241,
+                  "text": "VU: Vanuatu"
+                },
+                "WF": {
+                  "index": 242,
+                  "text": "WF: Wallis and Futuna"
+                },
+                "WS": {
+                  "index": 243,
+                  "text": "WS: Samoa"
+                },
+                "YE": {
+                  "index": 244,
+                  "text": "YE: Yemen"
+                },
+                "YT": {
+                  "index": 245,
+                  "text": "YT: Mayotte"
+                },
+                "ZA": {
+                  "index": 246,
+                  "text": "ZA: South Africa"
+                },
+                "ZM": {
+                  "index": 247,
+                  "text": "ZM: Zambia"
+                },
+                "ZW": {
+                  "index": 248,
+                  "text": "ZW: Zimbabwe"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Region"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 223
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "include",
+                "names": [
+                  "Connected",
+                  "Download",
+                  "Upload"
+                ]
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.footer.reducers",
+                "value": [
+                  "sum"
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Connected"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 117
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 62,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "id": 13,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Connected"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "format": "table",
+          "instant": true,
+          "refId": "Connected"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (increase(conduit_region_bytes_downloaded[1h]))",
+          "format": "table",
+          "instant": true,
+          "refId": "Download"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (region) (increase(conduit_region_bytes_uploaded[1h]))",
+          "format": "table",
+          "instant": true,
+          "refId": "Upload"
+        }
+      ],
+      "title": "Traffic by Region",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "region"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
+            "renameByName": {
+              "Value #Connected": "Connected",
+              "Value #Download": "Download",
+              "Value #Upload": "Upload",
+              "region": "Region"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -845,1005 +2917,1005 @@
           },
           "mappings": [
             {
-              "type": "value",
               "options": {
                 "AD": {
-                  "text": "AD: Andorra",
-                  "index": 0
+                  "index": 0,
+                  "text": "AD: Andorra"
                 },
                 "AE": {
-                  "text": "AE: United Arab Emirates",
-                  "index": 1
+                  "index": 1,
+                  "text": "AE: United Arab Emirates"
                 },
                 "AF": {
-                  "text": "AF: Afghanistan",
-                  "index": 2
+                  "index": 2,
+                  "text": "AF: Afghanistan"
                 },
                 "AG": {
-                  "text": "AG: Antigua and Barbuda",
-                  "index": 3
+                  "index": 3,
+                  "text": "AG: Antigua and Barbuda"
                 },
                 "AI": {
-                  "text": "AI: Anguilla",
-                  "index": 4
+                  "index": 4,
+                  "text": "AI: Anguilla"
                 },
                 "AL": {
-                  "text": "AL: Albania",
-                  "index": 5
+                  "index": 5,
+                  "text": "AL: Albania"
                 },
                 "AM": {
-                  "text": "AM: Armenia",
-                  "index": 6
+                  "index": 6,
+                  "text": "AM: Armenia"
                 },
                 "AO": {
-                  "text": "AO: Angola",
-                  "index": 7
+                  "index": 7,
+                  "text": "AO: Angola"
                 },
                 "AQ": {
-                  "text": "AQ: Antarctica",
-                  "index": 8
+                  "index": 8,
+                  "text": "AQ: Antarctica"
                 },
                 "AR": {
-                  "text": "AR: Argentina",
-                  "index": 9
+                  "index": 9,
+                  "text": "AR: Argentina"
                 },
                 "AS": {
-                  "text": "AS: American Samoa",
-                  "index": 10
+                  "index": 10,
+                  "text": "AS: American Samoa"
                 },
                 "AT": {
-                  "text": "AT: Austria",
-                  "index": 11
+                  "index": 11,
+                  "text": "AT: Austria"
                 },
                 "AU": {
-                  "text": "AU: Australia",
-                  "index": 12
+                  "index": 12,
+                  "text": "AU: Australia"
                 },
                 "AW": {
-                  "text": "AW: Aruba",
-                  "index": 13
+                  "index": 13,
+                  "text": "AW: Aruba"
                 },
                 "AX": {
-                  "text": "AX: \u00c5land Islands",
-                  "index": 14
+                  "index": 14,
+                  "text": "AX: Åland Islands"
                 },
                 "AZ": {
-                  "text": "AZ: Azerbaijan",
-                  "index": 15
+                  "index": 15,
+                  "text": "AZ: Azerbaijan"
                 },
                 "BA": {
-                  "text": "BA: Bosnia and Herzegovina",
-                  "index": 16
+                  "index": 16,
+                  "text": "BA: Bosnia and Herzegovina"
                 },
                 "BB": {
-                  "text": "BB: Barbados",
-                  "index": 17
+                  "index": 17,
+                  "text": "BB: Barbados"
                 },
                 "BD": {
-                  "text": "BD: Bangladesh",
-                  "index": 18
+                  "index": 18,
+                  "text": "BD: Bangladesh"
                 },
                 "BE": {
-                  "text": "BE: Belgium",
-                  "index": 19
+                  "index": 19,
+                  "text": "BE: Belgium"
                 },
                 "BF": {
-                  "text": "BF: Burkina Faso",
-                  "index": 20
+                  "index": 20,
+                  "text": "BF: Burkina Faso"
                 },
                 "BG": {
-                  "text": "BG: Bulgaria",
-                  "index": 21
+                  "index": 21,
+                  "text": "BG: Bulgaria"
                 },
                 "BH": {
-                  "text": "BH: Bahrain",
-                  "index": 22
+                  "index": 22,
+                  "text": "BH: Bahrain"
                 },
                 "BI": {
-                  "text": "BI: Burundi",
-                  "index": 23
+                  "index": 23,
+                  "text": "BI: Burundi"
                 },
                 "BJ": {
-                  "text": "BJ: Benin",
-                  "index": 24
+                  "index": 24,
+                  "text": "BJ: Benin"
                 },
                 "BL": {
-                  "text": "BL: Saint Barth\u00e9lemy",
-                  "index": 25
+                  "index": 25,
+                  "text": "BL: Saint Barthélemy"
                 },
                 "BM": {
-                  "text": "BM: Bermuda",
-                  "index": 26
+                  "index": 26,
+                  "text": "BM: Bermuda"
                 },
                 "BN": {
-                  "text": "BN: Brunei Darussalam",
-                  "index": 27
+                  "index": 27,
+                  "text": "BN: Brunei Darussalam"
                 },
                 "BO": {
-                  "text": "BO: Bolivia, Plurinational State of",
-                  "index": 28
+                  "index": 28,
+                  "text": "BO: Bolivia, Plurinational State of"
                 },
                 "BQ": {
-                  "text": "BQ: Bonaire, Sint Eustatius and Saba",
-                  "index": 29
+                  "index": 29,
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba"
                 },
                 "BR": {
-                  "text": "BR: Brazil",
-                  "index": 30
+                  "index": 30,
+                  "text": "BR: Brazil"
                 },
                 "BS": {
-                  "text": "BS: Bahamas",
-                  "index": 31
+                  "index": 31,
+                  "text": "BS: Bahamas"
                 },
                 "BT": {
-                  "text": "BT: Bhutan",
-                  "index": 32
+                  "index": 32,
+                  "text": "BT: Bhutan"
                 },
                 "BV": {
-                  "text": "BV: Bouvet Island",
-                  "index": 33
+                  "index": 33,
+                  "text": "BV: Bouvet Island"
                 },
                 "BW": {
-                  "text": "BW: Botswana",
-                  "index": 34
+                  "index": 34,
+                  "text": "BW: Botswana"
                 },
                 "BY": {
-                  "text": "BY: Belarus",
-                  "index": 35
+                  "index": 35,
+                  "text": "BY: Belarus"
                 },
                 "BZ": {
-                  "text": "BZ: Belize",
-                  "index": 36
+                  "index": 36,
+                  "text": "BZ: Belize"
                 },
                 "CA": {
-                  "text": "CA: Canada",
-                  "index": 37
+                  "index": 37,
+                  "text": "CA: Canada"
                 },
                 "CC": {
-                  "text": "CC: Cocos (Keeling) Islands",
-                  "index": 38
+                  "index": 38,
+                  "text": "CC: Cocos (Keeling) Islands"
                 },
                 "CD": {
-                  "text": "CD: Congo, The Democratic Republic of the",
-                  "index": 39
+                  "index": 39,
+                  "text": "CD: Congo, The Democratic Republic of the"
                 },
                 "CF": {
-                  "text": "CF: Central African Republic",
-                  "index": 40
+                  "index": 40,
+                  "text": "CF: Central African Republic"
                 },
                 "CG": {
-                  "text": "CG: Congo",
-                  "index": 41
+                  "index": 41,
+                  "text": "CG: Congo"
                 },
                 "CH": {
-                  "text": "CH: Switzerland",
-                  "index": 42
+                  "index": 42,
+                  "text": "CH: Switzerland"
                 },
                 "CI": {
-                  "text": "CI: C\u00f4te d'Ivoire",
-                  "index": 43
+                  "index": 43,
+                  "text": "CI: Côte d'Ivoire"
                 },
                 "CK": {
-                  "text": "CK: Cook Islands",
-                  "index": 44
+                  "index": 44,
+                  "text": "CK: Cook Islands"
                 },
                 "CL": {
-                  "text": "CL: Chile",
-                  "index": 45
+                  "index": 45,
+                  "text": "CL: Chile"
                 },
                 "CM": {
-                  "text": "CM: Cameroon",
-                  "index": 46
+                  "index": 46,
+                  "text": "CM: Cameroon"
                 },
                 "CN": {
-                  "text": "CN: China",
-                  "index": 47
+                  "index": 47,
+                  "text": "CN: China"
                 },
                 "CO": {
-                  "text": "CO: Colombia",
-                  "index": 48
+                  "index": 48,
+                  "text": "CO: Colombia"
                 },
                 "CR": {
-                  "text": "CR: Costa Rica",
-                  "index": 49
+                  "index": 49,
+                  "text": "CR: Costa Rica"
                 },
                 "CU": {
-                  "text": "CU: Cuba",
-                  "index": 50
+                  "index": 50,
+                  "text": "CU: Cuba"
                 },
                 "CV": {
-                  "text": "CV: Cabo Verde",
-                  "index": 51
+                  "index": 51,
+                  "text": "CV: Cabo Verde"
                 },
                 "CW": {
-                  "text": "CW: Cura\u00e7ao",
-                  "index": 52
+                  "index": 52,
+                  "text": "CW: Curaçao"
                 },
                 "CX": {
-                  "text": "CX: Christmas Island",
-                  "index": 53
+                  "index": 53,
+                  "text": "CX: Christmas Island"
                 },
                 "CY": {
-                  "text": "CY: Cyprus",
-                  "index": 54
+                  "index": 54,
+                  "text": "CY: Cyprus"
                 },
                 "CZ": {
-                  "text": "CZ: Czechia",
-                  "index": 55
+                  "index": 55,
+                  "text": "CZ: Czechia"
                 },
                 "DE": {
-                  "text": "DE: Germany",
-                  "index": 56
+                  "index": 56,
+                  "text": "DE: Germany"
                 },
                 "DJ": {
-                  "text": "DJ: Djibouti",
-                  "index": 57
+                  "index": 57,
+                  "text": "DJ: Djibouti"
                 },
                 "DK": {
-                  "text": "DK: Denmark",
-                  "index": 58
+                  "index": 58,
+                  "text": "DK: Denmark"
                 },
                 "DM": {
-                  "text": "DM: Dominica",
-                  "index": 59
+                  "index": 59,
+                  "text": "DM: Dominica"
                 },
                 "DO": {
-                  "text": "DO: Dominican Republic",
-                  "index": 60
+                  "index": 60,
+                  "text": "DO: Dominican Republic"
                 },
                 "DZ": {
-                  "text": "DZ: Algeria",
-                  "index": 61
+                  "index": 61,
+                  "text": "DZ: Algeria"
                 },
                 "EC": {
-                  "text": "EC: Ecuador",
-                  "index": 62
+                  "index": 62,
+                  "text": "EC: Ecuador"
                 },
                 "EE": {
-                  "text": "EE: Estonia",
-                  "index": 63
+                  "index": 63,
+                  "text": "EE: Estonia"
                 },
                 "EG": {
-                  "text": "EG: Egypt",
-                  "index": 64
+                  "index": 64,
+                  "text": "EG: Egypt"
                 },
                 "EH": {
-                  "text": "EH: Western Sahara",
-                  "index": 65
+                  "index": 65,
+                  "text": "EH: Western Sahara"
                 },
                 "ER": {
-                  "text": "ER: Eritrea",
-                  "index": 66
+                  "index": 66,
+                  "text": "ER: Eritrea"
                 },
                 "ES": {
-                  "text": "ES: Spain",
-                  "index": 67
+                  "index": 67,
+                  "text": "ES: Spain"
                 },
                 "ET": {
-                  "text": "ET: Ethiopia",
-                  "index": 68
+                  "index": 68,
+                  "text": "ET: Ethiopia"
                 },
                 "FI": {
-                  "text": "FI: Finland",
-                  "index": 69
+                  "index": 69,
+                  "text": "FI: Finland"
                 },
                 "FJ": {
-                  "text": "FJ: Fiji",
-                  "index": 70
+                  "index": 70,
+                  "text": "FJ: Fiji"
                 },
                 "FK": {
-                  "text": "FK: Falkland Islands (Malvinas)",
-                  "index": 71
+                  "index": 71,
+                  "text": "FK: Falkland Islands (Malvinas)"
                 },
                 "FM": {
-                  "text": "FM: Micronesia, Federated States of",
-                  "index": 72
+                  "index": 72,
+                  "text": "FM: Micronesia, Federated States of"
                 },
                 "FO": {
-                  "text": "FO: Faroe Islands",
-                  "index": 73
+                  "index": 73,
+                  "text": "FO: Faroe Islands"
                 },
                 "FR": {
-                  "text": "FR: France",
-                  "index": 74
+                  "index": 74,
+                  "text": "FR: France"
                 },
                 "GA": {
-                  "text": "GA: Gabon",
-                  "index": 75
+                  "index": 75,
+                  "text": "GA: Gabon"
                 },
                 "GB": {
-                  "text": "GB: United Kingdom",
-                  "index": 76
+                  "index": 76,
+                  "text": "GB: United Kingdom"
                 },
                 "GD": {
-                  "text": "GD: Grenada",
-                  "index": 77
+                  "index": 77,
+                  "text": "GD: Grenada"
                 },
                 "GE": {
-                  "text": "GE: Georgia",
-                  "index": 78
+                  "index": 78,
+                  "text": "GE: Georgia"
                 },
                 "GF": {
-                  "text": "GF: French Guiana",
-                  "index": 79
+                  "index": 79,
+                  "text": "GF: French Guiana"
                 },
                 "GG": {
-                  "text": "GG: Guernsey",
-                  "index": 80
+                  "index": 80,
+                  "text": "GG: Guernsey"
                 },
                 "GH": {
-                  "text": "GH: Ghana",
-                  "index": 81
+                  "index": 81,
+                  "text": "GH: Ghana"
                 },
                 "GI": {
-                  "text": "GI: Gibraltar",
-                  "index": 82
+                  "index": 82,
+                  "text": "GI: Gibraltar"
                 },
                 "GL": {
-                  "text": "GL: Greenland",
-                  "index": 83
+                  "index": 83,
+                  "text": "GL: Greenland"
                 },
                 "GM": {
-                  "text": "GM: Gambia",
-                  "index": 84
+                  "index": 84,
+                  "text": "GM: Gambia"
                 },
                 "GN": {
-                  "text": "GN: Guinea",
-                  "index": 85
+                  "index": 85,
+                  "text": "GN: Guinea"
                 },
                 "GP": {
-                  "text": "GP: Guadeloupe",
-                  "index": 86
+                  "index": 86,
+                  "text": "GP: Guadeloupe"
                 },
                 "GQ": {
-                  "text": "GQ: Equatorial Guinea",
-                  "index": 87
+                  "index": 87,
+                  "text": "GQ: Equatorial Guinea"
                 },
                 "GR": {
-                  "text": "GR: Greece",
-                  "index": 88
+                  "index": 88,
+                  "text": "GR: Greece"
                 },
                 "GS": {
-                  "text": "GS: South Georgia and the South Sandwich Islands",
-                  "index": 89
+                  "index": 89,
+                  "text": "GS: South Georgia and the South Sandwich Islands"
                 },
                 "GT": {
-                  "text": "GT: Guatemala",
-                  "index": 90
+                  "index": 90,
+                  "text": "GT: Guatemala"
                 },
                 "GU": {
-                  "text": "GU: Guam",
-                  "index": 91
+                  "index": 91,
+                  "text": "GU: Guam"
                 },
                 "GW": {
-                  "text": "GW: Guinea-Bissau",
-                  "index": 92
+                  "index": 92,
+                  "text": "GW: Guinea-Bissau"
                 },
                 "GY": {
-                  "text": "GY: Guyana",
-                  "index": 93
+                  "index": 93,
+                  "text": "GY: Guyana"
                 },
                 "HK": {
-                  "text": "HK: Hong Kong",
-                  "index": 94
+                  "index": 94,
+                  "text": "HK: Hong Kong"
                 },
                 "HM": {
-                  "text": "HM: Heard Island and McDonald Islands",
-                  "index": 95
+                  "index": 95,
+                  "text": "HM: Heard Island and McDonald Islands"
                 },
                 "HN": {
-                  "text": "HN: Honduras",
-                  "index": 96
+                  "index": 96,
+                  "text": "HN: Honduras"
                 },
                 "HR": {
-                  "text": "HR: Croatia",
-                  "index": 97
+                  "index": 97,
+                  "text": "HR: Croatia"
                 },
                 "HT": {
-                  "text": "HT: Haiti",
-                  "index": 98
+                  "index": 98,
+                  "text": "HT: Haiti"
                 },
                 "HU": {
-                  "text": "HU: Hungary",
-                  "index": 99
+                  "index": 99,
+                  "text": "HU: Hungary"
                 },
                 "ID": {
-                  "text": "ID: Indonesia",
-                  "index": 100
+                  "index": 100,
+                  "text": "ID: Indonesia"
                 },
                 "IE": {
-                  "text": "IE: Ireland",
-                  "index": 101
+                  "index": 101,
+                  "text": "IE: Ireland"
                 },
                 "IL": {
-                  "text": "IL: Israel",
-                  "index": 102
+                  "index": 102,
+                  "text": "IL: Israel"
                 },
                 "IM": {
-                  "text": "IM: Isle of Man",
-                  "index": 103
+                  "index": 103,
+                  "text": "IM: Isle of Man"
                 },
                 "IN": {
-                  "text": "IN: India",
-                  "index": 104
+                  "index": 104,
+                  "text": "IN: India"
                 },
                 "IO": {
-                  "text": "IO: British Indian Ocean Territory",
-                  "index": 105
+                  "index": 105,
+                  "text": "IO: British Indian Ocean Territory"
                 },
                 "IQ": {
-                  "text": "IQ: Iraq",
-                  "index": 106
+                  "index": 106,
+                  "text": "IQ: Iraq"
                 },
                 "IR": {
-                  "text": "IR: Iran, Islamic Republic of",
-                  "index": 107
+                  "index": 107,
+                  "text": "IR: Iran, Islamic Republic of"
                 },
                 "IS": {
-                  "text": "IS: Iceland",
-                  "index": 108
+                  "index": 108,
+                  "text": "IS: Iceland"
                 },
                 "IT": {
-                  "text": "IT: Italy",
-                  "index": 109
+                  "index": 109,
+                  "text": "IT: Italy"
                 },
                 "JE": {
-                  "text": "JE: Jersey",
-                  "index": 110
+                  "index": 110,
+                  "text": "JE: Jersey"
                 },
                 "JM": {
-                  "text": "JM: Jamaica",
-                  "index": 111
+                  "index": 111,
+                  "text": "JM: Jamaica"
                 },
                 "JO": {
-                  "text": "JO: Jordan",
-                  "index": 112
+                  "index": 112,
+                  "text": "JO: Jordan"
                 },
                 "JP": {
-                  "text": "JP: Japan",
-                  "index": 113
+                  "index": 113,
+                  "text": "JP: Japan"
                 },
                 "KE": {
-                  "text": "KE: Kenya",
-                  "index": 114
+                  "index": 114,
+                  "text": "KE: Kenya"
                 },
                 "KG": {
-                  "text": "KG: Kyrgyzstan",
-                  "index": 115
+                  "index": 115,
+                  "text": "KG: Kyrgyzstan"
                 },
                 "KH": {
-                  "text": "KH: Cambodia",
-                  "index": 116
+                  "index": 116,
+                  "text": "KH: Cambodia"
                 },
                 "KI": {
-                  "text": "KI: Kiribati",
-                  "index": 117
+                  "index": 117,
+                  "text": "KI: Kiribati"
                 },
                 "KM": {
-                  "text": "KM: Comoros",
-                  "index": 118
+                  "index": 118,
+                  "text": "KM: Comoros"
                 },
                 "KN": {
-                  "text": "KN: Saint Kitts and Nevis",
-                  "index": 119
+                  "index": 119,
+                  "text": "KN: Saint Kitts and Nevis"
                 },
                 "KP": {
-                  "text": "KP: Korea, Democratic People's Republic of",
-                  "index": 120
+                  "index": 120,
+                  "text": "KP: Korea, Democratic People's Republic of"
                 },
                 "KR": {
-                  "text": "KR: Korea, Republic of",
-                  "index": 121
+                  "index": 121,
+                  "text": "KR: Korea, Republic of"
                 },
                 "KW": {
-                  "text": "KW: Kuwait",
-                  "index": 122
+                  "index": 122,
+                  "text": "KW: Kuwait"
                 },
                 "KY": {
-                  "text": "KY: Cayman Islands",
-                  "index": 123
+                  "index": 123,
+                  "text": "KY: Cayman Islands"
                 },
                 "KZ": {
-                  "text": "KZ: Kazakhstan",
-                  "index": 124
+                  "index": 124,
+                  "text": "KZ: Kazakhstan"
                 },
                 "LA": {
-                  "text": "LA: Lao People's Democratic Republic",
-                  "index": 125
+                  "index": 125,
+                  "text": "LA: Lao People's Democratic Republic"
                 },
                 "LB": {
-                  "text": "LB: Lebanon",
-                  "index": 126
+                  "index": 126,
+                  "text": "LB: Lebanon"
                 },
                 "LC": {
-                  "text": "LC: Saint Lucia",
-                  "index": 127
+                  "index": 127,
+                  "text": "LC: Saint Lucia"
                 },
                 "LI": {
-                  "text": "LI: Liechtenstein",
-                  "index": 128
+                  "index": 128,
+                  "text": "LI: Liechtenstein"
                 },
                 "LK": {
-                  "text": "LK: Sri Lanka",
-                  "index": 129
+                  "index": 129,
+                  "text": "LK: Sri Lanka"
                 },
                 "LR": {
-                  "text": "LR: Liberia",
-                  "index": 130
+                  "index": 130,
+                  "text": "LR: Liberia"
                 },
                 "LS": {
-                  "text": "LS: Lesotho",
-                  "index": 131
+                  "index": 131,
+                  "text": "LS: Lesotho"
                 },
                 "LT": {
-                  "text": "LT: Lithuania",
-                  "index": 132
+                  "index": 132,
+                  "text": "LT: Lithuania"
                 },
                 "LU": {
-                  "text": "LU: Luxembourg",
-                  "index": 133
+                  "index": 133,
+                  "text": "LU: Luxembourg"
                 },
                 "LV": {
-                  "text": "LV: Latvia",
-                  "index": 134
+                  "index": 134,
+                  "text": "LV: Latvia"
                 },
                 "LY": {
-                  "text": "LY: Libya",
-                  "index": 135
+                  "index": 135,
+                  "text": "LY: Libya"
                 },
                 "MA": {
-                  "text": "MA: Morocco",
-                  "index": 136
+                  "index": 136,
+                  "text": "MA: Morocco"
                 },
                 "MC": {
-                  "text": "MC: Monaco",
-                  "index": 137
+                  "index": 137,
+                  "text": "MC: Monaco"
                 },
                 "MD": {
-                  "text": "MD: Moldova, Republic of",
-                  "index": 138
+                  "index": 138,
+                  "text": "MD: Moldova, Republic of"
                 },
                 "ME": {
-                  "text": "ME: Montenegro",
-                  "index": 139
+                  "index": 139,
+                  "text": "ME: Montenegro"
                 },
                 "MF": {
-                  "text": "MF: Saint Martin (French part)",
-                  "index": 140
+                  "index": 140,
+                  "text": "MF: Saint Martin (French part)"
                 },
                 "MG": {
-                  "text": "MG: Madagascar",
-                  "index": 141
+                  "index": 141,
+                  "text": "MG: Madagascar"
                 },
                 "MH": {
-                  "text": "MH: Marshall Islands",
-                  "index": 142
+                  "index": 142,
+                  "text": "MH: Marshall Islands"
                 },
                 "MK": {
-                  "text": "MK: North Macedonia",
-                  "index": 143
+                  "index": 143,
+                  "text": "MK: North Macedonia"
                 },
                 "ML": {
-                  "text": "ML: Mali",
-                  "index": 144
+                  "index": 144,
+                  "text": "ML: Mali"
                 },
                 "MM": {
-                  "text": "MM: Myanmar",
-                  "index": 145
+                  "index": 145,
+                  "text": "MM: Myanmar"
                 },
                 "MN": {
-                  "text": "MN: Mongolia",
-                  "index": 146
+                  "index": 146,
+                  "text": "MN: Mongolia"
                 },
                 "MO": {
-                  "text": "MO: Macao",
-                  "index": 147
+                  "index": 147,
+                  "text": "MO: Macao"
                 },
                 "MP": {
-                  "text": "MP: Northern Mariana Islands",
-                  "index": 148
+                  "index": 148,
+                  "text": "MP: Northern Mariana Islands"
                 },
                 "MQ": {
-                  "text": "MQ: Martinique",
-                  "index": 149
+                  "index": 149,
+                  "text": "MQ: Martinique"
                 },
                 "MR": {
-                  "text": "MR: Mauritania",
-                  "index": 150
+                  "index": 150,
+                  "text": "MR: Mauritania"
                 },
                 "MS": {
-                  "text": "MS: Montserrat",
-                  "index": 151
+                  "index": 151,
+                  "text": "MS: Montserrat"
                 },
                 "MT": {
-                  "text": "MT: Malta",
-                  "index": 152
+                  "index": 152,
+                  "text": "MT: Malta"
                 },
                 "MU": {
-                  "text": "MU: Mauritius",
-                  "index": 153
+                  "index": 153,
+                  "text": "MU: Mauritius"
                 },
                 "MV": {
-                  "text": "MV: Maldives",
-                  "index": 154
+                  "index": 154,
+                  "text": "MV: Maldives"
                 },
                 "MW": {
-                  "text": "MW: Malawi",
-                  "index": 155
+                  "index": 155,
+                  "text": "MW: Malawi"
                 },
                 "MX": {
-                  "text": "MX: Mexico",
-                  "index": 156
+                  "index": 156,
+                  "text": "MX: Mexico"
                 },
                 "MY": {
-                  "text": "MY: Malaysia",
-                  "index": 157
+                  "index": 157,
+                  "text": "MY: Malaysia"
                 },
                 "MZ": {
-                  "text": "MZ: Mozambique",
-                  "index": 158
+                  "index": 158,
+                  "text": "MZ: Mozambique"
                 },
                 "NA": {
-                  "text": "NA: Namibia",
-                  "index": 159
+                  "index": 159,
+                  "text": "NA: Namibia"
                 },
                 "NC": {
-                  "text": "NC: New Caledonia",
-                  "index": 160
+                  "index": 160,
+                  "text": "NC: New Caledonia"
                 },
                 "NE": {
-                  "text": "NE: Niger",
-                  "index": 161
+                  "index": 161,
+                  "text": "NE: Niger"
                 },
                 "NF": {
-                  "text": "NF: Norfolk Island",
-                  "index": 162
+                  "index": 162,
+                  "text": "NF: Norfolk Island"
                 },
                 "NG": {
-                  "text": "NG: Nigeria",
-                  "index": 163
+                  "index": 163,
+                  "text": "NG: Nigeria"
                 },
                 "NI": {
-                  "text": "NI: Nicaragua",
-                  "index": 164
+                  "index": 164,
+                  "text": "NI: Nicaragua"
                 },
                 "NL": {
-                  "text": "NL: Netherlands",
-                  "index": 165
+                  "index": 165,
+                  "text": "NL: Netherlands"
                 },
                 "NO": {
-                  "text": "NO: Norway",
-                  "index": 166
+                  "index": 166,
+                  "text": "NO: Norway"
                 },
                 "NP": {
-                  "text": "NP: Nepal",
-                  "index": 167
+                  "index": 167,
+                  "text": "NP: Nepal"
                 },
                 "NR": {
-                  "text": "NR: Nauru",
-                  "index": 168
+                  "index": 168,
+                  "text": "NR: Nauru"
                 },
                 "NU": {
-                  "text": "NU: Niue",
-                  "index": 169
+                  "index": 169,
+                  "text": "NU: Niue"
                 },
                 "NZ": {
-                  "text": "NZ: New Zealand",
-                  "index": 170
+                  "index": 170,
+                  "text": "NZ: New Zealand"
                 },
                 "OM": {
-                  "text": "OM: Oman",
-                  "index": 171
+                  "index": 171,
+                  "text": "OM: Oman"
                 },
                 "PA": {
-                  "text": "PA: Panama",
-                  "index": 172
+                  "index": 172,
+                  "text": "PA: Panama"
                 },
                 "PE": {
-                  "text": "PE: Peru",
-                  "index": 173
+                  "index": 173,
+                  "text": "PE: Peru"
                 },
                 "PF": {
-                  "text": "PF: French Polynesia",
-                  "index": 174
+                  "index": 174,
+                  "text": "PF: French Polynesia"
                 },
                 "PG": {
-                  "text": "PG: Papua New Guinea",
-                  "index": 175
+                  "index": 175,
+                  "text": "PG: Papua New Guinea"
                 },
                 "PH": {
-                  "text": "PH: Philippines",
-                  "index": 176
+                  "index": 176,
+                  "text": "PH: Philippines"
                 },
                 "PK": {
-                  "text": "PK: Pakistan",
-                  "index": 177
+                  "index": 177,
+                  "text": "PK: Pakistan"
                 },
                 "PL": {
-                  "text": "PL: Poland",
-                  "index": 178
+                  "index": 178,
+                  "text": "PL: Poland"
                 },
                 "PM": {
-                  "text": "PM: Saint Pierre and Miquelon",
-                  "index": 179
+                  "index": 179,
+                  "text": "PM: Saint Pierre and Miquelon"
                 },
                 "PN": {
-                  "text": "PN: Pitcairn",
-                  "index": 180
+                  "index": 180,
+                  "text": "PN: Pitcairn"
                 },
                 "PR": {
-                  "text": "PR: Puerto Rico",
-                  "index": 181
+                  "index": 181,
+                  "text": "PR: Puerto Rico"
                 },
                 "PS": {
-                  "text": "PS: Palestine, State of",
-                  "index": 182
+                  "index": 182,
+                  "text": "PS: Palestine, State of"
                 },
                 "PT": {
-                  "text": "PT: Portugal",
-                  "index": 183
+                  "index": 183,
+                  "text": "PT: Portugal"
                 },
                 "PW": {
-                  "text": "PW: Palau",
-                  "index": 184
+                  "index": 184,
+                  "text": "PW: Palau"
                 },
                 "PY": {
-                  "text": "PY: Paraguay",
-                  "index": 185
+                  "index": 185,
+                  "text": "PY: Paraguay"
                 },
                 "QA": {
-                  "text": "QA: Qatar",
-                  "index": 186
+                  "index": 186,
+                  "text": "QA: Qatar"
                 },
                 "RE": {
-                  "text": "RE: R\u00e9union",
-                  "index": 187
+                  "index": 187,
+                  "text": "RE: Réunion"
                 },
                 "RO": {
-                  "text": "RO: Romania",
-                  "index": 188
+                  "index": 188,
+                  "text": "RO: Romania"
                 },
                 "RS": {
-                  "text": "RS: Serbia",
-                  "index": 189
+                  "index": 189,
+                  "text": "RS: Serbia"
                 },
                 "RU": {
-                  "text": "RU: Russian Federation",
-                  "index": 190
+                  "index": 190,
+                  "text": "RU: Russian Federation"
                 },
                 "RW": {
-                  "text": "RW: Rwanda",
-                  "index": 191
+                  "index": 191,
+                  "text": "RW: Rwanda"
                 },
                 "SA": {
-                  "text": "SA: Saudi Arabia",
-                  "index": 192
+                  "index": 192,
+                  "text": "SA: Saudi Arabia"
                 },
                 "SB": {
-                  "text": "SB: Solomon Islands",
-                  "index": 193
+                  "index": 193,
+                  "text": "SB: Solomon Islands"
                 },
                 "SC": {
-                  "text": "SC: Seychelles",
-                  "index": 194
+                  "index": 194,
+                  "text": "SC: Seychelles"
                 },
                 "SD": {
-                  "text": "SD: Sudan",
-                  "index": 195
+                  "index": 195,
+                  "text": "SD: Sudan"
                 },
                 "SE": {
-                  "text": "SE: Sweden",
-                  "index": 196
+                  "index": 196,
+                  "text": "SE: Sweden"
                 },
                 "SG": {
-                  "text": "SG: Singapore",
-                  "index": 197
+                  "index": 197,
+                  "text": "SG: Singapore"
                 },
                 "SH": {
-                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha",
-                  "index": 198
+                  "index": 198,
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha"
                 },
                 "SI": {
-                  "text": "SI: Slovenia",
-                  "index": 199
+                  "index": 199,
+                  "text": "SI: Slovenia"
                 },
                 "SJ": {
-                  "text": "SJ: Svalbard and Jan Mayen",
-                  "index": 200
+                  "index": 200,
+                  "text": "SJ: Svalbard and Jan Mayen"
                 },
                 "SK": {
-                  "text": "SK: Slovakia",
-                  "index": 201
+                  "index": 201,
+                  "text": "SK: Slovakia"
                 },
                 "SL": {
-                  "text": "SL: Sierra Leone",
-                  "index": 202
+                  "index": 202,
+                  "text": "SL: Sierra Leone"
                 },
                 "SM": {
-                  "text": "SM: San Marino",
-                  "index": 203
+                  "index": 203,
+                  "text": "SM: San Marino"
                 },
                 "SN": {
-                  "text": "SN: Senegal",
-                  "index": 204
+                  "index": 204,
+                  "text": "SN: Senegal"
                 },
                 "SO": {
-                  "text": "SO: Somalia",
-                  "index": 205
+                  "index": 205,
+                  "text": "SO: Somalia"
                 },
                 "SR": {
-                  "text": "SR: Suriname",
-                  "index": 206
+                  "index": 206,
+                  "text": "SR: Suriname"
                 },
                 "SS": {
-                  "text": "SS: South Sudan",
-                  "index": 207
+                  "index": 207,
+                  "text": "SS: South Sudan"
                 },
                 "ST": {
-                  "text": "ST: Sao Tome and Principe",
-                  "index": 208
+                  "index": 208,
+                  "text": "ST: Sao Tome and Principe"
                 },
                 "SV": {
-                  "text": "SV: El Salvador",
-                  "index": 209
+                  "index": 209,
+                  "text": "SV: El Salvador"
                 },
                 "SX": {
-                  "text": "SX: Sint Maarten (Dutch part)",
-                  "index": 210
+                  "index": 210,
+                  "text": "SX: Sint Maarten (Dutch part)"
                 },
                 "SY": {
-                  "text": "SY: Syrian Arab Republic",
-                  "index": 211
+                  "index": 211,
+                  "text": "SY: Syrian Arab Republic"
                 },
                 "SZ": {
-                  "text": "SZ: Eswatini",
-                  "index": 212
+                  "index": 212,
+                  "text": "SZ: Eswatini"
                 },
                 "TC": {
-                  "text": "TC: Turks and Caicos Islands",
-                  "index": 213
+                  "index": 213,
+                  "text": "TC: Turks and Caicos Islands"
                 },
                 "TD": {
-                  "text": "TD: Chad",
-                  "index": 214
+                  "index": 214,
+                  "text": "TD: Chad"
                 },
                 "TF": {
-                  "text": "TF: French Southern Territories",
-                  "index": 215
+                  "index": 215,
+                  "text": "TF: French Southern Territories"
                 },
                 "TG": {
-                  "text": "TG: Togo",
-                  "index": 216
+                  "index": 216,
+                  "text": "TG: Togo"
                 },
                 "TH": {
-                  "text": "TH: Thailand",
-                  "index": 217
+                  "index": 217,
+                  "text": "TH: Thailand"
                 },
                 "TJ": {
-                  "text": "TJ: Tajikistan",
-                  "index": 218
+                  "index": 218,
+                  "text": "TJ: Tajikistan"
                 },
                 "TK": {
-                  "text": "TK: Tokelau",
-                  "index": 219
+                  "index": 219,
+                  "text": "TK: Tokelau"
                 },
                 "TL": {
-                  "text": "TL: Timor-Leste",
-                  "index": 220
+                  "index": 220,
+                  "text": "TL: Timor-Leste"
                 },
                 "TM": {
-                  "text": "TM: Turkmenistan",
-                  "index": 221
+                  "index": 221,
+                  "text": "TM: Turkmenistan"
                 },
                 "TN": {
-                  "text": "TN: Tunisia",
-                  "index": 222
+                  "index": 222,
+                  "text": "TN: Tunisia"
                 },
                 "TO": {
-                  "text": "TO: Tonga",
-                  "index": 223
+                  "index": 223,
+                  "text": "TO: Tonga"
                 },
                 "TR": {
-                  "text": "TR: T\u00fcrkiye",
-                  "index": 224
+                  "index": 224,
+                  "text": "TR: Türkiye"
                 },
                 "TT": {
-                  "text": "TT: Trinidad and Tobago",
-                  "index": 225
+                  "index": 225,
+                  "text": "TT: Trinidad and Tobago"
                 },
                 "TV": {
-                  "text": "TV: Tuvalu",
-                  "index": 226
+                  "index": 226,
+                  "text": "TV: Tuvalu"
                 },
                 "TW": {
-                  "text": "TW: Taiwan, Province of China",
-                  "index": 227
+                  "index": 227,
+                  "text": "TW: Taiwan, Province of China"
                 },
                 "TZ": {
-                  "text": "TZ: Tanzania, United Republic of",
-                  "index": 228
+                  "index": 228,
+                  "text": "TZ: Tanzania, United Republic of"
                 },
                 "UA": {
-                  "text": "UA: Ukraine",
-                  "index": 229
+                  "index": 229,
+                  "text": "UA: Ukraine"
                 },
                 "UG": {
-                  "text": "UG: Uganda",
-                  "index": 230
+                  "index": 230,
+                  "text": "UG: Uganda"
                 },
                 "UM": {
-                  "text": "UM: United States Minor Outlying Islands",
-                  "index": 231
+                  "index": 231,
+                  "text": "UM: United States Minor Outlying Islands"
                 },
                 "US": {
-                  "text": "US: United States",
-                  "index": 232
+                  "index": 232,
+                  "text": "US: United States"
                 },
                 "UY": {
-                  "text": "UY: Uruguay",
-                  "index": 233
+                  "index": 233,
+                  "text": "UY: Uruguay"
                 },
                 "UZ": {
-                  "text": "UZ: Uzbekistan",
-                  "index": 234
+                  "index": 234,
+                  "text": "UZ: Uzbekistan"
                 },
                 "VA": {
-                  "text": "VA: Holy See (Vatican City State)",
-                  "index": 235
+                  "index": 235,
+                  "text": "VA: Holy See (Vatican City State)"
                 },
                 "VC": {
-                  "text": "VC: Saint Vincent and the Grenadines",
-                  "index": 236
+                  "index": 236,
+                  "text": "VC: Saint Vincent and the Grenadines"
                 },
                 "VE": {
-                  "text": "VE: Venezuela, Bolivarian Republic of",
-                  "index": 237
+                  "index": 237,
+                  "text": "VE: Venezuela, Bolivarian Republic of"
                 },
                 "VG": {
-                  "text": "VG: Virgin Islands, British",
-                  "index": 238
+                  "index": 238,
+                  "text": "VG: Virgin Islands, British"
                 },
                 "VI": {
-                  "text": "VI: Virgin Islands, U.S.",
-                  "index": 239
+                  "index": 239,
+                  "text": "VI: Virgin Islands, U.S."
                 },
                 "VN": {
-                  "text": "VN: Viet Nam",
-                  "index": 240
+                  "index": 240,
+                  "text": "VN: Viet Nam"
                 },
                 "VU": {
-                  "text": "VU: Vanuatu",
-                  "index": 241
+                  "index": 241,
+                  "text": "VU: Vanuatu"
                 },
                 "WF": {
-                  "text": "WF: Wallis and Futuna",
-                  "index": 242
+                  "index": 242,
+                  "text": "WF: Wallis and Futuna"
                 },
                 "WS": {
-                  "text": "WS: Samoa",
-                  "index": 243
+                  "index": 243,
+                  "text": "WS: Samoa"
                 },
                 "YE": {
-                  "text": "YE: Yemen",
-                  "index": 244
+                  "index": 244,
+                  "text": "YE: Yemen"
                 },
                 "YT": {
-                  "text": "YT: Mayotte",
-                  "index": 245
+                  "index": 245,
+                  "text": "YT: Mayotte"
                 },
                 "ZA": {
-                  "text": "ZA: South Africa",
-                  "index": 246
+                  "index": 246,
+                  "text": "ZA: South Africa"
                 },
                 "ZM": {
-                  "text": "ZM: Zambia",
-                  "index": 247
+                  "index": 247,
+                  "text": "ZM: Zambia"
                 },
                 "ZW": {
-                  "text": "ZW: Zimbabwe",
-                  "index": 248
+                  "index": 248,
+                  "text": "ZW: Zimbabwe"
                 }
-              }
+              },
+              "type": "value"
             }
           ],
           "thresholds": {
@@ -1851,7 +3923,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -2033,7 +4105,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "AX: \u00c5land Islands"
+                "value": "AX: Åland Islands"
               }
             ]
           },
@@ -2165,7 +4237,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "BL: Saint Barth\u00e9lemy"
+                "value": "BL: Saint Barthélemy"
               }
             ]
           },
@@ -2381,7 +4453,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "CI: C\u00f4te d'Ivoire"
+                "value": "CI: Côte d'Ivoire"
               }
             ]
           },
@@ -2489,7 +4561,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "CW: Cura\u00e7ao"
+                "value": "CW: Curaçao"
               }
             ]
           },
@@ -4109,7 +6181,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "RE: R\u00e9union"
+                "value": "RE: Réunion"
               }
             ]
           },
@@ -4553,7 +6625,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "TR: T\u00fcrkiye"
+                "value": "TR: Türkiye"
               }
             ]
           },
@@ -4848,31 +6920,37 @@
         ]
       },
       "gridPos": {
-        "h": 16,
-        "w": 24,
-        "x": 0,
-        "y": 24
+        "h": 25,
+        "w": 12,
+        "x": 12,
+        "y": 65
       },
       "id": 12,
       "options": {
         "legend": {
-          "displayMode": "hidden",
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (region) (conduit_region_connected_clients)",
+          "expr": "conduit_region_connected_clients and on (region) topk(15, avg_over_time(conduit_region_connected_clients[$__range] @ end()))",
           "legendFormat": "{{region}}",
           "refId": "A"
         }
@@ -4887,1017 +6965,1017 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
           "custom": {
             "align": "auto",
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [
             {
-              "type": "value",
               "options": {
                 "AD": {
-                  "text": "AD: Andorra",
-                  "index": 0
+                  "index": 0,
+                  "text": "AD: Andorra"
                 },
                 "AE": {
-                  "text": "AE: United Arab Emirates",
-                  "index": 1
+                  "index": 1,
+                  "text": "AE: United Arab Emirates"
                 },
                 "AF": {
-                  "text": "AF: Afghanistan",
-                  "index": 2
+                  "index": 2,
+                  "text": "AF: Afghanistan"
                 },
                 "AG": {
-                  "text": "AG: Antigua and Barbuda",
-                  "index": 3
+                  "index": 3,
+                  "text": "AG: Antigua and Barbuda"
                 },
                 "AI": {
-                  "text": "AI: Anguilla",
-                  "index": 4
+                  "index": 4,
+                  "text": "AI: Anguilla"
                 },
                 "AL": {
-                  "text": "AL: Albania",
-                  "index": 5
+                  "index": 5,
+                  "text": "AL: Albania"
                 },
                 "AM": {
-                  "text": "AM: Armenia",
-                  "index": 6
+                  "index": 6,
+                  "text": "AM: Armenia"
                 },
                 "AO": {
-                  "text": "AO: Angola",
-                  "index": 7
+                  "index": 7,
+                  "text": "AO: Angola"
                 },
                 "AQ": {
-                  "text": "AQ: Antarctica",
-                  "index": 8
+                  "index": 8,
+                  "text": "AQ: Antarctica"
                 },
                 "AR": {
-                  "text": "AR: Argentina",
-                  "index": 9
+                  "index": 9,
+                  "text": "AR: Argentina"
                 },
                 "AS": {
-                  "text": "AS: American Samoa",
-                  "index": 10
+                  "index": 10,
+                  "text": "AS: American Samoa"
                 },
                 "AT": {
-                  "text": "AT: Austria",
-                  "index": 11
+                  "index": 11,
+                  "text": "AT: Austria"
                 },
                 "AU": {
-                  "text": "AU: Australia",
-                  "index": 12
+                  "index": 12,
+                  "text": "AU: Australia"
                 },
                 "AW": {
-                  "text": "AW: Aruba",
-                  "index": 13
+                  "index": 13,
+                  "text": "AW: Aruba"
                 },
                 "AX": {
-                  "text": "AX: \u00c5land Islands",
-                  "index": 14
+                  "index": 14,
+                  "text": "AX: Åland Islands"
                 },
                 "AZ": {
-                  "text": "AZ: Azerbaijan",
-                  "index": 15
+                  "index": 15,
+                  "text": "AZ: Azerbaijan"
                 },
                 "BA": {
-                  "text": "BA: Bosnia and Herzegovina",
-                  "index": 16
+                  "index": 16,
+                  "text": "BA: Bosnia and Herzegovina"
                 },
                 "BB": {
-                  "text": "BB: Barbados",
-                  "index": 17
+                  "index": 17,
+                  "text": "BB: Barbados"
                 },
                 "BD": {
-                  "text": "BD: Bangladesh",
-                  "index": 18
+                  "index": 18,
+                  "text": "BD: Bangladesh"
                 },
                 "BE": {
-                  "text": "BE: Belgium",
-                  "index": 19
+                  "index": 19,
+                  "text": "BE: Belgium"
                 },
                 "BF": {
-                  "text": "BF: Burkina Faso",
-                  "index": 20
+                  "index": 20,
+                  "text": "BF: Burkina Faso"
                 },
                 "BG": {
-                  "text": "BG: Bulgaria",
-                  "index": 21
+                  "index": 21,
+                  "text": "BG: Bulgaria"
                 },
                 "BH": {
-                  "text": "BH: Bahrain",
-                  "index": 22
+                  "index": 22,
+                  "text": "BH: Bahrain"
                 },
                 "BI": {
-                  "text": "BI: Burundi",
-                  "index": 23
+                  "index": 23,
+                  "text": "BI: Burundi"
                 },
                 "BJ": {
-                  "text": "BJ: Benin",
-                  "index": 24
+                  "index": 24,
+                  "text": "BJ: Benin"
                 },
                 "BL": {
-                  "text": "BL: Saint Barth\u00e9lemy",
-                  "index": 25
+                  "index": 25,
+                  "text": "BL: Saint Barthélemy"
                 },
                 "BM": {
-                  "text": "BM: Bermuda",
-                  "index": 26
+                  "index": 26,
+                  "text": "BM: Bermuda"
                 },
                 "BN": {
-                  "text": "BN: Brunei Darussalam",
-                  "index": 27
+                  "index": 27,
+                  "text": "BN: Brunei Darussalam"
                 },
                 "BO": {
-                  "text": "BO: Bolivia, Plurinational State of",
-                  "index": 28
+                  "index": 28,
+                  "text": "BO: Bolivia, Plurinational State of"
                 },
                 "BQ": {
-                  "text": "BQ: Bonaire, Sint Eustatius and Saba",
-                  "index": 29
+                  "index": 29,
+                  "text": "BQ: Bonaire, Sint Eustatius and Saba"
                 },
                 "BR": {
-                  "text": "BR: Brazil",
-                  "index": 30
+                  "index": 30,
+                  "text": "BR: Brazil"
                 },
                 "BS": {
-                  "text": "BS: Bahamas",
-                  "index": 31
+                  "index": 31,
+                  "text": "BS: Bahamas"
                 },
                 "BT": {
-                  "text": "BT: Bhutan",
-                  "index": 32
+                  "index": 32,
+                  "text": "BT: Bhutan"
                 },
                 "BV": {
-                  "text": "BV: Bouvet Island",
-                  "index": 33
+                  "index": 33,
+                  "text": "BV: Bouvet Island"
                 },
                 "BW": {
-                  "text": "BW: Botswana",
-                  "index": 34
+                  "index": 34,
+                  "text": "BW: Botswana"
                 },
                 "BY": {
-                  "text": "BY: Belarus",
-                  "index": 35
+                  "index": 35,
+                  "text": "BY: Belarus"
                 },
                 "BZ": {
-                  "text": "BZ: Belize",
-                  "index": 36
+                  "index": 36,
+                  "text": "BZ: Belize"
                 },
                 "CA": {
-                  "text": "CA: Canada",
-                  "index": 37
+                  "index": 37,
+                  "text": "CA: Canada"
                 },
                 "CC": {
-                  "text": "CC: Cocos (Keeling) Islands",
-                  "index": 38
+                  "index": 38,
+                  "text": "CC: Cocos (Keeling) Islands"
                 },
                 "CD": {
-                  "text": "CD: Congo, The Democratic Republic of the",
-                  "index": 39
+                  "index": 39,
+                  "text": "CD: Congo, The Democratic Republic of the"
                 },
                 "CF": {
-                  "text": "CF: Central African Republic",
-                  "index": 40
+                  "index": 40,
+                  "text": "CF: Central African Republic"
                 },
                 "CG": {
-                  "text": "CG: Congo",
-                  "index": 41
+                  "index": 41,
+                  "text": "CG: Congo"
                 },
                 "CH": {
-                  "text": "CH: Switzerland",
-                  "index": 42
+                  "index": 42,
+                  "text": "CH: Switzerland"
                 },
                 "CI": {
-                  "text": "CI: C\u00f4te d'Ivoire",
-                  "index": 43
+                  "index": 43,
+                  "text": "CI: Côte d'Ivoire"
                 },
                 "CK": {
-                  "text": "CK: Cook Islands",
-                  "index": 44
+                  "index": 44,
+                  "text": "CK: Cook Islands"
                 },
                 "CL": {
-                  "text": "CL: Chile",
-                  "index": 45
+                  "index": 45,
+                  "text": "CL: Chile"
                 },
                 "CM": {
-                  "text": "CM: Cameroon",
-                  "index": 46
+                  "index": 46,
+                  "text": "CM: Cameroon"
                 },
                 "CN": {
-                  "text": "CN: China",
-                  "index": 47
+                  "index": 47,
+                  "text": "CN: China"
                 },
                 "CO": {
-                  "text": "CO: Colombia",
-                  "index": 48
+                  "index": 48,
+                  "text": "CO: Colombia"
                 },
                 "CR": {
-                  "text": "CR: Costa Rica",
-                  "index": 49
+                  "index": 49,
+                  "text": "CR: Costa Rica"
                 },
                 "CU": {
-                  "text": "CU: Cuba",
-                  "index": 50
+                  "index": 50,
+                  "text": "CU: Cuba"
                 },
                 "CV": {
-                  "text": "CV: Cabo Verde",
-                  "index": 51
+                  "index": 51,
+                  "text": "CV: Cabo Verde"
                 },
                 "CW": {
-                  "text": "CW: Cura\u00e7ao",
-                  "index": 52
+                  "index": 52,
+                  "text": "CW: Curaçao"
                 },
                 "CX": {
-                  "text": "CX: Christmas Island",
-                  "index": 53
+                  "index": 53,
+                  "text": "CX: Christmas Island"
                 },
                 "CY": {
-                  "text": "CY: Cyprus",
-                  "index": 54
+                  "index": 54,
+                  "text": "CY: Cyprus"
                 },
                 "CZ": {
-                  "text": "CZ: Czechia",
-                  "index": 55
+                  "index": 55,
+                  "text": "CZ: Czechia"
                 },
                 "DE": {
-                  "text": "DE: Germany",
-                  "index": 56
+                  "index": 56,
+                  "text": "DE: Germany"
                 },
                 "DJ": {
-                  "text": "DJ: Djibouti",
-                  "index": 57
+                  "index": 57,
+                  "text": "DJ: Djibouti"
                 },
                 "DK": {
-                  "text": "DK: Denmark",
-                  "index": 58
+                  "index": 58,
+                  "text": "DK: Denmark"
                 },
                 "DM": {
-                  "text": "DM: Dominica",
-                  "index": 59
+                  "index": 59,
+                  "text": "DM: Dominica"
                 },
                 "DO": {
-                  "text": "DO: Dominican Republic",
-                  "index": 60
+                  "index": 60,
+                  "text": "DO: Dominican Republic"
                 },
                 "DZ": {
-                  "text": "DZ: Algeria",
-                  "index": 61
+                  "index": 61,
+                  "text": "DZ: Algeria"
                 },
                 "EC": {
-                  "text": "EC: Ecuador",
-                  "index": 62
+                  "index": 62,
+                  "text": "EC: Ecuador"
                 },
                 "EE": {
-                  "text": "EE: Estonia",
-                  "index": 63
+                  "index": 63,
+                  "text": "EE: Estonia"
                 },
                 "EG": {
-                  "text": "EG: Egypt",
-                  "index": 64
+                  "index": 64,
+                  "text": "EG: Egypt"
                 },
                 "EH": {
-                  "text": "EH: Western Sahara",
-                  "index": 65
+                  "index": 65,
+                  "text": "EH: Western Sahara"
                 },
                 "ER": {
-                  "text": "ER: Eritrea",
-                  "index": 66
+                  "index": 66,
+                  "text": "ER: Eritrea"
                 },
                 "ES": {
-                  "text": "ES: Spain",
-                  "index": 67
+                  "index": 67,
+                  "text": "ES: Spain"
                 },
                 "ET": {
-                  "text": "ET: Ethiopia",
-                  "index": 68
+                  "index": 68,
+                  "text": "ET: Ethiopia"
                 },
                 "FI": {
-                  "text": "FI: Finland",
-                  "index": 69
+                  "index": 69,
+                  "text": "FI: Finland"
                 },
                 "FJ": {
-                  "text": "FJ: Fiji",
-                  "index": 70
+                  "index": 70,
+                  "text": "FJ: Fiji"
                 },
                 "FK": {
-                  "text": "FK: Falkland Islands (Malvinas)",
-                  "index": 71
+                  "index": 71,
+                  "text": "FK: Falkland Islands (Malvinas)"
                 },
                 "FM": {
-                  "text": "FM: Micronesia, Federated States of",
-                  "index": 72
+                  "index": 72,
+                  "text": "FM: Micronesia, Federated States of"
                 },
                 "FO": {
-                  "text": "FO: Faroe Islands",
-                  "index": 73
+                  "index": 73,
+                  "text": "FO: Faroe Islands"
                 },
                 "FR": {
-                  "text": "FR: France",
-                  "index": 74
+                  "index": 74,
+                  "text": "FR: France"
                 },
                 "GA": {
-                  "text": "GA: Gabon",
-                  "index": 75
+                  "index": 75,
+                  "text": "GA: Gabon"
                 },
                 "GB": {
-                  "text": "GB: United Kingdom",
-                  "index": 76
+                  "index": 76,
+                  "text": "GB: United Kingdom"
                 },
                 "GD": {
-                  "text": "GD: Grenada",
-                  "index": 77
+                  "index": 77,
+                  "text": "GD: Grenada"
                 },
                 "GE": {
-                  "text": "GE: Georgia",
-                  "index": 78
+                  "index": 78,
+                  "text": "GE: Georgia"
                 },
                 "GF": {
-                  "text": "GF: French Guiana",
-                  "index": 79
+                  "index": 79,
+                  "text": "GF: French Guiana"
                 },
                 "GG": {
-                  "text": "GG: Guernsey",
-                  "index": 80
+                  "index": 80,
+                  "text": "GG: Guernsey"
                 },
                 "GH": {
-                  "text": "GH: Ghana",
-                  "index": 81
+                  "index": 81,
+                  "text": "GH: Ghana"
                 },
                 "GI": {
-                  "text": "GI: Gibraltar",
-                  "index": 82
+                  "index": 82,
+                  "text": "GI: Gibraltar"
                 },
                 "GL": {
-                  "text": "GL: Greenland",
-                  "index": 83
+                  "index": 83,
+                  "text": "GL: Greenland"
                 },
                 "GM": {
-                  "text": "GM: Gambia",
-                  "index": 84
+                  "index": 84,
+                  "text": "GM: Gambia"
                 },
                 "GN": {
-                  "text": "GN: Guinea",
-                  "index": 85
+                  "index": 85,
+                  "text": "GN: Guinea"
                 },
                 "GP": {
-                  "text": "GP: Guadeloupe",
-                  "index": 86
+                  "index": 86,
+                  "text": "GP: Guadeloupe"
                 },
                 "GQ": {
-                  "text": "GQ: Equatorial Guinea",
-                  "index": 87
+                  "index": 87,
+                  "text": "GQ: Equatorial Guinea"
                 },
                 "GR": {
-                  "text": "GR: Greece",
-                  "index": 88
+                  "index": 88,
+                  "text": "GR: Greece"
                 },
                 "GS": {
-                  "text": "GS: South Georgia and the South Sandwich Islands",
-                  "index": 89
+                  "index": 89,
+                  "text": "GS: South Georgia and the South Sandwich Islands"
                 },
                 "GT": {
-                  "text": "GT: Guatemala",
-                  "index": 90
+                  "index": 90,
+                  "text": "GT: Guatemala"
                 },
                 "GU": {
-                  "text": "GU: Guam",
-                  "index": 91
+                  "index": 91,
+                  "text": "GU: Guam"
                 },
                 "GW": {
-                  "text": "GW: Guinea-Bissau",
-                  "index": 92
+                  "index": 92,
+                  "text": "GW: Guinea-Bissau"
                 },
                 "GY": {
-                  "text": "GY: Guyana",
-                  "index": 93
+                  "index": 93,
+                  "text": "GY: Guyana"
                 },
                 "HK": {
-                  "text": "HK: Hong Kong",
-                  "index": 94
+                  "index": 94,
+                  "text": "HK: Hong Kong"
                 },
                 "HM": {
-                  "text": "HM: Heard Island and McDonald Islands",
-                  "index": 95
+                  "index": 95,
+                  "text": "HM: Heard Island and McDonald Islands"
                 },
                 "HN": {
-                  "text": "HN: Honduras",
-                  "index": 96
+                  "index": 96,
+                  "text": "HN: Honduras"
                 },
                 "HR": {
-                  "text": "HR: Croatia",
-                  "index": 97
+                  "index": 97,
+                  "text": "HR: Croatia"
                 },
                 "HT": {
-                  "text": "HT: Haiti",
-                  "index": 98
+                  "index": 98,
+                  "text": "HT: Haiti"
                 },
                 "HU": {
-                  "text": "HU: Hungary",
-                  "index": 99
+                  "index": 99,
+                  "text": "HU: Hungary"
                 },
                 "ID": {
-                  "text": "ID: Indonesia",
-                  "index": 100
+                  "index": 100,
+                  "text": "ID: Indonesia"
                 },
                 "IE": {
-                  "text": "IE: Ireland",
-                  "index": 101
+                  "index": 101,
+                  "text": "IE: Ireland"
                 },
                 "IL": {
-                  "text": "IL: Israel",
-                  "index": 102
+                  "index": 102,
+                  "text": "IL: Israel"
                 },
                 "IM": {
-                  "text": "IM: Isle of Man",
-                  "index": 103
+                  "index": 103,
+                  "text": "IM: Isle of Man"
                 },
                 "IN": {
-                  "text": "IN: India",
-                  "index": 104
+                  "index": 104,
+                  "text": "IN: India"
                 },
                 "IO": {
-                  "text": "IO: British Indian Ocean Territory",
-                  "index": 105
+                  "index": 105,
+                  "text": "IO: British Indian Ocean Territory"
                 },
                 "IQ": {
-                  "text": "IQ: Iraq",
-                  "index": 106
+                  "index": 106,
+                  "text": "IQ: Iraq"
                 },
                 "IR": {
-                  "text": "IR: Iran, Islamic Republic of",
-                  "index": 107
+                  "index": 107,
+                  "text": "IR: Iran, Islamic Republic of"
                 },
                 "IS": {
-                  "text": "IS: Iceland",
-                  "index": 108
+                  "index": 108,
+                  "text": "IS: Iceland"
                 },
                 "IT": {
-                  "text": "IT: Italy",
-                  "index": 109
+                  "index": 109,
+                  "text": "IT: Italy"
                 },
                 "JE": {
-                  "text": "JE: Jersey",
-                  "index": 110
+                  "index": 110,
+                  "text": "JE: Jersey"
                 },
                 "JM": {
-                  "text": "JM: Jamaica",
-                  "index": 111
+                  "index": 111,
+                  "text": "JM: Jamaica"
                 },
                 "JO": {
-                  "text": "JO: Jordan",
-                  "index": 112
+                  "index": 112,
+                  "text": "JO: Jordan"
                 },
                 "JP": {
-                  "text": "JP: Japan",
-                  "index": 113
+                  "index": 113,
+                  "text": "JP: Japan"
                 },
                 "KE": {
-                  "text": "KE: Kenya",
-                  "index": 114
+                  "index": 114,
+                  "text": "KE: Kenya"
                 },
                 "KG": {
-                  "text": "KG: Kyrgyzstan",
-                  "index": 115
+                  "index": 115,
+                  "text": "KG: Kyrgyzstan"
                 },
                 "KH": {
-                  "text": "KH: Cambodia",
-                  "index": 116
+                  "index": 116,
+                  "text": "KH: Cambodia"
                 },
                 "KI": {
-                  "text": "KI: Kiribati",
-                  "index": 117
+                  "index": 117,
+                  "text": "KI: Kiribati"
                 },
                 "KM": {
-                  "text": "KM: Comoros",
-                  "index": 118
+                  "index": 118,
+                  "text": "KM: Comoros"
                 },
                 "KN": {
-                  "text": "KN: Saint Kitts and Nevis",
-                  "index": 119
+                  "index": 119,
+                  "text": "KN: Saint Kitts and Nevis"
                 },
                 "KP": {
-                  "text": "KP: Korea, Democratic People's Republic of",
-                  "index": 120
+                  "index": 120,
+                  "text": "KP: Korea, Democratic People's Republic of"
                 },
                 "KR": {
-                  "text": "KR: Korea, Republic of",
-                  "index": 121
+                  "index": 121,
+                  "text": "KR: Korea, Republic of"
                 },
                 "KW": {
-                  "text": "KW: Kuwait",
-                  "index": 122
+                  "index": 122,
+                  "text": "KW: Kuwait"
                 },
                 "KY": {
-                  "text": "KY: Cayman Islands",
-                  "index": 123
+                  "index": 123,
+                  "text": "KY: Cayman Islands"
                 },
                 "KZ": {
-                  "text": "KZ: Kazakhstan",
-                  "index": 124
+                  "index": 124,
+                  "text": "KZ: Kazakhstan"
                 },
                 "LA": {
-                  "text": "LA: Lao People's Democratic Republic",
-                  "index": 125
+                  "index": 125,
+                  "text": "LA: Lao People's Democratic Republic"
                 },
                 "LB": {
-                  "text": "LB: Lebanon",
-                  "index": 126
+                  "index": 126,
+                  "text": "LB: Lebanon"
                 },
                 "LC": {
-                  "text": "LC: Saint Lucia",
-                  "index": 127
+                  "index": 127,
+                  "text": "LC: Saint Lucia"
                 },
                 "LI": {
-                  "text": "LI: Liechtenstein",
-                  "index": 128
+                  "index": 128,
+                  "text": "LI: Liechtenstein"
                 },
                 "LK": {
-                  "text": "LK: Sri Lanka",
-                  "index": 129
+                  "index": 129,
+                  "text": "LK: Sri Lanka"
                 },
                 "LR": {
-                  "text": "LR: Liberia",
-                  "index": 130
+                  "index": 130,
+                  "text": "LR: Liberia"
                 },
                 "LS": {
-                  "text": "LS: Lesotho",
-                  "index": 131
+                  "index": 131,
+                  "text": "LS: Lesotho"
                 },
                 "LT": {
-                  "text": "LT: Lithuania",
-                  "index": 132
+                  "index": 132,
+                  "text": "LT: Lithuania"
                 },
                 "LU": {
-                  "text": "LU: Luxembourg",
-                  "index": 133
+                  "index": 133,
+                  "text": "LU: Luxembourg"
                 },
                 "LV": {
-                  "text": "LV: Latvia",
-                  "index": 134
+                  "index": 134,
+                  "text": "LV: Latvia"
                 },
                 "LY": {
-                  "text": "LY: Libya",
-                  "index": 135
+                  "index": 135,
+                  "text": "LY: Libya"
                 },
                 "MA": {
-                  "text": "MA: Morocco",
-                  "index": 136
+                  "index": 136,
+                  "text": "MA: Morocco"
                 },
                 "MC": {
-                  "text": "MC: Monaco",
-                  "index": 137
+                  "index": 137,
+                  "text": "MC: Monaco"
                 },
                 "MD": {
-                  "text": "MD: Moldova, Republic of",
-                  "index": 138
+                  "index": 138,
+                  "text": "MD: Moldova, Republic of"
                 },
                 "ME": {
-                  "text": "ME: Montenegro",
-                  "index": 139
+                  "index": 139,
+                  "text": "ME: Montenegro"
                 },
                 "MF": {
-                  "text": "MF: Saint Martin (French part)",
-                  "index": 140
+                  "index": 140,
+                  "text": "MF: Saint Martin (French part)"
                 },
                 "MG": {
-                  "text": "MG: Madagascar",
-                  "index": 141
+                  "index": 141,
+                  "text": "MG: Madagascar"
                 },
                 "MH": {
-                  "text": "MH: Marshall Islands",
-                  "index": 142
+                  "index": 142,
+                  "text": "MH: Marshall Islands"
                 },
                 "MK": {
-                  "text": "MK: North Macedonia",
-                  "index": 143
+                  "index": 143,
+                  "text": "MK: North Macedonia"
                 },
                 "ML": {
-                  "text": "ML: Mali",
-                  "index": 144
+                  "index": 144,
+                  "text": "ML: Mali"
                 },
                 "MM": {
-                  "text": "MM: Myanmar",
-                  "index": 145
+                  "index": 145,
+                  "text": "MM: Myanmar"
                 },
                 "MN": {
-                  "text": "MN: Mongolia",
-                  "index": 146
+                  "index": 146,
+                  "text": "MN: Mongolia"
                 },
                 "MO": {
-                  "text": "MO: Macao",
-                  "index": 147
+                  "index": 147,
+                  "text": "MO: Macao"
                 },
                 "MP": {
-                  "text": "MP: Northern Mariana Islands",
-                  "index": 148
+                  "index": 148,
+                  "text": "MP: Northern Mariana Islands"
                 },
                 "MQ": {
-                  "text": "MQ: Martinique",
-                  "index": 149
+                  "index": 149,
+                  "text": "MQ: Martinique"
                 },
                 "MR": {
-                  "text": "MR: Mauritania",
-                  "index": 150
+                  "index": 150,
+                  "text": "MR: Mauritania"
                 },
                 "MS": {
-                  "text": "MS: Montserrat",
-                  "index": 151
+                  "index": 151,
+                  "text": "MS: Montserrat"
                 },
                 "MT": {
-                  "text": "MT: Malta",
-                  "index": 152
+                  "index": 152,
+                  "text": "MT: Malta"
                 },
                 "MU": {
-                  "text": "MU: Mauritius",
-                  "index": 153
+                  "index": 153,
+                  "text": "MU: Mauritius"
                 },
                 "MV": {
-                  "text": "MV: Maldives",
-                  "index": 154
+                  "index": 154,
+                  "text": "MV: Maldives"
                 },
                 "MW": {
-                  "text": "MW: Malawi",
-                  "index": 155
+                  "index": 155,
+                  "text": "MW: Malawi"
                 },
                 "MX": {
-                  "text": "MX: Mexico",
-                  "index": 156
+                  "index": 156,
+                  "text": "MX: Mexico"
                 },
                 "MY": {
-                  "text": "MY: Malaysia",
-                  "index": 157
+                  "index": 157,
+                  "text": "MY: Malaysia"
                 },
                 "MZ": {
-                  "text": "MZ: Mozambique",
-                  "index": 158
+                  "index": 158,
+                  "text": "MZ: Mozambique"
                 },
                 "NA": {
-                  "text": "NA: Namibia",
-                  "index": 159
+                  "index": 159,
+                  "text": "NA: Namibia"
                 },
                 "NC": {
-                  "text": "NC: New Caledonia",
-                  "index": 160
+                  "index": 160,
+                  "text": "NC: New Caledonia"
                 },
                 "NE": {
-                  "text": "NE: Niger",
-                  "index": 161
+                  "index": 161,
+                  "text": "NE: Niger"
                 },
                 "NF": {
-                  "text": "NF: Norfolk Island",
-                  "index": 162
+                  "index": 162,
+                  "text": "NF: Norfolk Island"
                 },
                 "NG": {
-                  "text": "NG: Nigeria",
-                  "index": 163
+                  "index": 163,
+                  "text": "NG: Nigeria"
                 },
                 "NI": {
-                  "text": "NI: Nicaragua",
-                  "index": 164
+                  "index": 164,
+                  "text": "NI: Nicaragua"
                 },
                 "NL": {
-                  "text": "NL: Netherlands",
-                  "index": 165
+                  "index": 165,
+                  "text": "NL: Netherlands"
                 },
                 "NO": {
-                  "text": "NO: Norway",
-                  "index": 166
+                  "index": 166,
+                  "text": "NO: Norway"
                 },
                 "NP": {
-                  "text": "NP: Nepal",
-                  "index": 167
+                  "index": 167,
+                  "text": "NP: Nepal"
                 },
                 "NR": {
-                  "text": "NR: Nauru",
-                  "index": 168
+                  "index": 168,
+                  "text": "NR: Nauru"
                 },
                 "NU": {
-                  "text": "NU: Niue",
-                  "index": 169
+                  "index": 169,
+                  "text": "NU: Niue"
                 },
                 "NZ": {
-                  "text": "NZ: New Zealand",
-                  "index": 170
+                  "index": 170,
+                  "text": "NZ: New Zealand"
                 },
                 "OM": {
-                  "text": "OM: Oman",
-                  "index": 171
+                  "index": 171,
+                  "text": "OM: Oman"
                 },
                 "PA": {
-                  "text": "PA: Panama",
-                  "index": 172
+                  "index": 172,
+                  "text": "PA: Panama"
                 },
                 "PE": {
-                  "text": "PE: Peru",
-                  "index": 173
+                  "index": 173,
+                  "text": "PE: Peru"
                 },
                 "PF": {
-                  "text": "PF: French Polynesia",
-                  "index": 174
+                  "index": 174,
+                  "text": "PF: French Polynesia"
                 },
                 "PG": {
-                  "text": "PG: Papua New Guinea",
-                  "index": 175
+                  "index": 175,
+                  "text": "PG: Papua New Guinea"
                 },
                 "PH": {
-                  "text": "PH: Philippines",
-                  "index": 176
+                  "index": 176,
+                  "text": "PH: Philippines"
                 },
                 "PK": {
-                  "text": "PK: Pakistan",
-                  "index": 177
+                  "index": 177,
+                  "text": "PK: Pakistan"
                 },
                 "PL": {
-                  "text": "PL: Poland",
-                  "index": 178
+                  "index": 178,
+                  "text": "PL: Poland"
                 },
                 "PM": {
-                  "text": "PM: Saint Pierre and Miquelon",
-                  "index": 179
+                  "index": 179,
+                  "text": "PM: Saint Pierre and Miquelon"
                 },
                 "PN": {
-                  "text": "PN: Pitcairn",
-                  "index": 180
+                  "index": 180,
+                  "text": "PN: Pitcairn"
                 },
                 "PR": {
-                  "text": "PR: Puerto Rico",
-                  "index": 181
+                  "index": 181,
+                  "text": "PR: Puerto Rico"
                 },
                 "PS": {
-                  "text": "PS: Palestine, State of",
-                  "index": 182
+                  "index": 182,
+                  "text": "PS: Palestine, State of"
                 },
                 "PT": {
-                  "text": "PT: Portugal",
-                  "index": 183
+                  "index": 183,
+                  "text": "PT: Portugal"
                 },
                 "PW": {
-                  "text": "PW: Palau",
-                  "index": 184
+                  "index": 184,
+                  "text": "PW: Palau"
                 },
                 "PY": {
-                  "text": "PY: Paraguay",
-                  "index": 185
+                  "index": 185,
+                  "text": "PY: Paraguay"
                 },
                 "QA": {
-                  "text": "QA: Qatar",
-                  "index": 186
+                  "index": 186,
+                  "text": "QA: Qatar"
                 },
                 "RE": {
-                  "text": "RE: R\u00e9union",
-                  "index": 187
+                  "index": 187,
+                  "text": "RE: Réunion"
                 },
                 "RO": {
-                  "text": "RO: Romania",
-                  "index": 188
+                  "index": 188,
+                  "text": "RO: Romania"
                 },
                 "RS": {
-                  "text": "RS: Serbia",
-                  "index": 189
+                  "index": 189,
+                  "text": "RS: Serbia"
                 },
                 "RU": {
-                  "text": "RU: Russian Federation",
-                  "index": 190
+                  "index": 190,
+                  "text": "RU: Russian Federation"
                 },
                 "RW": {
-                  "text": "RW: Rwanda",
-                  "index": 191
+                  "index": 191,
+                  "text": "RW: Rwanda"
                 },
                 "SA": {
-                  "text": "SA: Saudi Arabia",
-                  "index": 192
+                  "index": 192,
+                  "text": "SA: Saudi Arabia"
                 },
                 "SB": {
-                  "text": "SB: Solomon Islands",
-                  "index": 193
+                  "index": 193,
+                  "text": "SB: Solomon Islands"
                 },
                 "SC": {
-                  "text": "SC: Seychelles",
-                  "index": 194
+                  "index": 194,
+                  "text": "SC: Seychelles"
                 },
                 "SD": {
-                  "text": "SD: Sudan",
-                  "index": 195
+                  "index": 195,
+                  "text": "SD: Sudan"
                 },
                 "SE": {
-                  "text": "SE: Sweden",
-                  "index": 196
+                  "index": 196,
+                  "text": "SE: Sweden"
                 },
                 "SG": {
-                  "text": "SG: Singapore",
-                  "index": 197
+                  "index": 197,
+                  "text": "SG: Singapore"
                 },
                 "SH": {
-                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha",
-                  "index": 198
+                  "index": 198,
+                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha"
                 },
                 "SI": {
-                  "text": "SI: Slovenia",
-                  "index": 199
+                  "index": 199,
+                  "text": "SI: Slovenia"
                 },
                 "SJ": {
-                  "text": "SJ: Svalbard and Jan Mayen",
-                  "index": 200
+                  "index": 200,
+                  "text": "SJ: Svalbard and Jan Mayen"
                 },
                 "SK": {
-                  "text": "SK: Slovakia",
-                  "index": 201
+                  "index": 201,
+                  "text": "SK: Slovakia"
                 },
                 "SL": {
-                  "text": "SL: Sierra Leone",
-                  "index": 202
+                  "index": 202,
+                  "text": "SL: Sierra Leone"
                 },
                 "SM": {
-                  "text": "SM: San Marino",
-                  "index": 203
+                  "index": 203,
+                  "text": "SM: San Marino"
                 },
                 "SN": {
-                  "text": "SN: Senegal",
-                  "index": 204
+                  "index": 204,
+                  "text": "SN: Senegal"
                 },
                 "SO": {
-                  "text": "SO: Somalia",
-                  "index": 205
+                  "index": 205,
+                  "text": "SO: Somalia"
                 },
                 "SR": {
-                  "text": "SR: Suriname",
-                  "index": 206
+                  "index": 206,
+                  "text": "SR: Suriname"
                 },
                 "SS": {
-                  "text": "SS: South Sudan",
-                  "index": 207
+                  "index": 207,
+                  "text": "SS: South Sudan"
                 },
                 "ST": {
-                  "text": "ST: Sao Tome and Principe",
-                  "index": 208
+                  "index": 208,
+                  "text": "ST: Sao Tome and Principe"
                 },
                 "SV": {
-                  "text": "SV: El Salvador",
-                  "index": 209
+                  "index": 209,
+                  "text": "SV: El Salvador"
                 },
                 "SX": {
-                  "text": "SX: Sint Maarten (Dutch part)",
-                  "index": 210
+                  "index": 210,
+                  "text": "SX: Sint Maarten (Dutch part)"
                 },
                 "SY": {
-                  "text": "SY: Syrian Arab Republic",
-                  "index": 211
+                  "index": 211,
+                  "text": "SY: Syrian Arab Republic"
                 },
                 "SZ": {
-                  "text": "SZ: Eswatini",
-                  "index": 212
+                  "index": 212,
+                  "text": "SZ: Eswatini"
                 },
                 "TC": {
-                  "text": "TC: Turks and Caicos Islands",
-                  "index": 213
+                  "index": 213,
+                  "text": "TC: Turks and Caicos Islands"
                 },
                 "TD": {
-                  "text": "TD: Chad",
-                  "index": 214
+                  "index": 214,
+                  "text": "TD: Chad"
                 },
                 "TF": {
-                  "text": "TF: French Southern Territories",
-                  "index": 215
+                  "index": 215,
+                  "text": "TF: French Southern Territories"
                 },
                 "TG": {
-                  "text": "TG: Togo",
-                  "index": 216
+                  "index": 216,
+                  "text": "TG: Togo"
                 },
                 "TH": {
-                  "text": "TH: Thailand",
-                  "index": 217
+                  "index": 217,
+                  "text": "TH: Thailand"
                 },
                 "TJ": {
-                  "text": "TJ: Tajikistan",
-                  "index": 218
+                  "index": 218,
+                  "text": "TJ: Tajikistan"
                 },
                 "TK": {
-                  "text": "TK: Tokelau",
-                  "index": 219
+                  "index": 219,
+                  "text": "TK: Tokelau"
                 },
                 "TL": {
-                  "text": "TL: Timor-Leste",
-                  "index": 220
+                  "index": 220,
+                  "text": "TL: Timor-Leste"
                 },
                 "TM": {
-                  "text": "TM: Turkmenistan",
-                  "index": 221
+                  "index": 221,
+                  "text": "TM: Turkmenistan"
                 },
                 "TN": {
-                  "text": "TN: Tunisia",
-                  "index": 222
+                  "index": 222,
+                  "text": "TN: Tunisia"
                 },
                 "TO": {
-                  "text": "TO: Tonga",
-                  "index": 223
+                  "index": 223,
+                  "text": "TO: Tonga"
                 },
                 "TR": {
-                  "text": "TR: T\u00fcrkiye",
-                  "index": 224
+                  "index": 224,
+                  "text": "TR: Türkiye"
                 },
                 "TT": {
-                  "text": "TT: Trinidad and Tobago",
-                  "index": 225
+                  "index": 225,
+                  "text": "TT: Trinidad and Tobago"
                 },
                 "TV": {
-                  "text": "TV: Tuvalu",
-                  "index": 226
+                  "index": 226,
+                  "text": "TV: Tuvalu"
                 },
                 "TW": {
-                  "text": "TW: Taiwan, Province of China",
-                  "index": 227
+                  "index": 227,
+                  "text": "TW: Taiwan, Province of China"
                 },
                 "TZ": {
-                  "text": "TZ: Tanzania, United Republic of",
-                  "index": 228
+                  "index": 228,
+                  "text": "TZ: Tanzania, United Republic of"
                 },
                 "UA": {
-                  "text": "UA: Ukraine",
-                  "index": 229
+                  "index": 229,
+                  "text": "UA: Ukraine"
                 },
                 "UG": {
-                  "text": "UG: Uganda",
-                  "index": 230
+                  "index": 230,
+                  "text": "UG: Uganda"
                 },
                 "UM": {
-                  "text": "UM: United States Minor Outlying Islands",
-                  "index": 231
+                  "index": 231,
+                  "text": "UM: United States Minor Outlying Islands"
                 },
                 "US": {
-                  "text": "US: United States",
-                  "index": 232
+                  "index": 232,
+                  "text": "US: United States"
                 },
                 "UY": {
-                  "text": "UY: Uruguay",
-                  "index": 233
+                  "index": 233,
+                  "text": "UY: Uruguay"
                 },
                 "UZ": {
-                  "text": "UZ: Uzbekistan",
-                  "index": 234
+                  "index": 234,
+                  "text": "UZ: Uzbekistan"
                 },
                 "VA": {
-                  "text": "VA: Holy See (Vatican City State)",
-                  "index": 235
+                  "index": 235,
+                  "text": "VA: Holy See (Vatican City State)"
                 },
                 "VC": {
-                  "text": "VC: Saint Vincent and the Grenadines",
-                  "index": 236
+                  "index": 236,
+                  "text": "VC: Saint Vincent and the Grenadines"
                 },
                 "VE": {
-                  "text": "VE: Venezuela, Bolivarian Republic of",
-                  "index": 237
+                  "index": 237,
+                  "text": "VE: Venezuela, Bolivarian Republic of"
                 },
                 "VG": {
-                  "text": "VG: Virgin Islands, British",
-                  "index": 238
+                  "index": 238,
+                  "text": "VG: Virgin Islands, British"
                 },
                 "VI": {
-                  "text": "VI: Virgin Islands, U.S.",
-                  "index": 239
+                  "index": 239,
+                  "text": "VI: Virgin Islands, U.S."
                 },
                 "VN": {
-                  "text": "VN: Viet Nam",
-                  "index": 240
+                  "index": 240,
+                  "text": "VN: Viet Nam"
                 },
                 "VU": {
-                  "text": "VU: Vanuatu",
-                  "index": 241
+                  "index": 241,
+                  "text": "VU: Vanuatu"
                 },
                 "WF": {
-                  "text": "WF: Wallis and Futuna",
-                  "index": 242
+                  "index": 242,
+                  "text": "WF: Wallis and Futuna"
                 },
                 "WS": {
-                  "text": "WS: Samoa",
-                  "index": 243
+                  "index": 243,
+                  "text": "WS: Samoa"
                 },
                 "YE": {
-                  "text": "YE: Yemen",
-                  "index": 244
+                  "index": 244,
+                  "text": "YE: Yemen"
                 },
                 "YT": {
-                  "text": "YT: Mayotte",
-                  "index": 245
+                  "index": 245,
+                  "text": "YT: Mayotte"
                 },
                 "ZA": {
-                  "text": "ZA: South Africa",
-                  "index": 246
+                  "index": 246,
+                  "text": "ZA: South Africa"
                 },
                 "ZM": {
-                  "text": "ZM: Zambia",
-                  "index": 247
+                  "index": 247,
+                  "text": "ZM: Zambia"
                 },
                 "ZW": {
-                  "text": "ZW: Zimbabwe",
-                  "index": 248
+                  "index": 248,
+                  "text": "ZW: Zimbabwe"
                 }
-              }
+              },
+              "type": "value"
             }
           ],
           "thresholds": {
@@ -5905,7 +7983,11 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
@@ -5919,142 +8001,30 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 100
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Download"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Upload"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
+                "value": 264
               }
             ]
           }
         ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 50
+        "h": 37,
+        "w": 12,
+        "x": 12,
+        "y": 90
       },
-      "id": 13,
+      "id": 14,
       "options": {
-        "showHeader": true,
         "cellHeight": "sm",
-        "footer": {
-          "show": true,
-          "reducer": [
-            "sum"
-          ],
-          "countRows": false,
-          "fields": [
-            "Connected",
-            "Download",
-            "Upload"
-          ]
-        },
+        "showHeader": true,
         "sortBy": [
           {
-            "displayName": "Connected",
-            "desc": true
+            "desc": true,
+            "displayName": "Mean"
           }
         ]
       },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "last_over_time((sum by (region) (conduit_region_connected_clients))[5m:])",
-          "format": "table",
-          "instant": true,
-          "refId": "Connected"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "last_over_time((sum by (region) (conduit_region_bytes_downloaded))[5m:])",
-          "format": "table",
-          "instant": true,
-          "refId": "Download"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "last_over_time((sum by (region) (conduit_region_bytes_uploaded))[5m:])",
-          "format": "table",
-          "instant": true,
-          "refId": "Upload"
-        }
-      ],
-      "title": "Traffic by Region",
-      "description": "Current connected clients and cumulative traffic per region",
-      "transformations": [
-        {
-          "id": "seriesToColumns",
-          "options": {
-            "byField": "region"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true
-            },
-            "renameByName": {
-              "region": "Region",
-              "Value #Connected": "Connected",
-              "Value #Download": "Download",
-              "Value #Upload": "Upload"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "id": 14,
-      "title": "Connected Clients by Region \u2014 Stats",
-      "type": "table",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 40
-      },
-      "pluginVersion": "10.4.1",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -6066,6 +8036,7 @@
           "refId": "A"
         }
       ],
+      "title": "Connected Clients by Region — Stats",
       "transformations": [
         {
           "id": "reduce",
@@ -6088,1179 +8059,48 @@
           }
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "AD": {
-                  "text": "AD: Andorra",
-                  "index": 0
-                },
-                "AE": {
-                  "text": "AE: United Arab Emirates",
-                  "index": 1
-                },
-                "AF": {
-                  "text": "AF: Afghanistan",
-                  "index": 2
-                },
-                "AG": {
-                  "text": "AG: Antigua and Barbuda",
-                  "index": 3
-                },
-                "AI": {
-                  "text": "AI: Anguilla",
-                  "index": 4
-                },
-                "AL": {
-                  "text": "AL: Albania",
-                  "index": 5
-                },
-                "AM": {
-                  "text": "AM: Armenia",
-                  "index": 6
-                },
-                "AO": {
-                  "text": "AO: Angola",
-                  "index": 7
-                },
-                "AQ": {
-                  "text": "AQ: Antarctica",
-                  "index": 8
-                },
-                "AR": {
-                  "text": "AR: Argentina",
-                  "index": 9
-                },
-                "AS": {
-                  "text": "AS: American Samoa",
-                  "index": 10
-                },
-                "AT": {
-                  "text": "AT: Austria",
-                  "index": 11
-                },
-                "AU": {
-                  "text": "AU: Australia",
-                  "index": 12
-                },
-                "AW": {
-                  "text": "AW: Aruba",
-                  "index": 13
-                },
-                "AX": {
-                  "text": "AX: \u00c5land Islands",
-                  "index": 14
-                },
-                "AZ": {
-                  "text": "AZ: Azerbaijan",
-                  "index": 15
-                },
-                "BA": {
-                  "text": "BA: Bosnia and Herzegovina",
-                  "index": 16
-                },
-                "BB": {
-                  "text": "BB: Barbados",
-                  "index": 17
-                },
-                "BD": {
-                  "text": "BD: Bangladesh",
-                  "index": 18
-                },
-                "BE": {
-                  "text": "BE: Belgium",
-                  "index": 19
-                },
-                "BF": {
-                  "text": "BF: Burkina Faso",
-                  "index": 20
-                },
-                "BG": {
-                  "text": "BG: Bulgaria",
-                  "index": 21
-                },
-                "BH": {
-                  "text": "BH: Bahrain",
-                  "index": 22
-                },
-                "BI": {
-                  "text": "BI: Burundi",
-                  "index": 23
-                },
-                "BJ": {
-                  "text": "BJ: Benin",
-                  "index": 24
-                },
-                "BL": {
-                  "text": "BL: Saint Barth\u00e9lemy",
-                  "index": 25
-                },
-                "BM": {
-                  "text": "BM: Bermuda",
-                  "index": 26
-                },
-                "BN": {
-                  "text": "BN: Brunei Darussalam",
-                  "index": 27
-                },
-                "BO": {
-                  "text": "BO: Bolivia, Plurinational State of",
-                  "index": 28
-                },
-                "BQ": {
-                  "text": "BQ: Bonaire, Sint Eustatius and Saba",
-                  "index": 29
-                },
-                "BR": {
-                  "text": "BR: Brazil",
-                  "index": 30
-                },
-                "BS": {
-                  "text": "BS: Bahamas",
-                  "index": 31
-                },
-                "BT": {
-                  "text": "BT: Bhutan",
-                  "index": 32
-                },
-                "BV": {
-                  "text": "BV: Bouvet Island",
-                  "index": 33
-                },
-                "BW": {
-                  "text": "BW: Botswana",
-                  "index": 34
-                },
-                "BY": {
-                  "text": "BY: Belarus",
-                  "index": 35
-                },
-                "BZ": {
-                  "text": "BZ: Belize",
-                  "index": 36
-                },
-                "CA": {
-                  "text": "CA: Canada",
-                  "index": 37
-                },
-                "CC": {
-                  "text": "CC: Cocos (Keeling) Islands",
-                  "index": 38
-                },
-                "CD": {
-                  "text": "CD: Congo, The Democratic Republic of the",
-                  "index": 39
-                },
-                "CF": {
-                  "text": "CF: Central African Republic",
-                  "index": 40
-                },
-                "CG": {
-                  "text": "CG: Congo",
-                  "index": 41
-                },
-                "CH": {
-                  "text": "CH: Switzerland",
-                  "index": 42
-                },
-                "CI": {
-                  "text": "CI: C\u00f4te d'Ivoire",
-                  "index": 43
-                },
-                "CK": {
-                  "text": "CK: Cook Islands",
-                  "index": 44
-                },
-                "CL": {
-                  "text": "CL: Chile",
-                  "index": 45
-                },
-                "CM": {
-                  "text": "CM: Cameroon",
-                  "index": 46
-                },
-                "CN": {
-                  "text": "CN: China",
-                  "index": 47
-                },
-                "CO": {
-                  "text": "CO: Colombia",
-                  "index": 48
-                },
-                "CR": {
-                  "text": "CR: Costa Rica",
-                  "index": 49
-                },
-                "CU": {
-                  "text": "CU: Cuba",
-                  "index": 50
-                },
-                "CV": {
-                  "text": "CV: Cabo Verde",
-                  "index": 51
-                },
-                "CW": {
-                  "text": "CW: Cura\u00e7ao",
-                  "index": 52
-                },
-                "CX": {
-                  "text": "CX: Christmas Island",
-                  "index": 53
-                },
-                "CY": {
-                  "text": "CY: Cyprus",
-                  "index": 54
-                },
-                "CZ": {
-                  "text": "CZ: Czechia",
-                  "index": 55
-                },
-                "DE": {
-                  "text": "DE: Germany",
-                  "index": 56
-                },
-                "DJ": {
-                  "text": "DJ: Djibouti",
-                  "index": 57
-                },
-                "DK": {
-                  "text": "DK: Denmark",
-                  "index": 58
-                },
-                "DM": {
-                  "text": "DM: Dominica",
-                  "index": 59
-                },
-                "DO": {
-                  "text": "DO: Dominican Republic",
-                  "index": 60
-                },
-                "DZ": {
-                  "text": "DZ: Algeria",
-                  "index": 61
-                },
-                "EC": {
-                  "text": "EC: Ecuador",
-                  "index": 62
-                },
-                "EE": {
-                  "text": "EE: Estonia",
-                  "index": 63
-                },
-                "EG": {
-                  "text": "EG: Egypt",
-                  "index": 64
-                },
-                "EH": {
-                  "text": "EH: Western Sahara",
-                  "index": 65
-                },
-                "ER": {
-                  "text": "ER: Eritrea",
-                  "index": 66
-                },
-                "ES": {
-                  "text": "ES: Spain",
-                  "index": 67
-                },
-                "ET": {
-                  "text": "ET: Ethiopia",
-                  "index": 68
-                },
-                "FI": {
-                  "text": "FI: Finland",
-                  "index": 69
-                },
-                "FJ": {
-                  "text": "FJ: Fiji",
-                  "index": 70
-                },
-                "FK": {
-                  "text": "FK: Falkland Islands (Malvinas)",
-                  "index": 71
-                },
-                "FM": {
-                  "text": "FM: Micronesia, Federated States of",
-                  "index": 72
-                },
-                "FO": {
-                  "text": "FO: Faroe Islands",
-                  "index": 73
-                },
-                "FR": {
-                  "text": "FR: France",
-                  "index": 74
-                },
-                "GA": {
-                  "text": "GA: Gabon",
-                  "index": 75
-                },
-                "GB": {
-                  "text": "GB: United Kingdom",
-                  "index": 76
-                },
-                "GD": {
-                  "text": "GD: Grenada",
-                  "index": 77
-                },
-                "GE": {
-                  "text": "GE: Georgia",
-                  "index": 78
-                },
-                "GF": {
-                  "text": "GF: French Guiana",
-                  "index": 79
-                },
-                "GG": {
-                  "text": "GG: Guernsey",
-                  "index": 80
-                },
-                "GH": {
-                  "text": "GH: Ghana",
-                  "index": 81
-                },
-                "GI": {
-                  "text": "GI: Gibraltar",
-                  "index": 82
-                },
-                "GL": {
-                  "text": "GL: Greenland",
-                  "index": 83
-                },
-                "GM": {
-                  "text": "GM: Gambia",
-                  "index": 84
-                },
-                "GN": {
-                  "text": "GN: Guinea",
-                  "index": 85
-                },
-                "GP": {
-                  "text": "GP: Guadeloupe",
-                  "index": 86
-                },
-                "GQ": {
-                  "text": "GQ: Equatorial Guinea",
-                  "index": 87
-                },
-                "GR": {
-                  "text": "GR: Greece",
-                  "index": 88
-                },
-                "GS": {
-                  "text": "GS: South Georgia and the South Sandwich Islands",
-                  "index": 89
-                },
-                "GT": {
-                  "text": "GT: Guatemala",
-                  "index": 90
-                },
-                "GU": {
-                  "text": "GU: Guam",
-                  "index": 91
-                },
-                "GW": {
-                  "text": "GW: Guinea-Bissau",
-                  "index": 92
-                },
-                "GY": {
-                  "text": "GY: Guyana",
-                  "index": 93
-                },
-                "HK": {
-                  "text": "HK: Hong Kong",
-                  "index": 94
-                },
-                "HM": {
-                  "text": "HM: Heard Island and McDonald Islands",
-                  "index": 95
-                },
-                "HN": {
-                  "text": "HN: Honduras",
-                  "index": 96
-                },
-                "HR": {
-                  "text": "HR: Croatia",
-                  "index": 97
-                },
-                "HT": {
-                  "text": "HT: Haiti",
-                  "index": 98
-                },
-                "HU": {
-                  "text": "HU: Hungary",
-                  "index": 99
-                },
-                "ID": {
-                  "text": "ID: Indonesia",
-                  "index": 100
-                },
-                "IE": {
-                  "text": "IE: Ireland",
-                  "index": 101
-                },
-                "IL": {
-                  "text": "IL: Israel",
-                  "index": 102
-                },
-                "IM": {
-                  "text": "IM: Isle of Man",
-                  "index": 103
-                },
-                "IN": {
-                  "text": "IN: India",
-                  "index": 104
-                },
-                "IO": {
-                  "text": "IO: British Indian Ocean Territory",
-                  "index": 105
-                },
-                "IQ": {
-                  "text": "IQ: Iraq",
-                  "index": 106
-                },
-                "IR": {
-                  "text": "IR: Iran, Islamic Republic of",
-                  "index": 107
-                },
-                "IS": {
-                  "text": "IS: Iceland",
-                  "index": 108
-                },
-                "IT": {
-                  "text": "IT: Italy",
-                  "index": 109
-                },
-                "JE": {
-                  "text": "JE: Jersey",
-                  "index": 110
-                },
-                "JM": {
-                  "text": "JM: Jamaica",
-                  "index": 111
-                },
-                "JO": {
-                  "text": "JO: Jordan",
-                  "index": 112
-                },
-                "JP": {
-                  "text": "JP: Japan",
-                  "index": 113
-                },
-                "KE": {
-                  "text": "KE: Kenya",
-                  "index": 114
-                },
-                "KG": {
-                  "text": "KG: Kyrgyzstan",
-                  "index": 115
-                },
-                "KH": {
-                  "text": "KH: Cambodia",
-                  "index": 116
-                },
-                "KI": {
-                  "text": "KI: Kiribati",
-                  "index": 117
-                },
-                "KM": {
-                  "text": "KM: Comoros",
-                  "index": 118
-                },
-                "KN": {
-                  "text": "KN: Saint Kitts and Nevis",
-                  "index": 119
-                },
-                "KP": {
-                  "text": "KP: Korea, Democratic People's Republic of",
-                  "index": 120
-                },
-                "KR": {
-                  "text": "KR: Korea, Republic of",
-                  "index": 121
-                },
-                "KW": {
-                  "text": "KW: Kuwait",
-                  "index": 122
-                },
-                "KY": {
-                  "text": "KY: Cayman Islands",
-                  "index": 123
-                },
-                "KZ": {
-                  "text": "KZ: Kazakhstan",
-                  "index": 124
-                },
-                "LA": {
-                  "text": "LA: Lao People's Democratic Republic",
-                  "index": 125
-                },
-                "LB": {
-                  "text": "LB: Lebanon",
-                  "index": 126
-                },
-                "LC": {
-                  "text": "LC: Saint Lucia",
-                  "index": 127
-                },
-                "LI": {
-                  "text": "LI: Liechtenstein",
-                  "index": 128
-                },
-                "LK": {
-                  "text": "LK: Sri Lanka",
-                  "index": 129
-                },
-                "LR": {
-                  "text": "LR: Liberia",
-                  "index": 130
-                },
-                "LS": {
-                  "text": "LS: Lesotho",
-                  "index": 131
-                },
-                "LT": {
-                  "text": "LT: Lithuania",
-                  "index": 132
-                },
-                "LU": {
-                  "text": "LU: Luxembourg",
-                  "index": 133
-                },
-                "LV": {
-                  "text": "LV: Latvia",
-                  "index": 134
-                },
-                "LY": {
-                  "text": "LY: Libya",
-                  "index": 135
-                },
-                "MA": {
-                  "text": "MA: Morocco",
-                  "index": 136
-                },
-                "MC": {
-                  "text": "MC: Monaco",
-                  "index": 137
-                },
-                "MD": {
-                  "text": "MD: Moldova, Republic of",
-                  "index": 138
-                },
-                "ME": {
-                  "text": "ME: Montenegro",
-                  "index": 139
-                },
-                "MF": {
-                  "text": "MF: Saint Martin (French part)",
-                  "index": 140
-                },
-                "MG": {
-                  "text": "MG: Madagascar",
-                  "index": 141
-                },
-                "MH": {
-                  "text": "MH: Marshall Islands",
-                  "index": 142
-                },
-                "MK": {
-                  "text": "MK: North Macedonia",
-                  "index": 143
-                },
-                "ML": {
-                  "text": "ML: Mali",
-                  "index": 144
-                },
-                "MM": {
-                  "text": "MM: Myanmar",
-                  "index": 145
-                },
-                "MN": {
-                  "text": "MN: Mongolia",
-                  "index": 146
-                },
-                "MO": {
-                  "text": "MO: Macao",
-                  "index": 147
-                },
-                "MP": {
-                  "text": "MP: Northern Mariana Islands",
-                  "index": 148
-                },
-                "MQ": {
-                  "text": "MQ: Martinique",
-                  "index": 149
-                },
-                "MR": {
-                  "text": "MR: Mauritania",
-                  "index": 150
-                },
-                "MS": {
-                  "text": "MS: Montserrat",
-                  "index": 151
-                },
-                "MT": {
-                  "text": "MT: Malta",
-                  "index": 152
-                },
-                "MU": {
-                  "text": "MU: Mauritius",
-                  "index": 153
-                },
-                "MV": {
-                  "text": "MV: Maldives",
-                  "index": 154
-                },
-                "MW": {
-                  "text": "MW: Malawi",
-                  "index": 155
-                },
-                "MX": {
-                  "text": "MX: Mexico",
-                  "index": 156
-                },
-                "MY": {
-                  "text": "MY: Malaysia",
-                  "index": 157
-                },
-                "MZ": {
-                  "text": "MZ: Mozambique",
-                  "index": 158
-                },
-                "NA": {
-                  "text": "NA: Namibia",
-                  "index": 159
-                },
-                "NC": {
-                  "text": "NC: New Caledonia",
-                  "index": 160
-                },
-                "NE": {
-                  "text": "NE: Niger",
-                  "index": 161
-                },
-                "NF": {
-                  "text": "NF: Norfolk Island",
-                  "index": 162
-                },
-                "NG": {
-                  "text": "NG: Nigeria",
-                  "index": 163
-                },
-                "NI": {
-                  "text": "NI: Nicaragua",
-                  "index": 164
-                },
-                "NL": {
-                  "text": "NL: Netherlands",
-                  "index": 165
-                },
-                "NO": {
-                  "text": "NO: Norway",
-                  "index": 166
-                },
-                "NP": {
-                  "text": "NP: Nepal",
-                  "index": 167
-                },
-                "NR": {
-                  "text": "NR: Nauru",
-                  "index": 168
-                },
-                "NU": {
-                  "text": "NU: Niue",
-                  "index": 169
-                },
-                "NZ": {
-                  "text": "NZ: New Zealand",
-                  "index": 170
-                },
-                "OM": {
-                  "text": "OM: Oman",
-                  "index": 171
-                },
-                "PA": {
-                  "text": "PA: Panama",
-                  "index": 172
-                },
-                "PE": {
-                  "text": "PE: Peru",
-                  "index": 173
-                },
-                "PF": {
-                  "text": "PF: French Polynesia",
-                  "index": 174
-                },
-                "PG": {
-                  "text": "PG: Papua New Guinea",
-                  "index": 175
-                },
-                "PH": {
-                  "text": "PH: Philippines",
-                  "index": 176
-                },
-                "PK": {
-                  "text": "PK: Pakistan",
-                  "index": 177
-                },
-                "PL": {
-                  "text": "PL: Poland",
-                  "index": 178
-                },
-                "PM": {
-                  "text": "PM: Saint Pierre and Miquelon",
-                  "index": 179
-                },
-                "PN": {
-                  "text": "PN: Pitcairn",
-                  "index": 180
-                },
-                "PR": {
-                  "text": "PR: Puerto Rico",
-                  "index": 181
-                },
-                "PS": {
-                  "text": "PS: Palestine, State of",
-                  "index": 182
-                },
-                "PT": {
-                  "text": "PT: Portugal",
-                  "index": 183
-                },
-                "PW": {
-                  "text": "PW: Palau",
-                  "index": 184
-                },
-                "PY": {
-                  "text": "PY: Paraguay",
-                  "index": 185
-                },
-                "QA": {
-                  "text": "QA: Qatar",
-                  "index": 186
-                },
-                "RE": {
-                  "text": "RE: R\u00e9union",
-                  "index": 187
-                },
-                "RO": {
-                  "text": "RO: Romania",
-                  "index": 188
-                },
-                "RS": {
-                  "text": "RS: Serbia",
-                  "index": 189
-                },
-                "RU": {
-                  "text": "RU: Russian Federation",
-                  "index": 190
-                },
-                "RW": {
-                  "text": "RW: Rwanda",
-                  "index": 191
-                },
-                "SA": {
-                  "text": "SA: Saudi Arabia",
-                  "index": 192
-                },
-                "SB": {
-                  "text": "SB: Solomon Islands",
-                  "index": 193
-                },
-                "SC": {
-                  "text": "SC: Seychelles",
-                  "index": 194
-                },
-                "SD": {
-                  "text": "SD: Sudan",
-                  "index": 195
-                },
-                "SE": {
-                  "text": "SE: Sweden",
-                  "index": 196
-                },
-                "SG": {
-                  "text": "SG: Singapore",
-                  "index": 197
-                },
-                "SH": {
-                  "text": "SH: Saint Helena, Ascension and Tristan da Cunha",
-                  "index": 198
-                },
-                "SI": {
-                  "text": "SI: Slovenia",
-                  "index": 199
-                },
-                "SJ": {
-                  "text": "SJ: Svalbard and Jan Mayen",
-                  "index": 200
-                },
-                "SK": {
-                  "text": "SK: Slovakia",
-                  "index": 201
-                },
-                "SL": {
-                  "text": "SL: Sierra Leone",
-                  "index": 202
-                },
-                "SM": {
-                  "text": "SM: San Marino",
-                  "index": 203
-                },
-                "SN": {
-                  "text": "SN: Senegal",
-                  "index": 204
-                },
-                "SO": {
-                  "text": "SO: Somalia",
-                  "index": 205
-                },
-                "SR": {
-                  "text": "SR: Suriname",
-                  "index": 206
-                },
-                "SS": {
-                  "text": "SS: South Sudan",
-                  "index": 207
-                },
-                "ST": {
-                  "text": "ST: Sao Tome and Principe",
-                  "index": 208
-                },
-                "SV": {
-                  "text": "SV: El Salvador",
-                  "index": 209
-                },
-                "SX": {
-                  "text": "SX: Sint Maarten (Dutch part)",
-                  "index": 210
-                },
-                "SY": {
-                  "text": "SY: Syrian Arab Republic",
-                  "index": 211
-                },
-                "SZ": {
-                  "text": "SZ: Eswatini",
-                  "index": 212
-                },
-                "TC": {
-                  "text": "TC: Turks and Caicos Islands",
-                  "index": 213
-                },
-                "TD": {
-                  "text": "TD: Chad",
-                  "index": 214
-                },
-                "TF": {
-                  "text": "TF: French Southern Territories",
-                  "index": 215
-                },
-                "TG": {
-                  "text": "TG: Togo",
-                  "index": 216
-                },
-                "TH": {
-                  "text": "TH: Thailand",
-                  "index": 217
-                },
-                "TJ": {
-                  "text": "TJ: Tajikistan",
-                  "index": 218
-                },
-                "TK": {
-                  "text": "TK: Tokelau",
-                  "index": 219
-                },
-                "TL": {
-                  "text": "TL: Timor-Leste",
-                  "index": 220
-                },
-                "TM": {
-                  "text": "TM: Turkmenistan",
-                  "index": 221
-                },
-                "TN": {
-                  "text": "TN: Tunisia",
-                  "index": 222
-                },
-                "TO": {
-                  "text": "TO: Tonga",
-                  "index": 223
-                },
-                "TR": {
-                  "text": "TR: T\u00fcrkiye",
-                  "index": 224
-                },
-                "TT": {
-                  "text": "TT: Trinidad and Tobago",
-                  "index": 225
-                },
-                "TV": {
-                  "text": "TV: Tuvalu",
-                  "index": 226
-                },
-                "TW": {
-                  "text": "TW: Taiwan, Province of China",
-                  "index": 227
-                },
-                "TZ": {
-                  "text": "TZ: Tanzania, United Republic of",
-                  "index": 228
-                },
-                "UA": {
-                  "text": "UA: Ukraine",
-                  "index": 229
-                },
-                "UG": {
-                  "text": "UG: Uganda",
-                  "index": 230
-                },
-                "UM": {
-                  "text": "UM: United States Minor Outlying Islands",
-                  "index": 231
-                },
-                "US": {
-                  "text": "US: United States",
-                  "index": 232
-                },
-                "UY": {
-                  "text": "UY: Uruguay",
-                  "index": 233
-                },
-                "UZ": {
-                  "text": "UZ: Uzbekistan",
-                  "index": 234
-                },
-                "VA": {
-                  "text": "VA: Holy See (Vatican City State)",
-                  "index": 235
-                },
-                "VC": {
-                  "text": "VC: Saint Vincent and the Grenadines",
-                  "index": 236
-                },
-                "VE": {
-                  "text": "VE: Venezuela, Bolivarian Republic of",
-                  "index": 237
-                },
-                "VG": {
-                  "text": "VG: Virgin Islands, British",
-                  "index": 238
-                },
-                "VI": {
-                  "text": "VI: Virgin Islands, U.S.",
-                  "index": 239
-                },
-                "VN": {
-                  "text": "VN: Viet Nam",
-                  "index": 240
-                },
-                "VU": {
-                  "text": "VU: Vanuatu",
-                  "index": 241
-                },
-                "WF": {
-                  "text": "WF: Wallis and Futuna",
-                  "index": 242
-                },
-                "WS": {
-                  "text": "WS: Samoa",
-                  "index": 243
-                },
-                "YE": {
-                  "text": "YE: Yemen",
-                  "index": 244
-                },
-                "YT": {
-                  "text": "YT: Mayotte",
-                  "index": 245
-                },
-                "ZA": {
-                  "text": "ZA: South Africa",
-                  "index": 246
-                },
-                "ZM": {
-                  "text": "ZM: Zambia",
-                  "index": 247
-                },
-                "ZW": {
-                  "text": "ZW: Zimbabwe",
-                  "index": 248
-                }
-              }
-            }
-          ],
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "sortBy": [
-          {
-            "displayName": "Last",
-            "desc": true
-          }
-        ],
-        "footer": {
-          "show": false
-        }
-      }
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 12,
-        "x": 0,
-        "y": 4
-      },
-      "id": 15,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(conduit_bytes_downloaded_lifetime)",
-          "refId": "A",
-          "legendFormat": "Lifetime Download"
-        }
-      ],
-      "title": "Lifetime Download",
-      "type": "stat",
-      "description": "Total bytes downloaded across all Conduit sessions (survives restarts). Requires conduit_lifetime.rules.yml to be configured."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 12,
-        "x": 12,
-        "y": 4
-      },
-      "id": 16,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(conduit_bytes_uploaded_lifetime)",
-          "refId": "A",
-          "legendFormat": "Lifetime Upload"
-        }
-      ],
-      "title": "Lifetime Upload",
-      "type": "stat",
-      "description": "Total bytes uploaded across all Conduit sessions (survives restarts). Requires conduit_lifetime.rules.yml to be configured."
+      "type": "table"
     }
   ],
-  "refresh": "30s",
-  "schemaVersion": 39,
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
   "tags": [
     "moav",
     "conduit",
     "psiphon"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Client State (Top 5 Regions)",
+        "name": "client_state",
+        "options": [],
+        "query": "Connected : conduit_region_connected_clients,Connecting : conduit_region_connecting_clients",
+        "type": "custom",
+        "valuesFormat": "csv"
+      },
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Client State (Window Max)",
+        "name": "client_state_total",
+        "options": [],
+        "query": "Connected : conduit_connected_clients,Connecting : conduit_connecting_clients",
+        "type": "custom",
+        "valuesFormat": "csv"
+      }
+    ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "MoaV - Conduit",
   "uid": "moav-conduit",
-  "version": 3,
   "weekStart": ""
 }

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,64 @@
+# MoaV contrib
+
+Optional, self-contained tools contributed by operators. **Nothing here is part
+of the core MoaV stack:** these are not started by `moav`, not built by `moav
+build`, and not wired into `docker-compose.yml`. They are opt-in, and you set up
+the ones you want yourself.
+
+## What's here
+
+| Tool | What it does | How to run |
+|---|---|---|
+| [conduit-monitor](conduit-monitor/) | Health-checks a native Conduit CLI station and restarts it if it is down or stuck | host schedule (systemd timer / cron / LaunchAgent) |
+| [rotate-log](rotate-log/) | Weekly rotation for an append-only log that never rotates itself | host cron (or a scheduled container) |
+
+Each tool has its own README covering what it does, its configuration (all via
+environment variables, documented at the top of the script), and a **How to
+run** section with copy-pasteable setup.
+
+## How to run: the two common shapes
+
+Optional tools tend to be one of two shapes. Pick the one that fits and document
+it in the tool's own README.
+
+### A) Long-running daemon or metrics exporter → run it as a container
+
+A tool that scrapes a MoaV service and re-exposes something (a Prometheus
+exporter, a sidecar) drops cleanly onto the monitoring network. Mount the script
+read-only into a stock base image (match the image to the script's language) and
+point it at the service by its compose name on `moav_moav_net`:
+
+```bash
+docker run -d --name <tool> --restart unless-stopped \
+  --network moav_moav_net \
+  -e SOME_METRICS_URL=http://psiphon-conduit:9090/metrics \
+  -v /opt/moav/contrib/<tool>/<script>:/app/<script>:ro \
+  python:3-alpine python /app/<script>
+```
+
+If it exposes metrics for Prometheus, add a scrape job (a single-file mount
+needs a `docker restart moav-prometheus` to pick up the change, not just a HUP):
+
+```yaml
+# configs/monitoring/prometheus.yml
+  - job_name: '<tool>'
+    static_configs:
+      - targets: ['<tool>:9201']
+```
+
+### B) Periodic host task → run it on a schedule
+
+A tool that acts on the host (rotate a file, manage a native service, bounce an
+interface) runs as a scheduled host job, not a container: a **systemd timer** or
+**cron** on Linux, a **LaunchAgent** or **cron** on macOS. Each such tool's
+README gives a ready-to-paste example.
+
+## Adding a tool
+
+Contributions welcome. To keep `contrib/` consistent:
+
+- One directory per tool, `contrib/<tool>/`, containing the script(s) and a `README.md`.
+- Configure via **environment variables** with sane defaults, documented in a comment block at the top of the script. Don't hardcode paths, hosts, or machine-specific values.
+- The README covers: why it exists, what it does, its configuration, and a **How to run** section (shape A or B above).
+- Shell scripts must pass CI: `bash -n` and `shellcheck --severity=error` clean.
+- Add a row to the table at the top of this file.

--- a/contrib/conduit-monitor/README.md
+++ b/contrib/conduit-monitor/README.md
@@ -76,6 +76,90 @@ public-IP lookup, a stuck proxy that was already restarted too recently to
 restart again) gets logged and pushed as a notification instead of
 silently ignored.
 
+## How to run
+
+conduit-monitor is for a machine running a **native Conduit CLI station** (the
+service is managed by `launchctl` on macOS or `systemctl` on Linux). Run it
+every 15-30 minutes from a scheduled job so it survives closed terminals and
+sleep. Configure it with the environment variables documented at the top of
+`conduit-monitor.sh`; set only what differs from the defaults.
+
+> **Running the dockerized MoaV server?** You don't need this. `psiphon-conduit`
+> is a container with `restart: unless-stopped`, so Docker already restarts it on
+> crash. This tool restarts a *host* Conduit service and (on macOS) repairs host
+> network interfaces, neither of which applies to the container.
+
+### Linux — systemd timer (recommended)
+
+`/etc/systemd/system/conduit-monitor.service`:
+```ini
+[Unit]
+Description=Conduit health check + known-fix autopilot
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=CONDUIT_SERVICE_LABEL=conduit
+Environment=NTFY_TOPIC_FILE=%h/.conduit-ntfy-topic
+ExecStart=/opt/moav/contrib/conduit-monitor/conduit-monitor.sh
+```
+
+`/etc/systemd/system/conduit-monitor.timer`:
+```ini
+[Unit]
+Description=Run conduit-monitor every 15 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15min
+
+[Install]
+WantedBy=timers.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now conduit-monitor.timer
+systemctl list-timers conduit-monitor.timer   # confirm it is scheduled
+```
+
+### Linux / macOS — cron
+
+```bash
+# crontab -e  (every 15 minutes)
+*/15 * * * * CONDUIT_SERVICE_LABEL=conduit /opt/moav/contrib/conduit-monitor/conduit-monitor.sh >> "$HOME/conduit-monitor.log" 2>&1
+```
+
+### macOS — LaunchAgent
+
+`~/Library/LaunchAgents/sh.moav.conduit-monitor.plist`:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>sh.moav.conduit-monitor</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/opt/moav/contrib/conduit-monitor/conduit-monitor.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>NETWORK_INTERFACE</key><string>en0</string>
+  </dict>
+  <key>StartInterval</key><integer>900</integer>
+  <key>RunAtLoad</key><true/>
+</dict>
+</plist>
+```
+```bash
+launchctl load ~/Library/LaunchAgents/sh.moav.conduit-monitor.plist
+```
+
+See the top of `conduit-monitor.sh` for the full list of environment variables
+and their defaults.
+
 ## Platform differences
 
 The core logic — checking Conduit's own metrics, deciding whether it's

--- a/contrib/conduit-monitor/README.md
+++ b/contrib/conduit-monitor/README.md
@@ -1,0 +1,149 @@
+# conduit-monitor
+
+A periodic health-check-and-repair script for a Conduit CLI station, for
+macOS and Linux. Runs every 15-30 minutes via a scheduled job, notices if
+Conduit has stopped running or gotten stuck, and fixes the specific
+failure modes it knows how to fix — anything else, it logs and notifies
+about rather than guessing.
+
+## Why this exists
+
+A Conduit CLI station is usually unattended for long stretches. Two
+failure modes are common enough to be worth automating around:
+
+- The service stops running (a crash, a `launchctl bootout`/`systemctl
+  stop`, anything that leaves it down) and doesn't come back on its own.
+- Conduit is technically running but stuck — connected to nothing, or
+  cycling through failed connection attempts without ever landing one.
+  `conduit_idle_seconds` alone doesn't catch every shape of this (a proxy
+  that's actively failing, not idle, can show near-zero idle time while
+  still being fully broken), so this script checks both.
+
+Two design choices come directly from a real incident, not speculation:
+
+**An inconclusive check must default to "assume fine," not "assume the
+worst."** This script optionally supports stopping Conduit if it detects
+you've roamed onto a network that isn't your own (a privacy feature for
+laptop-based stations — donating a stranger's bandwidth isn't the point).
+The check that decides this depends on an external network lookup. If that
+lookup ever fails — a DNS hiccup, a routing blip, the lookup service being
+briefly down — treating the failure as "confirmed away from home" and
+stopping Conduit is exactly backwards: it turns a transient, unrelated
+network problem into an extended outage, because the same failing lookup
+then also blocks the script from ever starting it back up. This script
+treats a failed lookup as inconclusive and takes no action, while still
+logging the failure so it's visible.
+
+**A repair path shouldn't depend on the thing it's repairing.** An earlier
+version of the interface-repair logic here (macOS only, see below) was
+only reachable through a check that itself required a working IP address
+to run — meaning the one scenario that most needed the repair (no IP at
+all) could never actually trigger it. The no-usable-IPv4 check in this
+version has no prerequisites beyond the interface being powered on.
+
+**A safety check should fail closed, not guess.** `networksetup
+-setairportpower` doesn't validate that the interface name it's given is
+actually a WiFi device — given an unrecognized name, it silently falls
+back to controlling whatever WiFi interface *does* exist on the system,
+rather than erroring. Found live while testing a sibling script's
+identical code path: a misconfigured interface name toggled the real WiFi
+connection instead of failing loudly. This script now confirms
+`NETWORK_INTERFACE` actually matches the system's real Wi-Fi hardware port
+(via `networksetup -listallhardwareports`) before ever touching airport
+power, and refuses to act — logging it as an anomaly instead — if it
+doesn't match.
+
+## What it does
+
+Every run:
+1. **macOS only**: if configured, bounces a network interface that has no
+   usable IPv4 address at all (not even a self-assigned link-local) and
+   restarts Conduit. Not available on Linux — see "Platform differences"
+   below for why.
+2. If configured, checks whether this machine's public IP matches a
+   configured "home" prefix; stops Conduit if not, starts it if so. Both
+   sides of this are opt-in — skipped entirely unless you set
+   `HOME_PUBLIC_IP_PREFIX`. Works on both platforms.
+3. Starts Conduit if it isn't running.
+4. Detects a stuck/stale proxy (idle too long, or connected=0 with recent
+   errors) and restarts it, with a cooldown to avoid restart loops.
+5. Optionally calls out to a log-rotation helper you provide.
+6. Logs every check, and sends one consolidated notification per run if
+   anything happened — not one per finding.
+
+Everything it can't fix (not connected to the broker at all, a stale
+public-IP lookup, a stuck proxy that was already restarted too recently to
+restart again) gets logged and pushed as a notification instead of
+silently ignored.
+
+## Platform differences
+
+The core logic — checking Conduit's own metrics, deciding whether it's
+down or stuck — is identical on both platforms. Only the actual
+start/stop/restart/notify commands differ (macOS: `launchctl`; Linux:
+`systemctl`), branched once via `uname` near the top of the script.
+
+**The network-interface repair feature is macOS-only, on purpose, not
+because it wasn't gotten to.** It was tested for real against a genuine
+Linux environment (see "How this was tested" below) and found to be
+genuinely fragmented across distros in a way the macOS version isn't:
+which mechanism actually re-acquires a DHCP lease after a link is brought
+back up — NetworkManager, `dhclient`, `dhcpcd`, `systemd-networkd`, or
+sometimes nothing at all — varies by distro and by how that particular
+machine is configured, and there's no single command that reliably works
+everywhere the way `networksetup` does on macOS. Shipping something that
+silently does the wrong thing (or nothing) on someone's specific setup
+seemed worse than not including it. It's also arguably more of a
+laptop/roaming-station concern than a typical fixed-location Linux
+deployment (a server, a Raspberry Pi on a stable wired connection) would
+actually need.
+
+## How this was tested
+
+The macOS path has been running in production on a real station for an
+extended period, including through a real multi-hour outage that led
+directly to two of the fixes described above.
+
+The Linux path was tested for real, not just written from documentation —
+against a genuine `systemd`-based environment running in Docker via
+[Colima](https://github.com/abiosoft/colima) on macOS (a real Linux VM,
+not just a container-in-name-only): a custom Debian image with `systemd`,
+`systemd-sysv`, and `network-manager` actually installed, run with
+`--privileged --cgroupns=host` so `systemd` genuinely manages services
+inside it. Both restart paths were verified against a real dummy
+`systemd` service: stopping it and confirming the script detects the
+failure and runs `systemctl start`, and separately simulating a stuck
+proxy (via a fake metrics endpoint reporting elevated `conduit_idle_seconds`)
+against an already-running service and confirming the script correctly
+runs `systemctl restart` instead.
+
+This is a real `systemd` environment, not a mock, so the `systemctl`
+commands behave as expected — but a privileged `systemd`-in-Docker VM can
+still differ from a bare-metal or VM Linux install in edge cases. If you
+deploy this on Linux, keep an eye on the log the first few runs rather than
+assuming it's flawless from a container test alone.
+
+## What it needs
+
+Nothing beyond what the OS already ships with, plus optionally:
+- macOS: [terminal-notifier](https://github.com/julienXX/terminal-notifier)
+  (falls back to `osascript` if not present).
+- Linux: `notify-send`, if you want a local desktop notification — most
+  headless servers won't have this, which is fine, it's skipped silently
+  if absent.
+- Either platform: an [ntfy.sh](https://ntfy.sh) topic if you want push
+  notifications to a phone — this is the more reliable channel on a
+  headless Linux server specifically, since there's often no local
+  notification system to fall back on there at all.
+
+Configuration is entirely via environment variables — see the comment
+block at the top of the script for the full list and defaults. Nothing is
+hardcoded to any particular machine, router, or network.
+
+## What this isn't
+
+This isn't a full station-management suite — it doesn't touch router
+configuration and doesn't manage anything beyond Conduit itself. It's
+deliberately narrow: notice Conduit is down or stuck, and get it running
+again, correctly, without guessing at problems it doesn't actually
+understand.

--- a/contrib/conduit-monitor/conduit-monitor.sh
+++ b/contrib/conduit-monitor/conduit-monitor.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# conduit-monitor.sh — periodic Conduit health check + known-fix autopilot for
+# macOS and Linux. Run every 15-30 min from a scheduled job (macOS LaunchAgent
+# with StartCalendarInterval, or a Linux systemd timer / cron) so it survives
+# closed terminals and sleep. Detection logic is identical on both platforms;
+# only the restart/notify commands branch on `uname`. Conservative by design:
+# it applies a small set of deterministic known fixes, and logs or notifies
+# about anything else rather than guessing. See README.md for details.
+#
+# Configuration — all via environment variables, defaults except where noted:
+#   CONDUIT_SERVICE_LABEL      launchd label (macOS, default ca.psiphon.conduit)
+#                              / systemd unit name (Linux, default conduit)
+#   CONDUIT_PLIST_PATH         macOS only: LaunchAgent plist path
+#                              (default ~/Library/LaunchAgents/$CONDUIT_SERVICE_LABEL.plist)
+#   CONDUIT_METRICS_URL        Conduit metrics (default http://127.0.0.1:9090/metrics)
+#   CONDUIT_LOG_PATH           Conduit log, for a recent-error heuristic (default ~/conduit.log)
+#   MONITOR_LOG_PATH           this script's own log (default ~/conduit-monitor.log)
+#   KICKSTART_COOLDOWN_FILE    timestamp file guarding against restart loops
+#                              (default ~/.conduit_monitor_last_kickstart)
+#   KICKSTART_COOLDOWN_SECS    min seconds between auto-restarts (default 1200)
+#   IDLE_THRESHOLD_SECS        max conduit_idle_seconds before "stuck" (default 300)
+#   ROTATE_LOG_SCRIPT          optional log-rotation helper, called weekly as
+#                              `$ROTATE_LOG_SCRIPT $CONDUIT_LOG_PATH conduit`; skipped if unset
+#   NETWORK_INTERFACE          macOS only, optional (e.g. en0): bounce this interface
+#                              when it has no usable IPv4. No effect on Linux.
+#   NETWORK_INTERFACE_IS_WIFI  macOS only (default true): WiFi vs wired bounce method
+#   HOME_PUBLIC_IP_PREFIX      optional (e.g. 203.0.113): stop Conduit when the public
+#                              IP doesn't match this prefix (roaming/privacy guard)
+#   NTFY_TOPIC_FILE            optional file holding an ntfy.sh topic for push notifications
+
+OS="$(uname)"   # "Darwin" or "Linux" — the only two supported
+
+if [ "$OS" = "Darwin" ]; then
+    CONDUIT_SERVICE_LABEL="${CONDUIT_SERVICE_LABEL:-ca.psiphon.conduit}"
+else
+    CONDUIT_SERVICE_LABEL="${CONDUIT_SERVICE_LABEL:-conduit}"
+fi
+CONDUIT_PLIST_PATH="${CONDUIT_PLIST_PATH:-$HOME/Library/LaunchAgents/${CONDUIT_SERVICE_LABEL}.plist}"
+CONDUIT_METRICS_URL="${CONDUIT_METRICS_URL:-http://127.0.0.1:9090/metrics}"
+CONDUIT_LOG_PATH="${CONDUIT_LOG_PATH:-$HOME/conduit.log}"
+MONITOR_LOG_PATH="${MONITOR_LOG_PATH:-$HOME/conduit-monitor.log}"
+KICKSTART_COOLDOWN_FILE="${KICKSTART_COOLDOWN_FILE:-$HOME/.conduit_monitor_last_kickstart}"
+KICKSTART_COOLDOWN_SECS="${KICKSTART_COOLDOWN_SECS:-1200}"
+IDLE_THRESHOLD_SECS="${IDLE_THRESHOLD_SECS:-300}"
+ROTATE_LOG_SCRIPT="${ROTATE_LOG_SCRIPT:-}"
+NETWORK_INTERFACE="${NETWORK_INTERFACE:-}"
+NETWORK_INTERFACE_IS_WIFI="${NETWORK_INTERFACE_IS_WIFI:-true}"
+HOME_PUBLIC_IP_PREFIX="${HOME_PUBLIC_IP_PREFIX:-}"
+NTFY_TOPIC_FILE="${NTFY_TOPIC_FILE:-}"
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$MONITOR_LOG_PATH"
+}
+
+notify() {
+    local msg
+    msg="[$(date '+%m/%d %H:%M')] $1"
+    if [ "$OS" = "Darwin" ]; then
+        if command -v terminal-notifier >/dev/null 2>&1; then
+            terminal-notifier -message "$msg" -title "Conduit Monitor" -open "file://$MONITOR_LOG_PATH" >/dev/null 2>&1
+        else
+            osascript -e "display notification \"$msg\" with title \"Conduit Monitor\"" >/dev/null 2>&1
+        fi
+    else
+        # Most headless Linux servers have no desktop notification service
+        # at all -- only attempt this if notify-send actually exists, and
+        # don't treat its absence as a problem worth logging. ntfy (below)
+        # is the reliable channel on Linux; this is a bonus if available.
+        command -v notify-send >/dev/null 2>&1 && notify-send "Conduit Monitor" "$msg" >/dev/null 2>&1
+    fi
+    if [ -n "$NTFY_TOPIC_FILE" ] && [ -f "$NTFY_TOPIC_FILE" ]; then
+        curl -s --max-time 5 -d "$msg" -H "Title: Conduit Monitor" "https://ntfy.sh/$(cat "$NTFY_TOPIC_FILE")" >/dev/null 2>&1
+    fi
+}
+
+# Bounces $NETWORK_INTERFACE and kickstarts Conduit when that interface has no
+# usable IPv4 (empty or a self-assigned 169.254.x link-local — DHCP never
+# completed). Has no prerequisites: a repair for "no working network" must not
+# itself depend on a working network.
+fix_no_ip_interface() {
+    [ "$OS" != "Darwin" ] && return   # not ported to Linux -- see header comment
+    [ -z "$NETWORK_INTERFACE" ] && return
+    local ip
+    ip=$(ipconfig getifaddr "$NETWORK_INTERFACE" 2>/dev/null)
+    if [ -n "$ip" ] && ! echo "$ip" | grep -qE "^169\.254\."; then
+        return   # has a real address, nothing to do
+    fi
+    if [ "$NETWORK_INTERFACE_IS_WIFI" = "true" ]; then
+        # `networksetup -setairportpower` doesn't validate its argument is a
+        # WiFi device — given an unknown name it silently toggles whatever WiFi
+        # interface exists. Confirm NETWORK_INTERFACE is the real Wi-Fi port first.
+        local wifi_device
+        wifi_device=$(networksetup -listallhardwareports | awk '/Hardware Port: Wi-Fi/{getline; print $2}')
+        if [ "$wifi_device" != "$NETWORK_INTERFACE" ]; then
+            ANOMALIES+=("NETWORK_INTERFACE=$NETWORK_INTERFACE is not this system's actual Wi-Fi device (that's $wifi_device) -- refusing to touch airport power to avoid affecting the wrong interface, needs a manual look")
+            return
+        fi
+        networksetup -setairportpower "$NETWORK_INTERFACE" off
+        sleep 5
+        networksetup -setairportpower "$NETWORK_INTERFACE" on
+    else
+        local service
+        service=$(networksetup -listallhardwareports | awk -v dev="$NETWORK_INTERFACE" '/Hardware Port:/{name=$0; sub(/Hardware Port: /,"",name)} $0=="Device: " dev {print name}')
+        if [ -z "$service" ]; then
+            ANOMALIES+=("NETWORK_INTERFACE=$NETWORK_INTERFACE has no usable IPv4 (${ip:-none}), but could not find its network service name to bounce it — needs a manual look")
+            return
+        fi
+        networksetup -setnetworkserviceenabled "$service" off
+        sleep 3
+        networksetup -setnetworkserviceenabled "$service" on
+    fi
+    sleep 12
+    service_restart
+    ACTIONS+=("$NETWORK_INTERFACE had no usable IPv4 (was: ${ip:-none}), bounced it and restarted Conduit")
+}
+
+# Small OS-branching wrappers so the actual health-check logic below (which
+# is identical on both platforms) doesn't need its own if/else at every step.
+service_is_running() {
+    if [ "$OS" = "Darwin" ]; then
+        [ "$(launchctl print "gui/$(id -u)/${CONDUIT_SERVICE_LABEL}" 2>/dev/null | grep -m1 state | awk '{print $3}')" = "running" ]
+    else
+        systemctl is-active --quiet "${CONDUIT_SERVICE_LABEL}.service" 2>/dev/null
+    fi
+}
+
+service_start() {
+    if [ "$OS" = "Darwin" ]; then
+        launchctl bootstrap "gui/$(id -u)" "$CONDUIT_PLIST_PATH" 2>/dev/null
+    else
+        systemctl start "${CONDUIT_SERVICE_LABEL}.service" 2>/dev/null
+    fi
+}
+
+service_stop() {
+    if [ "$OS" = "Darwin" ]; then
+        launchctl bootout "gui/$(id -u)" "$CONDUIT_PLIST_PATH" 2>/dev/null
+    else
+        systemctl stop "${CONDUIT_SERVICE_LABEL}.service" 2>/dev/null
+    fi
+}
+
+service_restart() {
+    if [ "$OS" = "Darwin" ]; then
+        launchctl kickstart -k "gui/$(id -u)/${CONDUIT_SERVICE_LABEL}" 2>/dev/null
+    else
+        systemctl restart "${CONDUIT_SERVICE_LABEL}.service" 2>/dev/null
+    fi
+}
+
+# --- gather state ---
+if service_is_running; then CONDUIT_STATE="running"; else CONDUIT_STATE="not running"; fi
+METRICS=$(curl -s --max-time 5 "$CONDUIT_METRICS_URL")
+IS_LIVE=$(echo "$METRICS" | awk '/^conduit_is_live/{print $2}')
+CONNECTED=$(echo "$METRICS" | awk '/^conduit_connected_clients/{print $2}')
+IDLE_SECONDS=$(echo "$METRICS" | awk '/^conduit_idle_seconds/{print $2}')
+ERROR_COUNT=$(tail -n 100 "$CONDUIT_LOG_PATH" 2>/dev/null | grep -cE "404|ERROR")
+
+ACTIONS=()
+ANOMALIES=()
+
+# --- optional: fix an interface with no usable IPv4 BEFORE the home-network
+# check below, which itself needs working connectivity to run. ---
+fix_no_ip_interface
+
+# --- optional: pause Conduit if this Mac's public IP doesn't match the
+# configured home prefix (mobile/laptop stations only — skipped entirely
+# if HOME_PUBLIC_IP_PREFIX is unset) ---
+ON_NON_HOME_NETWORK="no"
+PUBLIC_IP_LOOKUP_FAILED="no"
+if [ -n "$HOME_PUBLIC_IP_PREFIX" ]; then
+    CURRENT_PUBLIC_IP=$(curl -s --max-time 5 https://api.ipify.org)
+    if [ -z "$CURRENT_PUBLIC_IP" ]; then
+        # An inconclusive lookup must NOT be treated as "confirmed away from
+        # home": pausing on a failed lookup then blocks the un-pause on every
+        # later check too. Default to "assume home, don't act" and log the
+        # failure as a visible anomaly.
+        PUBLIC_IP_LOOKUP_FAILED="yes"
+    else
+        case "$CURRENT_PUBLIC_IP" in
+            ${HOME_PUBLIC_IP_PREFIX}*) ON_NON_HOME_NETWORK="no" ;;
+            *) ON_NON_HOME_NETWORK="yes" ;;
+        esac
+    fi
+fi
+
+if [ "$PUBLIC_IP_LOOKUP_FAILED" = "yes" ]; then
+    ANOMALIES+=("public-IP lookup (api.ipify.org) failed/empty this cycle — treated as inconclusive, did NOT pause Conduit, but check general internet routing if this recurs")
+fi
+
+# --- metrics endpoint unreachable entirely ---
+# Expected/correct when Conduit is intentionally paused on a non-home
+# network (nothing listening on the metrics port) — not an anomaly then.
+if [ -z "$METRICS" ] && [ "$ON_NON_HOME_NETWORK" = "no" ]; then
+    ANOMALIES+=("metrics endpoint ($CONDUIT_METRICS_URL) did not respond at all — Conduit or its metrics exporter may be down, needs a look")
+fi
+
+# --- Conduit not running -> start it ---
+# Skipped if on a non-home network — that's the correct, intentionally-
+# paused state, not something to fight every cycle.
+if [ "$CONDUIT_STATE" != "running" ] && [ "$ON_NON_HOME_NETWORK" = "no" ]; then
+    service_start
+    ACTIONS+=("Conduit was not running, started it")
+fi
+
+# --- Conduit running on a non-home network -> pause it ---
+if [ -n "$HOME_PUBLIC_IP_PREFIX" ] && [ "$CONDUIT_STATE" = "running" ] && [ "$ON_NON_HOME_NETWORK" = "yes" ]; then
+    service_stop
+    ACTIONS+=("Conduit was running on a non-home network (public IP: ${CURRENT_PUBLIC_IP:-unknown}), paused it")
+fi
+
+# --- not connected to the broker at all -- no known fix, needs a human look ---
+if [ -n "$METRICS" ] && [ "$IS_LIVE" != "1" ]; then
+    ANOMALIES+=("conduit_is_live=$IS_LIVE (not connected to broker) — no known fix for this, needs investigation")
+fi
+
+# --- stale/stuck proxy, two failure shapes both worth catching:
+# 1) conduit_idle_seconds elevated — genuinely dead, no activity at all.
+# 2) connected=0 with recent errors — "actively failing" rather than idle, so
+#    idle_seconds can stay near zero while still broken. Keep both checks. ---
+IDLE_INT=${IDLE_SECONDS%.*}
+STALE_REASON=""
+if [ "$IS_LIVE" = "1" ] && [ -n "$IDLE_INT" ] && [ "$IDLE_INT" -gt "$IDLE_THRESHOLD_SECS" ] 2>/dev/null; then
+    STALE_REASON="idle_seconds=${IDLE_INT}"
+elif [ "$IS_LIVE" = "1" ] && [ "$CONNECTED" = "0" ] && [ "$ERROR_COUNT" -gt 0 ] 2>/dev/null; then
+    STALE_REASON="connected=0 with ${ERROR_COUNT} errors/100 lines despite active connecting attempts"
+fi
+
+if [ -n "$STALE_REASON" ]; then
+    LAST_KICKSTART=$(cat "$KICKSTART_COOLDOWN_FILE" 2>/dev/null || echo 0)
+    NOW=$(date +%s)
+    if [ $((NOW - LAST_KICKSTART)) -gt "$KICKSTART_COOLDOWN_SECS" ]; then
+        service_restart
+        echo "$NOW" > "$KICKSTART_COOLDOWN_FILE"
+        ACTIONS+=("stale/stuck proxy ($STALE_REASON), kickstarted Conduit")
+    else
+        ANOMALIES+=("stale/stuck proxy detected ($STALE_REASON) but kickstarted within the last ${KICKSTART_COOLDOWN_SECS}s — skipping to avoid a restart loop, this needs a manual look, it is NOT self-resolving")
+    fi
+fi
+
+# --- optional weekly log rotation, if a rotation helper is configured ---
+if [ -n "$ROTATE_LOG_SCRIPT" ] && [ -x "$ROTATE_LOG_SCRIPT" ]; then
+    ROTATE_OUTPUT=$("$ROTATE_LOG_SCRIPT" "$CONDUIT_LOG_PATH" conduit)
+    [ -n "$ROTATE_OUTPUT" ] && ACTIONS+=("$ROTATE_OUTPUT")
+fi
+
+# --- log + notify (one consolidated notification per run, not one per finding) ---
+if [ ${#ACTIONS[@]} -eq 0 ] && [ ${#ANOMALIES[@]} -eq 0 ]; then
+    log "CHECK: healthy (live=$IS_LIVE, connected=$CONNECTED, idle=${IDLE_INT}s, errors=$ERROR_COUNT) ACTION: none"
+else
+    ACTION_TEXT="none"
+    [ ${#ACTIONS[@]} -gt 0 ] && ACTION_TEXT=$(IFS='; '; echo "${ACTIONS[*]}")
+    ANOMALY_TEXT=$(IFS='; '; echo "${ANOMALIES[*]}")
+
+    if [ ${#ANOMALIES[@]} -gt 0 ]; then
+        log "CHECK: live=$IS_LIVE connected=$CONNECTED idle=${IDLE_INT}s errors=$ERROR_COUNT ACTION: $ACTION_TEXT NEEDS-ATTENTION: $ANOMALY_TEXT"
+        notify "NEEDS ATTENTION: ${ANOMALIES[0]}$([ ${#ANOMALIES[@]} -gt 1 ] && echo " (+$((${#ANOMALIES[@]}-1)) more, see $MONITOR_LOG_PATH)")"
+    else
+        log "CHECK: live=$IS_LIVE connected=$CONNECTED idle=${IDLE_INT}s errors=$ERROR_COUNT ACTION: $ACTION_TEXT"
+        notify "Fixed automatically: ${ACTIONS[0]}$([ ${#ACTIONS[@]} -gt 1 ] && echo " (+$((${#ACTIONS[@]}-1)) more, see log)")"
+    fi
+fi

--- a/contrib/rotate-log/README.md
+++ b/contrib/rotate-log/README.md
@@ -1,0 +1,73 @@
+# rotate-log.sh
+
+A small, generic weekly log rotation script for any append-mode log file
+that never rotates on its own — for macOS and Linux.
+
+## Why this exists
+
+If you run Conduit CLI with `-v` (verbose logging), you probably need to —
+error-level messages are gated behind that same flag, not just debug
+noise, so verbose logging is closer to required than optional for
+meaningful diagnostics. But verbose logging on a busy station means the
+log file grows fast: gigabytes within days is normal, not a sign anything
+is wrong. Conduit doesn't rotate its own log, so left alone it grows
+without bound.
+
+## What it does
+
+```
+rotate-log.sh <log_path> <archive_prefix>
+```
+
+Checks whether the newest existing archive for that prefix is at least 7
+days old (or doesn't exist yet). If so: copies the log to
+`<same_dir>/log_archive/<prefix>_<timestamp>.log`, truncates the live file
+in place (not a rename — a rename would break whatever process still has
+the original file open in append mode, requiring a restart; truncating in
+place is transparent to an already-running writer), then **synchronously**
+gzips the copy and verifies the resulting archive with `gzip -t` before
+declaring success. If gzip fails or produces a corrupt archive, the raw
+copy is left in place rather than silently lost.
+
+Meant to be called periodically from your own health-check loop or cron
+job — it manages its own weekly cadence internally, so calling it more
+often than that is a harmless no-op.
+
+## A real bug this script's history is worth knowing about
+
+An earlier version ran gzip in the background (`nohup gzip ... &`) so a
+large one-time archive wouldn't block the caller. In production, this
+failed silently on the largest archives — the background process got cut
+off before finishing (most likely because the calling script was itself a
+short-lived scheduled job, and the process manager reaped the whole job's
+process group once the main script exited, taking the still-running gzip
+with it) — leaving a truncated, corrupt `.gz` file sitting next to an
+un-deleted multi-gigabyte raw copy. This happened twice, silently, over
+several weeks, before being noticed. A real timed test showed synchronous
+gzip only takes 16-17 seconds even on a ~5GB file — nowhere near enough to
+justify the background/detach complexity that caused the silent failure.
+Current version gzips synchronously and verifies the result; if you're
+reviewing or adapting this script, the backgrounded version is a trap
+worth knowing not to reintroduce.
+
+## How this was tested
+
+Both platforms were tested for real, end-to-end, immediately before this
+README was written — not assumed from reading the code:
+
+- **macOS**: ran directly against a real test log file, confirmed the
+  archive was created, gzip-verified as valid, the live file correctly
+  truncated to zero, and a second immediate run correctly no-op'd (archive
+  too fresh to rotate again).
+- **Linux**: same test, run inside a Debian container via
+  [Colima](https://github.com/abiosoft/colima) (a real Linux VM on macOS,
+  not just a container-in-name-only). This actually caught a real bug in
+  the process: the archive-age check used `stat -f%m`, which is BSD/macOS-
+  only syntax — Linux's `stat` needs `-c%Y` for the same value. As
+  originally written, this would have silently misbehaved on Linux. Fixed
+  (branches on `uname` now) and re-verified with the same end-to-end test
+  described above, which passed cleanly afterward.
+
+Nothing else in this script is platform-specific — it's plain file
+operations (`cp`, truncate-in-place, `gzip`) throughout, so once that one
+`stat` call was fixed, both platforms behave identically.

--- a/contrib/rotate-log/README.md
+++ b/contrib/rotate-log/README.md
@@ -33,6 +33,37 @@ Meant to be called periodically from your own health-check loop or cron
 job — it manages its own weekly cadence internally, so calling it more
 often than that is a harmless no-op.
 
+## How to run
+
+Run it on a schedule, or let another script call it (conduit-monitor invokes it
+via `ROTATE_LOG_SCRIPT`). It self-limits to one rotation per 7 days, so running
+it daily is fine.
+
+### Linux / macOS — cron (simplest)
+
+```bash
+# crontab -e  (daily; the script self-limits to a weekly rotation)
+0 4 * * * /opt/moav/contrib/rotate-log/rotate-log.sh /var/log/conduit/conduit.log conduit
+```
+
+### Linux — systemd timer
+
+A `Type=oneshot` service running `rotate-log.sh <log> <prefix>`, on a timer with
+`OnUnitActiveSec=1d` (same shape as conduit-monitor's timer).
+
+### As a container (when the log lives in a Docker volume)
+
+To rotate a log a MoaV container writes to a named volume, run it from the host
+on a schedule against that volume (bash + gzip, so use a `debian` base):
+
+```bash
+# e.g. rotate the snowflake proxy log volume
+docker run --rm \
+  -v moav_snowflake_logs:/logs \
+  -v /opt/moav/contrib/rotate-log/rotate-log.sh:/rotate-log.sh:ro \
+  debian:stable-slim bash /rotate-log.sh /logs/snowflake.log snowflake
+```
+
 ## A real bug this script's history is worth knowing about
 
 An earlier version ran gzip in the background (`nohup gzip ... &`) so a

--- a/contrib/rotate-log/rotate-log.sh
+++ b/contrib/rotate-log/rotate-log.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# rotate-log.sh <log_path> <archive_prefix> — generic weekly archive+truncate
+# for any append-mode log file that never rotates on its own. Archives go to a
+# log_archive/ dir alongside the log file, named <prefix>_YYMMDD_HHMM.log.gz.
+# Copy-then-truncate-in-place, not rename: a rename would break the writer's
+# open O_APPEND fd; truncating is transparent to an already-running writer.
+
+LOG="$1"
+PREFIX="$2"
+ROTATE_DAYS=7
+
+if [ -z "$LOG" ] || [ -z "$PREFIX" ]; then
+    echo "Usage: rotate-log.sh <log_path> <archive_prefix>" >&2
+    exit 1
+fi
+
+ARCHIVE_DIR="$(dirname "$LOG")/log_archive"
+mkdir -p "$ARCHIVE_DIR"
+
+latest_archive=$(ls -t "$ARCHIVE_DIR"/${PREFIX}_*.log.gz 2>/dev/null | head -1)
+
+should_rotate=0
+if [ -z "$latest_archive" ]; then
+    should_rotate=1
+else
+    if [ "$(uname)" = "Darwin" ]; then
+        archive_mtime=$(stat -f%m "$latest_archive")
+    else
+        archive_mtime=$(stat -c%Y "$latest_archive")
+    fi
+    age_seconds=$(( $(date +%s) - archive_mtime ))
+    age_days=$(( age_seconds / 86400 ))
+    if [ "$age_days" -ge "$ROTATE_DAYS" ]; then
+        should_rotate=1
+    fi
+fi
+
+if [ "$should_rotate" -eq 0 ]; then
+    exit 0
+fi
+
+if [ ! -f "$LOG" ] || [ ! -s "$LOG" ]; then
+    exit 0
+fi
+
+ts=$(date +%y%m%d_%H%M)
+archive_path="$ARCHIVE_DIR/${PREFIX}_${ts}.log"
+
+cp "$LOG" "$archive_path"
+: > "$LOG"
+
+# gzip synchronously and verify with `gzip -t` before declaring success. An
+# earlier backgrounded (`nohup ... &`) version was silently reaped mid-run when
+# the caller exited, leaving truncated .gz files next to un-deleted raw copies.
+if gzip "$archive_path" && gzip -t "${archive_path}.gz"; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') Rotated $(basename "$LOG") -> ${archive_path}.gz (verified)"
+else
+    echo "$(date '+%Y-%m-%d %H:%M:%S') WARNING: gzip of $archive_path failed or produced a corrupt archive — raw copy left in place at $archive_path for manual recovery, not deleted"
+fi


### PR DESCRIPTION
Consolidates the two Conduit-monitoring contributions from @jSFBay (originally #305 and #314) into one branch with two focused commits. Each commit is cleaned up to pass CI and keeps @jSFBay as co-author.

### Commits
1. **contrib: add conduit-monitor and rotate-log ops scripts** — adds `contrib/conduit-monitor/` and `contrib/rotate-log/` (script + README each). `bash -n` and `shellcheck --severity=error` clean.
2. **monitoring(grafana): expand the Conduit dashboard with new panels** — expands the provisioned Conduit dashboard. Two `log-metrics-exporter` panels were dropped (they were the only CI failures) and the exporter-only "Session High" query was replaced with `max_over_time($client_state_total[24h])`, so no new exporters are required.

### Verification
- `tests/dashboard-timerange-test.sh` — **13 passed, 0 failed**
- `shellcheck --severity=error` on both scripts — clean
- `python3 -m json.tool` — dashboard JSON valid

### Note for reviewers
"Session High" now uses a fixed 24h `max_over_time` window (Window Max already covers `$__range`). If the intended semantic is "peak since service start," 24h is an approximation but needs no exporter.

Supersedes #305 and #314.
