### PR TITLE
fix(amneziawg): make AWG 1.5 header protection opt-in (default off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -303,6 +303,13 @@ PORT_AMNEZIAWG=51821 # AmneziaWG (obfuscated WireGuard, UDP)
 # WireGuard's handshake-flood DoS defence, so default false (cookies on). Applied
 # on bootstrap / `moav regenerate-users`.
 AWG_DISABLE_COOKIES=false
+# AmneziaWG 1.5 header-protection obfuscation (HeaderProtectionKey / content
+# padding / random trailers). Default false for broad client compatibility: the
+# AmneziaVPN app's .conf importer silently drops these keys, so a bundle imported
+# there connects but relays no traffic. The dedicated AmneziaWG app supports them.
+# Set true only when every client uses the AmneziaWG app; changing it requires
+# re-issuing user bundles (moav regenerate-users) so client and server match.
+AMNEZIAWG_HEADER_PROTECTION=false
 PORT_TRUSTTUNNEL=4443 # TrustTunnel (HTTP/2 + QUIC)
 PORT_TELEMT=993      # Telegram MTProxy (fake-TLS on IMAPS port)
 PORT_XHTTP=2096      # XHTTP (VLESS+XHTTP+Reality via Xray-core)

--- a/scripts/lib/amneziawg.sh
+++ b/scripts/lib/amneziawg.sh
@@ -146,6 +146,18 @@ generate_amneziawg_config() {
     local awg_dcookies=""
     [[ "${AWG_DISABLE_COOKIES:-false}" == "true" ]] && awg_dcookies="DisableCookies = on"
 
+    # AWG 1.5 header-protection obfuscation (HeaderProtectionKey / ContentPadding /
+    # RandomTrailers). OFF by default: the AmneziaVPN app's .conf importer silently
+    # drops these keys, so a bundle imported there sends un-protected handshakes the
+    # server can no longer parse -> connects but relays zero traffic. The dedicated
+    # AmneziaWG app supports them. Enable only when every client runs the AmneziaWG
+    # app, for stronger obfuscation. Read at generation time so regenerate applies it.
+    local awg_hdrprot=""
+    if [[ "${AMNEZIAWG_HEADER_PROTECTION:-false}" == "true" ]]; then
+        printf -v awg_hdrprot 'HeaderProtectionKey = %s\nContentPaddingAddition = %s\nRandomTrailers = %s' \
+            "$AWG_H_KEY" "$AWG_CPA" "$AWG_RTRAILERS"
+    fi
+
     cat > "$AWG_CONFIG_DIR/awg0.conf" <<EOF
 [Interface]
 Address = $server_addresses
@@ -163,14 +175,12 @@ H1 = $AWG_H1
 H2 = $AWG_H2
 H3 = $AWG_H3
 H4 = $AWG_H4
-HeaderProtectionKey = $AWG_H_KEY
-ContentPaddingAddition = $AWG_CPA
+$awg_hdrprot
 RekeyAfterTime = $AWG_REKEY_AFTER
 RekeyTimeout = $AWG_REKEY_TIMEOUT
 RejectAfterTime = $AWG_REJECT_AFTER
 KeepaliveTimeout = $AWG_KEEPALIVE_TIMEOUT
 MaxHandshakeAttempts = $AWG_MAX_HANDSHAKE
-RandomTrailers = $AWG_RTRAILERS
 $awg_dcookies
 PostUp = $postup_rules
 PostDown = $postdown_rules
@@ -337,6 +347,16 @@ amneziawg_generate_client_config() {
     local dcookies_line=""
     [[ -n "$AWG_DCOOKIES" ]] && dcookies_line="DisableCookies = $AWG_DCOOKIES"
 
+    # Mirror the server's awg0.conf: emit the AWG 1.5 header-protection block only
+    # when the server actually has it (AMNEZIAWG_HEADER_PROTECTION=true). Empty ->
+    # omit, so a compat-mode bundle never ships a bare `HeaderProtectionKey =` and
+    # every client (incl. the AmneziaVPN importer) can handshake.
+    local awg_hdrprot=""
+    if [[ -n "$AWG_HKEY" ]]; then
+        printf -v awg_hdrprot 'HeaderProtectionKey = %s\nContentPaddingAddition = %s\nRandomTrailers = %s' \
+            "$AWG_HKEY" "$AWG_CPA" "$AWG_RTRAILERS"
+    fi
+
     local server_public_key
     server_public_key=$(cat "$AWG_CONFIG_DIR/server.pub")
 
@@ -364,14 +384,12 @@ H1 = $AWG_H1
 H2 = $AWG_H2
 H3 = $AWG_H3
 H4 = $AWG_H4
-HeaderProtectionKey = $AWG_HKEY
-ContentPaddingAddition = $AWG_CPA
+$awg_hdrprot
 RekeyAfterTime = $AWG_REKEY_AFTER
 RekeyTimeout = $AWG_REKEY_TIMEOUT
 RejectAfterTime = $AWG_REJECT_AFTER
 KeepaliveTimeout = $AWG_KEEPALIVE_TIMEOUT
 MaxHandshakeAttempts = $AWG_MAX_HANDSHAKE
-RandomTrailers = $AWG_RTRAILERS
 $dcookies_line
 
 [Peer]
@@ -400,14 +418,12 @@ H1 = $AWG_H1
 H2 = $AWG_H2
 H3 = $AWG_H3
 H4 = $AWG_H4
-HeaderProtectionKey = $AWG_HKEY
-ContentPaddingAddition = $AWG_CPA
+$awg_hdrprot
 RekeyAfterTime = $AWG_REKEY_AFTER
 RekeyTimeout = $AWG_REKEY_TIMEOUT
 RejectAfterTime = $AWG_REJECT_AFTER
 KeepaliveTimeout = $AWG_KEEPALIVE_TIMEOUT
 MaxHandshakeAttempts = $AWG_MAX_HANDSHAKE
-RandomTrailers = $AWG_RTRAILERS
 $dcookies_line
 
 [Peer]

--- a/tests/amneziawg-v3-test.sh
+++ b/tests/amneziawg-v3-test.sh
@@ -67,16 +67,32 @@ is_wgkey "$hk" && ok "HeaderProtectionKey is a base64 wg key" || bad "HeaderProt
 before=$(wc -l < "$env_file"); amneziawg_ensure_v3_params; after=$(wc -l < "$env_file")
 [ "$before" = "$after" ] && ok "ensure_v3_params is idempotent" || bad "ensure_v3_params duplicated ($before->$after)"
 
-# --- 2. server awg0.conf carries every v3 key ---------------------------------
+# --- 2. server awg0.conf: always-on obf params, gated header protection --------
 export STATE_DIR="$WORK/s2"; AWG_CONFIG_DIR="$WORK/s2/cfg"
 mkdir -p "$STATE_DIR/keys" "$AWG_CONFIG_DIR"
 export SERVER_IP="203.0.113.10"
-generate_amneziawg_config >/dev/null 2>&1
+generate_amneziawg_config >/dev/null 2>&1   # default: header protection OFF
 conf="$AWG_CONFIG_DIR/awg0.conf"
-for key in "S3 =" "S4 =" "HeaderProtectionKey =" "ContentPaddingAddition =" \
-           "RekeyAfterTime =" "RekeyTimeout =" "RejectAfterTime =" \
-           "KeepaliveTimeout =" "MaxHandshakeAttempts =" "RandomTrailers ="; do
+# S3/S4 + randomized timings are supported by every client, always emitted.
+for key in "S3 =" "S4 =" "RekeyAfterTime =" "RekeyTimeout =" "RejectAfterTime =" \
+           "KeepaliveTimeout =" "MaxHandshakeAttempts ="; do
     grep -q "^${key}" "$conf" && ok "awg0.conf has ${key%% *}" || bad "awg0.conf missing ${key%% *}"
+done
+# The AWG 1.5 header-protection block is OFF by default: the AmneziaVPN app's
+# .conf importer drops these keys, so emitting them makes that client connect
+# but relay nothing. Regression net for that bug.
+for key in "HeaderProtectionKey =" "ContentPaddingAddition =" "RandomTrailers ="; do
+    grep -q "^${key}" "$conf" && bad "awg0.conf emits ${key%% *} by default (breaks AmneziaVPN import)" \
+        || ok "awg0.conf omits ${key%% *} by default"
+done
+
+# --- 2c. AMNEZIAWG_HEADER_PROTECTION=true opts back into the block -------------
+export STATE_DIR="$WORK/s2h"; AWG_CONFIG_DIR="$WORK/s2h/cfg"
+mkdir -p "$STATE_DIR/keys" "$AWG_CONFIG_DIR"
+AMNEZIAWG_HEADER_PROTECTION=true generate_amneziawg_config >/dev/null 2>&1
+hconf="$AWG_CONFIG_DIR/awg0.conf"
+for key in "HeaderProtectionKey =" "ContentPaddingAddition =" "RandomTrailers ="; do
+    grep -q "^${key}" "$hconf" && ok "opt-in emits ${key%% *}" || bad "opt-in missing ${key%% *}"
 done
 
 # --- 2b. DisableCookies toggle: absent by default, present when opted in -------
@@ -90,27 +106,53 @@ grep -q "^DisableCookies = on" "$AWG_CONFIG_DIR/awg0.conf" \
 # restore the default-config path for section 3
 export STATE_DIR="$WORK/s2"; AWG_CONFIG_DIR="$WORK/s2/cfg"; conf="$AWG_CONFIG_DIR/awg0.conf"
 
-# --- 3. client config carries the v3 keys + a keepalive range -----------------
+# --- 3. compat-mode client mirrors the compat server (no header protection) ----
+# STATE_DIR/AWG_CONFIG_DIR are the default (compat) server from section 2.
 user="tester"
-mkdir -p "$STATE_DIR/users/$user"
-cat > "$STATE_DIR/users/$user/amneziawg.env" <<EOF
+mk_user_env() {   # $1 = STATE_DIR
+    mkdir -p "$1/users/$user"
+    cat > "$1/users/$user/amneziawg.env" <<EOF
 AWG_PRIVATE_KEY=$(wg genkey)
 AWG_PUBLIC_KEY=$(wg genkey)
 AWG_CLIENT_IP=10.67.67.2
 EOF
+}
+mk_user_env "$STATE_DIR"
 out="$WORK/out"; mkdir -p "$out"
 amneziawg_generate_client_config "$user" "$out" >/dev/null 2>&1
 cconf=$(ls "$out"/*awg*.conf 2>/dev/null | head -1)
 if [ -z "$cconf" ]; then
     bad "no client config produced"
 else
-    for key in "HeaderProtectionKey =" "S3 =" "S4 =" "ContentPaddingAddition ="; do
+    for key in "S3 =" "S4 ="; do
         grep -q "^${key}" "$cconf" && ok "client conf has ${key%% *}" || bad "client conf missing ${key%% *}"
+    done
+    # Mirrors the compat server: the header-protection keys the AmneziaVPN
+    # importer drops must NOT be in the bundle either, or client and server
+    # disagree on the wire format and the tunnel connects with no traffic.
+    for key in "HeaderProtectionKey =" "ContentPaddingAddition =" "RandomTrailers ="; do
+        grep -q "^${key}" "$cconf" && bad "compat client conf has ${key%% *} (server omits it)" \
+            || ok "compat client conf omits ${key%% *}"
     done
     grep -qE '^PersistentKeepalive = [0-9]+-[0-9]+$' "$cconf" \
         && ok "client conf keepalive is a range" || bad "client conf keepalive not a range"
-    skey=$(awk '/^HeaderProtectionKey/{print $3; exit}' "$conf")
-    ckey=$(awk '/^HeaderProtectionKey/{print $3; exit}' "$cconf")
+fi
+
+# --- 3b. header-protection client mirrors the opt-in server, keys match --------
+export STATE_DIR="$WORK/s2h"; AWG_CONFIG_DIR="$WORK/s2h/cfg"
+mk_user_env "$STATE_DIR"
+outh="$WORK/outh"; mkdir -p "$outh"
+amneziawg_generate_client_config "$user" "$outh" >/dev/null 2>&1
+hcconf=$(ls "$outh"/*awg*.conf 2>/dev/null | head -1)
+if [ -z "$hcconf" ]; then
+    bad "no header-protection client config produced"
+else
+    for key in "HeaderProtectionKey =" "ContentPaddingAddition =" "RandomTrailers ="; do
+        grep -q "^${key}" "$hcconf" && ok "hdrprot client conf has ${key%% *}" \
+            || bad "hdrprot client conf missing ${key%% *}"
+    done
+    skey=$(awk '/^HeaderProtectionKey/{print $3; exit}' "$hconf")
+    ckey=$(awk '/^HeaderProtectionKey/{print $3; exit}' "$hcconf")
     [ -n "$skey" ] && [ "$skey" = "$ckey" ] \
         && ok "client HeaderProtectionKey matches server" || bad "client/server HeaderProtectionKey differ"
 fi


### PR DESCRIPTION
## Problem

Since the Aug-14 `amneziawg-go v3.1.20260814` bump, the generator enabled three AWG 1.5 obfuscation params on `awg0` and in every client bundle:

- `HeaderProtectionKey`
- `ContentPaddingAddition`
- `RandomTrailers`

The **dedicated AmneziaWG app** supports these and works. But the **AmneziaVPN app**'s `.conf` importer (recently added) **silently drops all three** — verified from a client's own logs: the params never appear in the config the app loads. The client then sends handshakes without header-protection/content-padding, the server (which requires them) can't parse the initiation, and drops it → **connects but relays zero traffic**, for every peer.

## Fix

Gate the three params behind `AMNEZIAWG_HEADER_PROTECTION` (**default false**):

- Compat default omits them from both the server `awg0.conf` and client bundles → every current client (both apps) handshakes.
- Operators whose users all run the AmneziaWG app can set `AMNEZIAWG_HEADER_PROTECTION=true` for the stronger obfuscation.
- The client generator emits the block **only when the server's `awg0.conf` actually has it**, so client and server can never disagree on the wire format (no bare `HeaderProtectionKey =`).

`S3`/`S4`, `H1`-`H4` and the randomized timings stay always-on — every client applies those, and they don't break the importer.

## Test

`tests/amneziawg-v3-test.sh` rewritten to pin the new contract: default omits the block (server + client), opt-in emits it, and the client mirrors the server (key match). 40/40 pass.

## Rollout note

Because one `awg0` interface has a single obfuscation profile, flipping an existing server to compat mode requires re-issuing user bundles (`moav regenerate-users`) so client and server match. New installs get the compat default automatically.