### PR TITLE
fix(amneziawg,wireguard): strip inline .env comment from client Endpoint

### DIFF
--- a/scripts/lib/amneziawg.sh
+++ b/scripts/lib/amneziawg.sh
@@ -346,6 +346,14 @@ amneziawg_generate_client_config() {
         client_addresses="$AWG_CLIENT_IP/32, $AWG_CLIENT_IP_V6/128"
     fi
 
+    # docker-compose env_file does not strip inline comments, so a .env line like
+    # `PORT_AMNEZIAWG=51821 # AmneziaWG (obfuscated WireGuard, UDP)` arrives as the
+    # whole string. Keep only the leading digits, or the generated Endpoint becomes
+    # `IP:51821 # AmneziaWG ...` and clients reject the config outright.
+    local awg_port="${PORT_AMNEZIAWG:-51821}"
+    awg_port="${awg_port%%[!0-9]*}"
+    [[ -n "$awg_port" ]] || awg_port="51821"
+
     # AmneziaWG client config (includes obfuscation params)
     cat > "$output_dir/$(moav_wg_basename awg).conf" <<EOF
 [Interface]
@@ -377,7 +385,7 @@ $dcookies_line
 [Peer]
 PublicKey = $server_public_key
 AllowedIPs = 0.0.0.0/0, ::/0
-Endpoint = ${SERVER_IP}:${PORT_AMNEZIAWG:-51821}
+Endpoint = ${SERVER_IP}:${awg_port}
 PersistentKeepalive = 22-30
 EOF
 
@@ -413,7 +421,7 @@ $dcookies_line
 [Peer]
 PublicKey = $server_public_key
 AllowedIPs = 0.0.0.0/0, ::/0
-Endpoint = [${SERVER_IPV6}]:${PORT_AMNEZIAWG:-51821}
+Endpoint = [${SERVER_IPV6}]:${awg_port}
 PersistentKeepalive = 22-30
 EOF
         log_info "Generated AmneziaWG IPv6 endpoint config"

--- a/scripts/lib/wireguard.sh
+++ b/scripts/lib/wireguard.sh
@@ -195,6 +195,12 @@ wireguard_generate_client_config() {
         client_addresses="$WG_CLIENT_IP/32, $WG_CLIENT_IP_V6/128"
     fi
 
+    # docker-compose env_file keeps inline comments, so `PORT_WIREGUARD=51820 # ...`
+    # would leak the comment into the Endpoint. Keep only the leading digits.
+    local wg_port="${PORT_WIREGUARD:-51820}"
+    wg_port="${wg_port%%[!0-9]*}"
+    [[ -n "$wg_port" ]] || wg_port="51820"
+
     # Direct WireGuard config (IPv4 endpoint)
     cat > "$output_dir/$(moav_wg_basename wg).conf" <<EOF
 [Interface]
@@ -206,7 +212,7 @@ MTU = 1280
 [Peer]
 PublicKey = $server_public_key
 AllowedIPs = 0.0.0.0/0, ::/0
-Endpoint = ${SERVER_IP}:${PORT_WIREGUARD:-51820}
+Endpoint = ${SERVER_IP}:${wg_port}
 PersistentKeepalive = 25
 EOF
 
@@ -222,7 +228,7 @@ MTU = 1280
 [Peer]
 PublicKey = $server_public_key
 AllowedIPs = 0.0.0.0/0, ::/0
-Endpoint = [${SERVER_IPV6}]:${PORT_WIREGUARD:-51820}
+Endpoint = [${SERVER_IPV6}]:${wg_port}
 PersistentKeepalive = 25
 EOF
         log_info "Generated WireGuard IPv6 endpoint config"


### PR DESCRIPTION
## Problem

Importing the AmneziaWG bundle into the updated AmneziaVPN app fails: the QR won't scan and direct file import returns `ErrorCode 900: the config does not contain any containers or credentials`.

Root cause: `docker-compose` `env_file` does **not** strip inline comments, so a `.env` line like

```
PORT_AMNEZIAWG=51821 # AmneziaWG (obfuscated WireGuard, UDP)
```

reaches the config generator as the whole string, producing:

```
Endpoint = <server-ip>:51821 # AmneziaWG (obfuscated WireGuard, UDP)
```

which clients reject outright.

## Fix

When building the client `Endpoint`, keep only the leading digits of `PORT_AMNEZIAWG` / `PORT_WIREGUARD` (v4 and v6 endpoints). `get_env_val` already strips comments, but these two generators used the bare env var.

WireGuard had the identical pattern and is fixed for parity.

## Test

```
in=[51821 # AmneziaWG (obfuscated WireGuard, UDP)] -> out=[51821]
in=[51821]                                          -> out=[51821]
in=[]                                               -> out=[51821]  (default)
```

`bash -n` clean on both files.

## Note

The underlying footgun is inline comments on `PORT_*` value lines in `.env.example`. This PR hardens the generators (fixes existing servers too, whose live `.env` already carries the comment); a follow-up can move those comments to their own lines.