### PR TITLE
chore: bump Grafana 13.2.0 (security) + telemt 3.5.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,7 +156,7 @@ AWGTOOLS_VERSION=3.1.20260812
 # Pre-built binaries: https://github.com/net2share/slipstream-rust-build/releases
 SLIPSTREAM_VERSION=2026.02.22.1
 # telemt (Telegram MTProxy) - https://github.com/telemt/telemt/releases
-TELEMT_VERSION=3.4.25
+TELEMT_VERSION=3.5.2
 # dnstt (KCP+Noise DNS tunnel) - https://www.bamsoftware.com/software/dnstt/
 DNSTT_VERSION=v1.20260501.0
 # MasterDNS (advanced DNS tunnel) - https://github.com/masterking32/MasterDnsVPN
@@ -167,7 +167,7 @@ GOOSERELAY_VERSION=v1.7.1
 XRAY_VERSION=v26.7.28
 # Monitoring stack versions (for moav build --local)
 PROMETHEUS_VERSION=3.13.2
-GRAFANA_VERSION=13.1.3
+GRAFANA_VERSION=13.2.0
 NODE_EXPORTER_VERSION=1.12.1
 CADVISOR_VERSION=0.60.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Grafana updated to 13.2.0, which includes upstream security fixes.
+
+### Changed
+- telemt updated to 3.5.2.
+
 ## [2.2.2] - 2026-08-23
 
 Two new Grafana dashboards and consistent colours across monitoring; AmneziaWG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -444,7 +444,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.telemt
       args:
-        TELEMT_VERSION: ${TELEMT_VERSION:-3.4.23}
+        TELEMT_VERSION: ${TELEMT_VERSION:-3.5.2}
     container_name: moav-telemt
     restart: unless-stopped
     logging: *default-logging

--- a/dockerfiles/Dockerfile.grafana
+++ b/dockerfiles/Dockerfile.grafana
@@ -7,7 +7,7 @@
 
 FROM alpine:3.21
 
-ARG GRAFANA_VERSION=13.1.3
+ARG GRAFANA_VERSION=13.2.0
 ARG TARGETARCH=amd64
 
 RUN apk add --no-cache ca-certificates tzdata bash wget


### PR DESCRIPTION
Component version bumps for the next release (independent of #317).

- **Grafana 13.1.3 → 13.2.0** — includes upstream **security fixes** ([release notes](https://github.com/grafana/grafana/releases/tag/v13.2.0)). Updated in `.env.example` and the `Dockerfile.grafana` ARG default.
- **telemt 3.4.25 → 3.5.2** ([release](https://github.com/telemt/telemt/releases/tag/3.5.2)). Updated in `.env.example` and the `docker-compose.yml` build-arg default.
- CHANGELOG `[Unreleased]` updated (Security + Changed).

Merge after #317 so it lands in the same release train.
