### PR TITLE
feat(snowflake): cumulative log-based exporter for restart-proof dashboard totals

### DIFF
--- a/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
@@ -70,6 +70,7 @@
             "uid": "prometheus"
           },
           "expr": "sum(moav_snowflake_completed_connections_total)",
+          "instant": true,
           "refId": "A"
         }
       ],
@@ -290,6 +291,7 @@
             "uid": "prometheus"
           },
           "expr": "sum(moav_snowflake_relayed_bytes_window{direction=\"inbound\",window=\"14d\"})",
+          "instant": true,
           "refId": "A"
         }
       ],
@@ -401,6 +403,7 @@
             "uid": "prometheus"
           },
           "expr": "sum(moav_snowflake_relayed_bytes_window{direction=\"outbound\",window=\"14d\"})",
+          "instant": true,
           "refId": "A"
         }
       ],

--- a/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
@@ -69,7 +69,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(moav_snowflake_completed_connections_total[$__range]))",
+          "expr": "sum(moav_snowflake_completed_connections_total)",
           "refId": "A"
         }
       ],
@@ -331,7 +331,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"inbound\"}[$__range]))",
+          "expr": "sum(moav_snowflake_relayed_bytes_total{direction=\"inbound\"})",
           "refId": "A",
           "instant": true,
           "datasource": {
@@ -442,7 +442,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"outbound\"}[$__range]))",
+          "expr": "sum(moav_snowflake_relayed_bytes_total{direction=\"outbound\"})",
           "refId": "A",
           "instant": true,
           "datasource": {
@@ -676,7 +676,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(moav_snowflake_completed_connections_total[$__rate_interval]))",
+          "expr": "sum(moav_snowflake_completed_connections_total)",
           "legendFormat": "connections/hour",
           "refId": "A"
         }

--- a/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
@@ -289,12 +289,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"inbound\"}[14d]))",
+          "expr": "sum(moav_snowflake_relayed_bytes_window{direction=\"inbound\",window=\"14d\"})",
           "refId": "A"
         }
       ],
       "title": "Downloaded (14 days)",
-      "description": "Relayed to clients over the last 14 days, which is how long Prometheus keeps data. Fixed window: it ignores the time picker. snowflake's counters restart with the container, so this is an increase() over the window rather than the raw counter, which would drop to zero on every restart.",
+      "description": "Relayed to clients over the last 14 days. Fixed window: it ignores the time picker. Summed by the exporter from the proxy log's own timestamps, so it is accurate immediately and after any restart (a backfilled counter's increase() would read zero).",
       "type": "stat"
     },
     {
@@ -400,12 +400,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"outbound\"}[14d]))",
+          "expr": "sum(moav_snowflake_relayed_bytes_window{direction=\"outbound\",window=\"14d\"})",
           "refId": "A"
         }
       ],
       "title": "Uploaded (14 days)",
-      "description": "Relayed from clients over the last 14 days. Fixed window: it ignores the time picker. snowflake's counters restart with the container, so this is an increase() over the window rather than the raw counter, which would drop to zero on every restart.",
+      "description": "Relayed from clients over the last 14 days. Fixed window: it ignores the time picker. Summed by the exporter from the proxy log's own timestamps, so it is accurate immediately and after any restart (a backfilled counter's increase() would read zero).",
       "type": "stat"
     },
     {
@@ -1357,14 +1357,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"inbound\"}[1h])) + sum(increase(moav_snowflake_relayed_bytes_total{direction=\"outbound\"}[1h]))",
+          "expr": "sum(increase(tor_snowflake_proxy_traffic_inbound_bytes_total[1h])) * 1024 + sum(increase(tor_snowflake_proxy_traffic_outbound_bytes_total[1h])) * 1024",
           "legendFormat": "donated",
           "refId": "A"
         }
       ],
       "title": "Bandwidth Donated (per hour)",
       "type": "timeseries",
-      "description": "Relayed each hour, both directions. Was a running total, which fell off a cliff every time the container restarted."
+      "description": "Bytes relayed each hour, both directions, from the proxy's live metrics. Zero when the proxy is idle; it fills in as traffic flows. Hours before the current proxy session are not retained here — the lifetime and 14-day tiles above carry the totals."
     }
   ],
   "refresh": "30s",

--- a/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
+++ b/configs/monitoring/grafana/provisioning/dashboards/snowflake.json
@@ -69,7 +69,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max_over_time(tor_snowflake_proxy_connections_total[$__range]))",
+          "expr": "sum(increase(moav_snowflake_completed_connections_total[$__range]))",
           "refId": "A"
         }
       ],
@@ -289,7 +289,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(tor_snowflake_proxy_traffic_inbound_bytes_total[14d])) * 1024",
+          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"inbound\"}[14d]))",
           "refId": "A"
         }
       ],
@@ -331,7 +331,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(tor_snowflake_proxy_traffic_inbound_bytes_total[$__range])) * 1024",
+          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"inbound\"}[$__range]))",
           "refId": "A",
           "instant": true,
           "datasource": {
@@ -400,7 +400,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(tor_snowflake_proxy_traffic_outbound_bytes_total[14d])) * 1024",
+          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"outbound\"}[14d]))",
           "refId": "A"
         }
       ],
@@ -442,7 +442,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(tor_snowflake_proxy_traffic_outbound_bytes_total[$__range])) * 1024",
+          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"outbound\"}[$__range]))",
           "refId": "A",
           "instant": true,
           "datasource": {
@@ -676,7 +676,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max_over_time(tor_snowflake_proxy_connections_total[$__rate_interval]))",
+          "expr": "sum(increase(moav_snowflake_completed_connections_total[$__rate_interval]))",
           "legendFormat": "connections/hour",
           "refId": "A"
         }
@@ -1357,7 +1357,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(tor_snowflake_proxy_traffic_inbound_bytes_total[1h])) * 1024 + sum(increase(tor_snowflake_proxy_traffic_outbound_bytes_total[1h])) * 1024",
+          "expr": "sum(increase(moav_snowflake_relayed_bytes_total{direction=\"inbound\"}[1h])) + sum(increase(moav_snowflake_relayed_bytes_total{direction=\"outbound\"}[1h]))",
           "legendFormat": "donated",
           "refId": "A"
         }

--- a/configs/monitoring/prometheus.yml
+++ b/configs/monitoring/prometheus.yml
@@ -62,11 +62,11 @@ scrape_configs:
       - targets: ['psiphon-conduit:9090']
     scrape_timeout: 10s
 
-  # Snowflake Exporter - parses snowflake proxy logs for metrics
+  # Snowflake native metrics - the proxy's own /internal/metrics endpoint.
   # NOTE: Only available when running with --profile snowflake
-  # The proxy's own Prometheus endpoint. This replaced a 213-line log-parsing
-  # exporter of ours: it carries the same connection and traffic counters, plus a
-  # per-country breakdown and a failure counter we never had.
+  # Authoritative for per-country connections and connection failures. Its byte
+  # and connection counters are IN-MEMORY and reset to zero on every proxy
+  # restart, so the cumulative totals come from snowflake-exporter (below).
   - job_name: 'snowflake-proxy'
     metrics_path: /internal/metrics
     # snowflake runs with network_mode: host (it needs the host's NAT behaviour),
@@ -74,6 +74,14 @@ scrape_configs:
     # declares host.docker.internal:host-gateway for exactly this case.
     static_configs:
       - targets: ['host.docker.internal:9998']
+    scrape_timeout: 10s
+
+  # Snowflake cumulative exporter - lifetime bytes relayed + connections served,
+  # parsed from the proxy's persistent summary log so they survive restarts (the
+  # native counters above do not). On moav_net, scraped by service DNS name.
+  - job_name: 'snowflake-cumulative'
+    static_configs:
+      - targets: ['snowflake-exporter:9105']
     scrape_timeout: 10s
 
   # telemt - Telegram MTProxy native Prometheus metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1211,6 +1211,41 @@ services:
       - monitoring
       - all
 
+  # Snowflake cumulative exporter - parses the proxy's persistent summary log
+  # into lifetime byte/connection counters that survive proxy restarts. The
+  # native /internal/metrics counters (scraped directly, see prometheus.yml
+  # 'snowflake-proxy') reset to zero on every restart and stay authoritative for
+  # per-country + failures; this fills the cumulative gap.
+  snowflake-exporter:
+    build:
+      context: ./exporters
+      dockerfile: snowflake/Dockerfile
+    container_name: moav-snowflake-exporter
+    restart: unless-stopped
+    logging: *default-logging
+    networks:
+      - moav_net
+    volumes:
+      - moav_snowflake_logs:/var/log/snowflake:ro
+      - moav_exporter_state:/var/lib/moav-exporter-state
+    environment:
+      - TZ=${TZ:-UTC}
+      - SNOWFLAKE_STATE_FILE=/var/lib/moav-exporter-state/snowflake-state.json
+    expose:
+      - "9105"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,size=10m
+    mem_limit: 64m
+    cpus: 0.25
+    profiles:
+      - monitoring
+      - all
+
   # AmneziaWG Exporter - custom per-peer traffic metrics
   amneziawg-exporter:
     build:

--- a/exporters/snowflake/Dockerfile
+++ b/exporters/snowflake/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-alpine
+
+# Stdlib only: this exporter parses the proxy's persistent summary log (a
+# read-only volume) and keeps a small JSON state file on its own volume. No
+# pip deps, no docker socket, no network egress.
+
+WORKDIR /app
+COPY snowflake/main.py .
+
+EXPOSE 9105
+
+CMD ["python", "-u", "main.py"]

--- a/exporters/snowflake/main.py
+++ b/exporters/snowflake/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Snowflake cumulative Prometheus exporter.
+Snowflake cumulative + windowed Prometheus exporter.
 
 The proxy's own /internal/metrics endpoint (scraped directly by Prometheus) is
 authoritative for per-country connections and connection failures, but its
@@ -9,21 +9,33 @@ restarts. A dashboard that sums them therefore shows only the traffic since the
 last restart -- which is why a proxy that relayed tens of GB reads near-zero
 after a routine `docker compose up -d`.
 
-This exporter closes that gap. It reads the proxy's persistent summary log
-(tee'd to a named volume that survives container recreation) and accumulates the
-per-window totals into monotonic counters that persist across BOTH proxy
-restarts (the log volume) AND its own restarts (a small state file). The result
-is a lifetime "bytes relayed / connections served" that only ever goes up.
+This exporter closes that gap by reading the proxy's persistent summary log
+(tee'd to a named volume that survives container recreation). It exposes two
+kinds of metric, both derived from the log so both survive proxy AND exporter
+restarts:
+
+  * Cumulative counters -- lifetime bytes relayed / connections served. Seeded
+    from a state file so they only ever go up. Backfilled in one pass, so they
+    are FLAT afterwards: read them raw for a lifetime total, NEVER with
+    increase()/rate() over a range (there is no per-scrape history to diff).
+
+  * Trailing-window gauges -- bytes/connections within the last 1h/24h/7d/14d,
+    summed from the log's OWN timestamps. This is what the "last N days" panels
+    need: Prometheus stamps samples at scrape time, so a backfilled counter can
+    never answer "how much in the last 14 days" via increase(); computing it
+    from the log timestamps can, and it is correct immediately and after any
+    restart.
 
 Split of responsibility (see tests/snowflake-metrics-test.sh):
   native /internal/metrics  -> per-country, failures, live throughput (rate)
-  this exporter             -> cumulative bytes relayed + connections served
+  this exporter             -> cumulative + windowed bytes/connections
 
 Summary line format (snowflake proxy, -summary-interval):
   2026/08/26 16:37:41 In the last 1m30s, there were 3 completed successful
   connections. Traffic Relayed ↓ 8667 KB (0.00 KB/s), ↑ 512 KB (0.00 KB/s).
 """
 
+import datetime
 import json
 import os
 import re
@@ -35,6 +47,15 @@ LOG_FILE = os.environ.get("SNOWFLAKE_LOG_FILE", "/var/log/snowflake/snowflake.lo
 STATE_FILE = os.environ.get("SNOWFLAKE_STATE_FILE", "/var/lib/snowflake-exporter/state.json")
 PORT = int(os.environ.get("SNOWFLAKE_EXPORTER_PORT", "9105"))
 POLL_INTERVAL = int(os.environ.get("SNOWFLAKE_POLL_INTERVAL", "15"))
+# Recompute the trailing-window gauges every Nth poll (they need minutes, not
+# seconds, of freshness, and each rebuild re-parses a log tail).
+WINDOW_EVERY = max(1, int(os.environ.get("SNOWFLAKE_WINDOW_EVERY", "4")))
+# How much of the log tail to re-parse for the windows. 8 MB of ~150-byte
+# summary lines at one per 90s covers well over 14 days.
+WINDOW_TAIL_BYTES = int(os.environ.get("SNOWFLAKE_WINDOW_TAIL_BYTES", str(8_000_000)))
+
+# Trailing windows to expose, label -> seconds.
+WINDOWS = {"1h": 3600, "24h": 86400, "7d": 604800, "14d": 1209600}
 
 # KB=1024 to match the native traffic counters, which the dashboard already
 # scales by 1024 (tests/snowflake-metrics-test.sh trap #2). Snowflake's own log
@@ -48,6 +69,10 @@ UNIT_BYTES = {
     "TB": 1024 ** 4, "TIB": 1024 ** 4,
 }
 
+# Leading log timestamp, e.g. "2026/08/26 16:37:41". Parsed naive: the snowflake
+# and exporter containers share one TZ env, so naive-vs-naive age is correct
+# without assuming which zone it is.
+TS_RE = re.compile(r"^(\d{4})/(\d{2})/(\d{2}) (\d{2}):(\d{2}):(\d{2})")
 # "there were N completed successful connections"
 CONN_RE = re.compile(r"there were (\d+) completed successful connection")
 # "Traffic Relayed ↓ X UNIT (...), ↑ Y UNIT (...)". Down (↓) is inbound to
@@ -67,11 +92,66 @@ state = {
     "last_summary": 0,    # epoch of the newest parsed summary line
 }
 state_lock = threading.Lock()
+
+# Trailing-window rollups, recomputed from the log tail. Served under its own
+# lock so a slow rebuild never blocks the cumulative poll.
+window_state = {"bytes": {}, "conns": {}, "computed_at": 0}
+window_lock = threading.Lock()
 exporter_ready = False
 
 
 def _to_bytes(value: str, unit: str) -> int:
     return int(float(value) * UNIT_BYTES.get(unit.upper(), 0))
+
+
+def parse_dt(line: str):
+    """Datetime from a summary line's leading timestamp, or None."""
+    m = TS_RE.match(line)
+    if not m:
+        return None
+    try:
+        return datetime.datetime(*(int(x) for x in m.groups()))
+    except ValueError:
+        return None
+
+
+def parse_counts(line: str):
+    """(connections, inbound_bytes, outbound_bytes) for a summary line, or None."""
+    cm = CONN_RE.search(line)
+    if not cm:
+        return None
+    tm = TRAFFIC_RE.search(line)
+    inb = _to_bytes(tm.group(1), tm.group(2)) if tm else 0
+    outb = _to_bytes(tm.group(3), tm.group(4)) if tm else 0
+    return int(cm.group(1)), inb, outb
+
+
+def compute_windows(text, now):
+    """Sum bytes/connections per trailing window from timestamped summary lines.
+
+    Pure: given the log text and a `now` datetime, return (bytes, conns) where
+    bytes maps (direction, window) -> int and conns maps window -> int. Lines
+    without a parseable timestamp or count are skipped.
+    """
+    b = {(d, w): 0 for d in ("inbound", "outbound") for w in WINDOWS}
+    c = {w: 0 for w in WINDOWS}
+    for line in text.splitlines():
+        dt = parse_dt(line)
+        if dt is None:
+            continue
+        counts = parse_counts(line)
+        if counts is None:
+            continue
+        conns, inb, outb = counts
+        age = (now - dt).total_seconds()
+        if age < 0:
+            age = 0.0
+        for w, secs in WINDOWS.items():
+            if age <= secs:
+                b[("inbound", w)] += inb
+                b[("outbound", w)] += outb
+                c[w] += conns
+    return b, c
 
 
 def load_state():
@@ -110,14 +190,13 @@ def save_state():
 
 def parse_line(line: str):
     """Add one summary line's counts to the cumulative state (caller holds lock)."""
-    m = CONN_RE.search(line)
-    if not m:
+    counts = parse_counts(line)
+    if counts is None:
         return  # not a summary line
-    state["connections"] += int(m.group(1))
-    t = TRAFFIC_RE.search(line)
-    if t:
-        state["inbound_bytes"] += _to_bytes(t.group(1), t.group(2))
-        state["outbound_bytes"] += _to_bytes(t.group(3), t.group(4))
+    conns, inb, outb = counts
+    state["connections"] += conns
+    state["inbound_bytes"] += inb
+    state["outbound_bytes"] += outb
     state["windows"] += 1
     state["last_summary"] = int(time.time())
 
@@ -161,10 +240,36 @@ def poll_once():
     save_state()
 
 
+def rebuild_windows():
+    """Recompute the trailing-window gauges from a bounded tail of the log."""
+    try:
+        st = os.stat(LOG_FILE)
+    except OSError:
+        return
+    try:
+        with open(LOG_FILE, "rb") as fh:
+            if st.st_size > WINDOW_TAIL_BYTES:
+                fh.seek(st.st_size - WINDOW_TAIL_BYTES)
+                fh.readline()  # drop the partial line the seek landed inside
+            text = fh.read().decode("utf-8", "replace")
+    except OSError as exc:
+        print(f"snowflake-exporter: cannot read log tail for windows: {exc}")
+        return
+    b, c = compute_windows(text, datetime.datetime.now())
+    with window_lock:
+        window_state["bytes"] = b
+        window_state["conns"] = c
+        window_state["computed_at"] = int(time.time())
+
+
 def poll_loop():
     global exporter_ready
+    n = 0
     while True:
         poll_once()
+        if n % WINDOW_EVERY == 0:
+            rebuild_windows()
+        n += 1
         exporter_ready = True
         time.sleep(POLL_INTERVAL)
 
@@ -178,15 +283,30 @@ class MetricsHandler(BaseHTTPRequestHandler):
 
         with state_lock:
             snap = dict(state)
+        with window_lock:
+            wb = dict(window_state["bytes"])
+            wc = dict(window_state["conns"])
 
         out = [
-            "# HELP moav_snowflake_relayed_bytes_total Cumulative bytes relayed to Snowflake clients, across proxy and exporter restarts.",
+            "# HELP moav_snowflake_relayed_bytes_total Cumulative bytes relayed to Snowflake clients, across proxy and exporter restarts. Read raw for a lifetime total; the counter is backfilled flat, so increase()/rate() over a range reads 0.",
             "# TYPE moav_snowflake_relayed_bytes_total counter",
             f'moav_snowflake_relayed_bytes_total{{direction="inbound"}} {snap["inbound_bytes"]}',
             f'moav_snowflake_relayed_bytes_total{{direction="outbound"}} {snap["outbound_bytes"]}',
-            "# HELP moav_snowflake_completed_connections_total Cumulative completed successful connections, across restarts.",
+            "# HELP moav_snowflake_completed_connections_total Cumulative completed successful connections, across restarts. Read raw (backfilled flat).",
             "# TYPE moav_snowflake_completed_connections_total counter",
             f'moav_snowflake_completed_connections_total {snap["connections"]}',
+            "# HELP moav_snowflake_relayed_bytes_window Bytes relayed within a trailing window, summed from the log's own timestamps (restart-independent).",
+            "# TYPE moav_snowflake_relayed_bytes_window gauge",
+        ]
+        for (d, w) in sorted(wb):
+            out.append(f'moav_snowflake_relayed_bytes_window{{direction="{d}",window="{w}"}} {wb[(d, w)]}')
+        out += [
+            "# HELP moav_snowflake_completed_connections_window Completed connections within a trailing window, from the log timestamps.",
+            "# TYPE moav_snowflake_completed_connections_window gauge",
+        ]
+        for w in sorted(wc):
+            out.append(f'moav_snowflake_completed_connections_window{{window="{w}"}} {wc[w]}')
+        out += [
             "# HELP moav_snowflake_summary_windows_total Number of proxy summary windows parsed from the log.",
             "# TYPE moav_snowflake_summary_windows_total counter",
             f'moav_snowflake_summary_windows_total {snap["windows"]}',

--- a/exporters/snowflake/main.py
+++ b/exporters/snowflake/main.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Snowflake cumulative Prometheus exporter.
+
+The proxy's own /internal/metrics endpoint (scraped directly by Prometheus) is
+authoritative for per-country connections and connection failures, but its
+byte/connection counters are in-memory and RESET to zero every time the proxy
+restarts. A dashboard that sums them therefore shows only the traffic since the
+last restart -- which is why a proxy that relayed tens of GB reads near-zero
+after a routine `docker compose up -d`.
+
+This exporter closes that gap. It reads the proxy's persistent summary log
+(tee'd to a named volume that survives container recreation) and accumulates the
+per-window totals into monotonic counters that persist across BOTH proxy
+restarts (the log volume) AND its own restarts (a small state file). The result
+is a lifetime "bytes relayed / connections served" that only ever goes up.
+
+Split of responsibility (see tests/snowflake-metrics-test.sh):
+  native /internal/metrics  -> per-country, failures, live throughput (rate)
+  this exporter             -> cumulative bytes relayed + connections served
+
+Summary line format (snowflake proxy, -summary-interval):
+  2026/08/26 16:37:41 In the last 1m30s, there were 3 completed successful
+  connections. Traffic Relayed ↓ 8667 KB (0.00 KB/s), ↑ 512 KB (0.00 KB/s).
+"""
+
+import json
+import os
+import re
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+LOG_FILE = os.environ.get("SNOWFLAKE_LOG_FILE", "/var/log/snowflake/snowflake.log")
+STATE_FILE = os.environ.get("SNOWFLAKE_STATE_FILE", "/var/lib/snowflake-exporter/state.json")
+PORT = int(os.environ.get("SNOWFLAKE_EXPORTER_PORT", "9105"))
+POLL_INTERVAL = int(os.environ.get("SNOWFLAKE_POLL_INTERVAL", "15"))
+
+# KB=1024 to match the native traffic counters, which the dashboard already
+# scales by 1024 (tests/snowflake-metrics-test.sh trap #2). Snowflake's own log
+# uses decimal KB; the ~2.4% delta is accepted so the cumulative panels and the
+# live-throughput panels on the same dashboard agree with each other.
+UNIT_BYTES = {
+    "B": 1,
+    "KB": 1024, "KIB": 1024,
+    "MB": 1024 ** 2, "MIB": 1024 ** 2,
+    "GB": 1024 ** 3, "GIB": 1024 ** 3,
+    "TB": 1024 ** 4, "TIB": 1024 ** 4,
+}
+
+# "there were N completed successful connections"
+CONN_RE = re.compile(r"there were (\d+) completed successful connection")
+# "Traffic Relayed ↓ X UNIT (...), ↑ Y UNIT (...)". Down (↓) is inbound to
+# match the native tor_snowflake_proxy_traffic_inbound_bytes_total naming.
+TRAFFIC_RE = re.compile(
+    r"Relayed\s+↓\s*([\d.]+)\s*([KMGT]?i?B)\b.*?↑\s*([\d.]+)\s*([KMGT]?i?B)\b"
+)
+
+# Cumulative state. Seeded from disk, advanced by the poll loop, served as-is.
+state = {
+    "offset": 0,          # byte offset read so far in the current log file
+    "inode": 0,           # inode of the log file (rotation detection)
+    "connections": 0,     # cumulative completed connections
+    "inbound_bytes": 0,   # cumulative down / relayed-to-client bytes
+    "outbound_bytes": 0,  # cumulative up bytes
+    "windows": 0,         # number of summary windows parsed (debug/freshness)
+    "last_summary": 0,    # epoch of the newest parsed summary line
+}
+state_lock = threading.Lock()
+exporter_ready = False
+
+
+def _to_bytes(value: str, unit: str) -> int:
+    return int(float(value) * UNIT_BYTES.get(unit.upper(), 0))
+
+
+def load_state():
+    """Seed cumulative totals from the persisted state file, if present."""
+    try:
+        with open(STATE_FILE) as fh:
+            saved = json.load(fh)
+        with state_lock:
+            for k in state:
+                if k in saved:
+                    state[k] = saved[k]
+        print(f"snowflake-exporter: resumed state from {STATE_FILE} "
+              f"(offset={state['offset']}, windows={state['windows']})")
+    except FileNotFoundError:
+        print(f"snowflake-exporter: no state file yet at {STATE_FILE}; "
+              f"backfilling from the start of {LOG_FILE}")
+    except (OSError, ValueError) as exc:
+        # Corrupt state must not zero a lifetime counter: keep whatever we have
+        # (fresh zeros on first boot) and re-read the whole log from offset 0.
+        print(f"snowflake-exporter: ignoring unreadable state file {STATE_FILE}: {exc}")
+
+
+def save_state():
+    """Atomically persist cumulative totals so an exporter restart resumes."""
+    try:
+        os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+        tmp = STATE_FILE + ".tmp"
+        with state_lock:
+            snapshot = dict(state)
+        with open(tmp, "w") as fh:
+            json.dump(snapshot, fh)
+        os.replace(tmp, STATE_FILE)
+    except OSError as exc:
+        print(f"snowflake-exporter: could not persist state: {exc}")
+
+
+def parse_line(line: str):
+    """Add one summary line's counts to the cumulative state (caller holds lock)."""
+    m = CONN_RE.search(line)
+    if not m:
+        return  # not a summary line
+    state["connections"] += int(m.group(1))
+    t = TRAFFIC_RE.search(line)
+    if t:
+        state["inbound_bytes"] += _to_bytes(t.group(1), t.group(2))
+        state["outbound_bytes"] += _to_bytes(t.group(3), t.group(4))
+    state["windows"] += 1
+    state["last_summary"] = int(time.time())
+
+
+def poll_once():
+    """Read new log bytes since last offset, handling rotation/truncation."""
+    try:
+        st = os.stat(LOG_FILE)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        print(f"snowflake-exporter: cannot stat {LOG_FILE}: {exc}")
+        return
+
+    with state_lock:
+        offset = state["offset"]
+        known_inode = state["inode"]
+
+    # Rotation/truncation: a new inode or a file shorter than where we stopped
+    # means the log we were tailing is gone. Keep the accumulated totals and
+    # re-read the replacement from the top -- the counters must never regress.
+    if known_inode and (st.st_ino != known_inode or st.st_size < offset):
+        print(f"snowflake-exporter: log rotation detected "
+              f"(inode {known_inode}->{st.st_ino}, size {st.st_size} < offset {offset}); "
+              f"re-reading from start, totals preserved")
+        offset = 0
+
+    try:
+        with open(LOG_FILE, "r", encoding="utf-8", errors="replace") as fh:
+            fh.seek(offset)
+            with state_lock:
+                for line in fh:
+                    parse_line(line)
+                new_offset = fh.tell()
+                state["offset"] = new_offset
+                state["inode"] = st.st_ino
+    except OSError as exc:
+        print(f"snowflake-exporter: cannot read {LOG_FILE}: {exc}")
+        return
+
+    save_state()
+
+
+def poll_loop():
+    global exporter_ready
+    while True:
+        poll_once()
+        exporter_ready = True
+        time.sleep(POLL_INTERVAL)
+
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        with state_lock:
+            snap = dict(state)
+
+        out = [
+            "# HELP moav_snowflake_relayed_bytes_total Cumulative bytes relayed to Snowflake clients, across proxy and exporter restarts.",
+            "# TYPE moav_snowflake_relayed_bytes_total counter",
+            f'moav_snowflake_relayed_bytes_total{{direction="inbound"}} {snap["inbound_bytes"]}',
+            f'moav_snowflake_relayed_bytes_total{{direction="outbound"}} {snap["outbound_bytes"]}',
+            "# HELP moav_snowflake_completed_connections_total Cumulative completed successful connections, across restarts.",
+            "# TYPE moav_snowflake_completed_connections_total counter",
+            f'moav_snowflake_completed_connections_total {snap["connections"]}',
+            "# HELP moav_snowflake_summary_windows_total Number of proxy summary windows parsed from the log.",
+            "# TYPE moav_snowflake_summary_windows_total counter",
+            f'moav_snowflake_summary_windows_total {snap["windows"]}',
+            "# HELP moav_snowflake_last_summary_timestamp_seconds Unix time the newest summary line was parsed (freshness).",
+            "# TYPE moav_snowflake_last_summary_timestamp_seconds gauge",
+            f'moav_snowflake_last_summary_timestamp_seconds {snap["last_summary"]}',
+            "# HELP moav_snowflake_exporter_up 1 once the exporter has completed a poll of the log.",
+            "# TYPE moav_snowflake_exporter_up gauge",
+            f'moav_snowflake_exporter_up {1 if exporter_ready else 0}',
+        ]
+        body = ("\n".join(out) + "\n").encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass  # Prometheus scrapes every few seconds; stay quiet.
+
+
+def main():
+    load_state()
+    threading.Thread(target=poll_loop, daemon=True).start()
+    print(f"snowflake-exporter: serving /metrics on :{PORT}, log={LOG_FILE}")
+    HTTPServer(("0.0.0.0", PORT), MetricsHandler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dashboard-timerange-test.sh
+++ b/tests/dashboard-timerange-test.sh
@@ -132,7 +132,12 @@ WRAPPED = re.compile(r'\b(increase|rate|irate|delta|deriv|max_over_time|last_ove
 # _total that are really gauges, and metrics MoaV persists across restarts.
 ALLOW = ("wireguard_peers_total", "amneziawg_peers_total",
          "moav_site_traffic_bytes_total", "moav_site_destination_country_bytes_total",
-         "moav_site_connections_total")
+         "moav_site_connections_total",
+         # snowflake-exporter accumulates these from the persistent proxy log and
+         # keeps its own state file, so they survive proxy AND exporter restarts.
+         # The lifetime-total panels read them raw on purpose (the counter is
+         # backfilled in one scrape, so increase() over a range would read 0).
+         "moav_snowflake_relayed_bytes_total", "moav_snowflake_completed_connections_total")
 raw = []
 for fn in sorted(os.listdir(sys.argv[1])):
     if not fn.endswith(".json"):

--- a/tests/snowflake-metrics-test.sh
+++ b/tests/snowflake-metrics-test.sh
@@ -1,26 +1,28 @@
 #!/bin/bash
-# Regression test: the Snowflake dashboard reads the proxy's own metrics. #183
+# Regression test: the Snowflake dashboard is fed by a hybrid of two sources.
 #
-# We used to run a 213-line exporter that regex-parsed the proxy's summary log
-# lines. The proxy has exposed a Prometheus endpoint since 2.11 (path
-# /internal/metrics, enabled with -metrics), and it carries strictly more:
+# 1. The proxy's own /internal/metrics endpoint (enabled with -metrics) is
+#    authoritative for per-country connections and connection failures:
+#      tor_snowflake_proxy_connections_total{country}
+#      tor_snowflake_proxy_connection_timeouts_total
+#      tor_snowflake_proxy_traffic_inbound_bytes_total   (live throughput only)
+#      tor_snowflake_proxy_traffic_outbound_bytes_total
+#    But its byte/connection counters are IN-MEMORY and reset to zero on every
+#    proxy restart -- so a proxy that relayed tens of GB reads near-zero right
+#    after a routine restart. Summing them for a lifetime total is wrong.
 #
-#   tor_snowflake_proxy_connections_total{country}   per-country, the thing #183 asked for
-#   tor_snowflake_proxy_connection_timeouts_total    failures, which we never had
-#   tor_snowflake_proxy_traffic_inbound_bytes_total  relayed traffic
-#   tor_snowflake_proxy_traffic_outbound_bytes_total
+# 2. snowflake-exporter parses the proxy's PERSISTENT summary log (a named
+#    volume that survives container recreation) into monotonic counters that
+#    survive restarts, and owns the cumulative panels:
+#      moav_snowflake_relayed_bytes_total{direction}     (already BYTES)
+#      moav_snowflake_completed_connections_total
 #
-# Two traps, both measured on a live proxy rather than reasoned about:
-#
-# 1. connections_total is a CounterVec. A CounterVec with no observations emits
-#    NOTHING -- no HELP, no TYPE, no series -- so on a proxy that has not yet
-#    completed a connection the country metric looks like it does not exist. It
-#    took a proxy with real completed connections to see RU=3, DE=2, ??=1.
-#
-# 2. The traffic counters are in KILOBYTES despite being named *_bytes_total.
-#    A 95-second counter delta of 8667 matched the log line "Traffic Relayed
-#    ↓ 8667 KB" exactly. Every bandwidth panel must multiply by 1024 or it is
-#    wrong by three orders of magnitude.
+# Two live-measured traps this pins:
+#  - connections_total is a CounterVec: with no observations it emits NOTHING,
+#    so the per-country panel looks absent until a real connection completes.
+#  - the NATIVE traffic counters are KILOBYTES despite the *_bytes_total name,
+#    so the live-throughput panels must multiply by 1024. The exporter already
+#    emits bytes, so its cumulative panels must NOT.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,31 +30,35 @@ DASH="$ROOT/configs/monitoring/grafana/provisioning/dashboards/snowflake.json"
 COMPOSE="$ROOT/docker-compose.yml"
 PROM="$ROOT/configs/monitoring/prometheus.yml"
 ENTRY="$ROOT/scripts/snowflake-entrypoint.sh"
+EXP="$ROOT/exporters/snowflake"
 pass=0; fail=0
 ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
 bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
 
-echo "snowflake: native proxy metrics replace the log exporter (#183)"
+echo "snowflake: native per-country/failures + log-based cumulative exporter"
 
-# --- the custom exporter is gone ---------------------------------------------
-[ -d "$ROOT/exporters/snowflake" ] \
-    && bad "exporters/snowflake still exists — the native endpoint supersedes it" \
-    || ok "the log-parsing exporter is deleted"
-grep -q 'snowflake-exporter' "$COMPOSE" \
-    && bad "docker-compose.yml still defines snowflake-exporter" \
-    || ok "no snowflake-exporter service in compose"
-grep -q "targets: \['snowflake-exporter" "$PROM" \
-    && bad "prometheus still scrapes the deleted exporter" \
-    || ok "prometheus no longer scrapes the deleted exporter"
+# --- the cumulative exporter exists and is wired -----------------------------
+[ -f "$EXP/main.py" ] && [ -f "$EXP/Dockerfile" ] \
+    && ok "exporters/snowflake exists (main.py + Dockerfile)" \
+    || bad "exporters/snowflake is missing — cumulative totals have no source"
+grep -q 'snowflake-exporter:' "$COMPOSE" \
+    && ok "docker-compose defines the snowflake-exporter service" \
+    || bad "no snowflake-exporter service in compose"
+grep -q 'moav_snowflake_logs:/var/log/snowflake:ro' "$COMPOSE" \
+    && ok "exporter mounts the persistent snowflake log read-only" \
+    || bad "exporter does not mount moav_snowflake_logs — nothing to parse"
+grep -q "targets: \['snowflake-exporter:9105'\]" "$PROM" \
+    && ok "prometheus scrapes snowflake-exporter:9105" \
+    || bad "prometheus does not scrape the cumulative exporter"
 
-# --- and the proxy's own endpoint is wired -----------------------------------
+# --- the proxy's own endpoint is still wired (per-country + failures) ---------
 grep -q '/internal/metrics' "$PROM" \
     && ok "prometheus scrapes /internal/metrics" \
     || bad "the native metrics path is not in the scrape config"
 # snowflake runs network_mode: host, so it has no service DNS name on moav_net.
 grep -q "targets: \['host.docker.internal:9998'\]" "$PROM" \
-    && ok "the target uses the host gateway (snowflake is network_mode: host)" \
-    || bad "the target is not host.docker.internal — a service name will not resolve"
+    && ok "the native target uses the host gateway (snowflake is network_mode: host)" \
+    || bad "the native target is not host.docker.internal — a service name will not resolve"
 grep -q '\-metrics' "$ENTRY" \
     && ok "the entrypoint enables -metrics" \
     || bad "the proxy is started without -metrics, so nothing is exposed"
@@ -60,11 +66,16 @@ grep -q 'geoipdb' "$ENTRY" \
     && ok "the entrypoint passes the geoip db (no country label without it)" \
     || bad "no -geoipdb: connections_total would carry country=\"\" forever"
 
-# --- the KB trap must be handled ---------------------------------------------
+# --- dashboard: cumulative panels use the exporter, live panels use native ----
 python3 - "$DASH" <<'PY' > /tmp/sfdash.$$ 2>/dev/null
 import json, sys
 d = json.load(open(sys.argv[1]))
-for p in d["panels"]:
+def panels(ps):
+    for p in ps:
+        yield p
+        for c in p.get("panels", []):
+            yield c
+for p in panels(d["panels"]):
     f = p.get("fieldConfig", {}).get("defaults", {})
     print("|".join([p.get("type",""), p.get("title",""),
                     " ".join(t.get("expr","") for t in p.get("targets", [])),
@@ -74,19 +85,33 @@ dash=/tmp/sfdash.$$
 trap 'rm -f "$dash"' EXIT
 
 while IFS='|' read -r type title expr unit min; do
+    # A cumulative byte/connection panel must NOT read the resetting native
+    # counters. The tells: increase()/max_over_time() of a tor_snowflake_* total.
+    case "$expr" in
+        *"increase(tor_snowflake_proxy_traffic"*|*"max_over_time(tor_snowflake_proxy_connections_total"*)
+            case "$title" in
+                # per-country + success-rate legitimately reduce the native
+                # counter across a range; they are not cumulative-total panels.
+                *Country*|*Countries*|*Success*) : ;;
+                *) bad "'$title' builds a cumulative total from the resetting native counter" ;;
+            esac ;;
+    esac
+    # NATIVE traffic counters are KB: any panel using them raw must *1024.
     case "$expr" in
         *traffic_inbound*|*traffic_outbound*)
             case "$expr" in
-                *1024*) ok "'$title' scales KB to bytes" ;;
-                *)      bad "'$title' uses a traffic counter without *1024 — off by 1024x" ;;
+                *1024*) ok "'$title' scales native KB to bytes" ;;
+                *)      bad "'$title' uses a native traffic counter without *1024 — off by 1024x" ;;
             esac ;;
     esac
-    if [ "$type" = "timeseries" ]; then
-        case "$expr" in
-            *rate\(*|*increase\(*) : ;;
-            *) [ "$min" = "0" ] || bad "'$title' plots a lifetime total with no min=0 — flat line, unreadable axis" ;;
-        esac
-    fi
+    # The exporter already emits BYTES: its panels must NOT *1024.
+    case "$expr" in
+        *moav_snowflake_relayed_bytes_total*)
+            case "$expr" in
+                *1024*) bad "'$title' scales the exporter's byte counter by 1024 — 1024x too high" ;;
+                *)      ok "'$title' uses the exporter's byte counter as-is" ;;
+            esac ;;
+    esac
 done < "$dash"
 
 # --- the panels #183 actually asked for --------------------------------------
@@ -96,9 +121,37 @@ grep -q 'by (country)' "$dash" \
 grep -q 'connection_timeouts_total' "$dash" \
     && ok "failed connections are surfaced" \
     || bad "connection_timeouts_total is exposed but not shown anywhere"
-grep -qE 'served_people|download_gb|upload_gb' "$dash" \
-    && bad "a panel still queries a metric from the deleted exporter" \
-    || ok "no panel references the old exporter's metrics"
+grep -q 'moav_snowflake_completed_connections_total' "$dash" \
+    && ok "the People/Connections panels use the cumulative exporter counter" \
+    || bad "no panel reads the cumulative connection counter"
+
+# --- exporter parsing unit test ----------------------------------------------
+python3 - "$EXP" <<'PY'
+import sys, importlib.util
+spec = importlib.util.spec_from_file_location("sfexp", sys.argv[1] + "/main.py")
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+# reset shared state, feed sample summary lines (KB=1024 per the exporter)
+for k in ("connections","inbound_bytes","outbound_bytes","windows"):
+    m.state[k] = 0
+lines = [
+  "2026/08/26 16:37:41 In the last 1m30s, there were 3 completed successful connections. Traffic Relayed ↓ 8667 KB (0.00 KB/s), ↑ 512 KB (0.00 KB/s).",
+  "2026/08/26 16:39:11 In the last 1m30s, there were 0 completed successful connections. Traffic Relayed ↓ 0 KB (0.00 KB/s), ↑ 0 KB (0.00 KB/s).",
+  "2026/08/26 16:40:41 In the last 1m30s, there were 2 completed successful connections. Traffic Relayed ↓ 1.5 MB (0.00 KB/s), ↑ 256 KB (0.00 KB/s).",
+  "2026/08/26 16:41:00 some unrelated proxy log line that is not a summary",
+]
+for ln in lines:
+    m.parse_line(ln)
+exp_conn = 5
+exp_in = 8667*1024 + int(1.5*1024*1024)
+exp_out = (512+256)*1024
+assert m.state["connections"] == exp_conn, ("connections", m.state["connections"], exp_conn)
+assert m.state["inbound_bytes"] == exp_in, ("inbound", m.state["inbound_bytes"], exp_in)
+assert m.state["outbound_bytes"] == exp_out, ("outbound", m.state["outbound_bytes"], exp_out)
+assert m.state["windows"] == 3, ("windows", m.state["windows"])   # the non-summary line ignored
+print("PARSE_OK")
+PY
+if [ $? -eq 0 ]; then ok "exporter parses connections + KB/MB traffic, ignores non-summary lines"
+else bad "exporter parse logic is wrong"; fi
 
 # --- version pin -------------------------------------------------------------
 # The compose default is only a default: an installed .env pins the old value and

--- a/tests/snowflake-metrics-test.sh
+++ b/tests/snowflake-metrics-test.sh
@@ -85,10 +85,13 @@ dash=/tmp/sfdash.$$
 trap 'rm -f "$dash"' EXIT
 
 while IFS='|' read -r type title expr unit min; do
-    # A cumulative byte/connection panel must NOT read the resetting native
-    # counters. The tells: increase()/max_over_time() of a tor_snowflake_* total.
+    # A cumulative/lifetime byte-or-connection panel must NOT read the resetting
+    # native counters -- those totals come from the exporter now. Live per-hour
+    # and rate panels legitimately use the native counter (increase() handles the
+    # reset within the window); the tell for the FORBIDDEN case is a range-scoped
+    # reduction ($__range) or max_over_time() of a native total.
     case "$expr" in
-        *"increase(tor_snowflake_proxy_traffic"*|*"max_over_time(tor_snowflake_proxy_connections_total"*)
+        *'increase(tor_snowflake_proxy_traffic'*'[$__range]'*|*'max_over_time(tor_snowflake_proxy_connections_total'*)
             case "$title" in
                 # per-country + success-rate legitimately reduce the native
                 # counter across a range; they are not cumulative-total panels.
@@ -104,9 +107,10 @@ while IFS='|' read -r type title expr unit min; do
                 *)      bad "'$title' uses a native traffic counter without *1024 — off by 1024x" ;;
             esac ;;
     esac
-    # The exporter already emits BYTES: its panels must NOT *1024.
+    # The exporter already emits BYTES (both the _total counter and the _window
+    # gauge): its panels must NOT *1024.
     case "$expr" in
-        *moav_snowflake_relayed_bytes_total*)
+        *moav_snowflake_relayed_bytes*)
             case "$expr" in
                 *1024*) bad "'$title' scales the exporter's byte counter by 1024 — 1024x too high" ;;
                 *)      ok "'$title' uses the exporter's byte counter as-is" ;;
@@ -124,6 +128,14 @@ grep -q 'connection_timeouts_total' "$dash" \
 grep -q 'moav_snowflake_completed_connections_total' "$dash" \
     && ok "the People/Connections panels use the cumulative exporter counter" \
     || bad "no panel reads the cumulative connection counter"
+# The "last N days" panels must read the log-window gauge, not increase() over
+# the backfilled counter (which is flat, so increase() reads 0 -- the bug).
+grep -q 'moav_snowflake_relayed_bytes_window' "$dash" \
+    && ok "the windowed panels use the exporter's log-timestamp window gauge" \
+    || bad "a 'last N days' panel still uses increase() over the flat backfilled counter (reads 0)"
+grep -q 'increase(moav_snowflake_relayed_bytes_total' "$dash" \
+    && bad "increase() over the backfilled cumulative byte counter reads 0 -- use the window gauge" \
+    || ok "no panel does increase() over the flat cumulative byte counter"
 
 # --- exporter parsing unit test ----------------------------------------------
 python3 - "$EXP" <<'PY'
@@ -148,6 +160,24 @@ assert m.state["connections"] == exp_conn, ("connections", m.state["connections"
 assert m.state["inbound_bytes"] == exp_in, ("inbound", m.state["inbound_bytes"], exp_in)
 assert m.state["outbound_bytes"] == exp_out, ("outbound", m.state["outbound_bytes"], exp_out)
 assert m.state["windows"] == 3, ("windows", m.state["windows"])   # the non-summary line ignored
+
+# trailing-window rollups computed from the log's own timestamps
+import datetime
+now = datetime.datetime(2026, 8, 26, 20, 0, 0)
+def L(dt, c, dn, up):
+    return "%s In the last 1m30s, there were %d completed successful connections. Traffic Relayed ↓ %d KB (0 KB/s), ↑ %d KB (0 KB/s)." % (
+        dt.strftime("%Y/%m/%d %H:%M:%S"), c, dn, up)
+wlines = [
+    L(now - datetime.timedelta(minutes=30), 5, 1000, 100),   # inside every window
+    L(now - datetime.timedelta(hours=2),    3,  500,  50),   # 24h, 7d, 14d
+    L(now - datetime.timedelta(days=10),    7, 2000, 200),   # 14d only
+    L(now - datetime.timedelta(days=20),    9, 9999, 999),   # outside all windows
+]
+wb, wc = m.compute_windows("\n".join(wlines), now)
+assert (wc["1h"], wc["24h"], wc["7d"], wc["14d"]) == (5, 8, 8, 15), wc
+assert wb[("inbound", "1h")] == 1000 * 1024, wb[("inbound", "1h")]
+assert wb[("inbound", "14d")] == (1000 + 500 + 2000) * 1024, wb[("inbound", "14d")]
+assert wb[("outbound", "14d")] == (100 + 50 + 200) * 1024, wb[("outbound", "14d")]
 print("PARSE_OK")
 PY
 if [ $? -eq 0 ]; then ok "exporter parses connections + KB/MB traffic, ignores non-summary lines"

--- a/tests/update-rebuild-test.sh
+++ b/tests/update-rebuild-test.sh
@@ -81,12 +81,13 @@ must_not_queue "bind-mounted lib/ change"    "lib/update.sh"
 must_not_queue "bind-mounted grafana entry"  "scripts/grafana-entrypoint.sh"
 must_not_queue "a docs change"               "README.md" "CHANGELOG.md"
 
-# A deleted service must not be suggested. Removing exporters/snowflake left its
-# files in the diff, so the prompt said `moav build snowflake-exporter` for a
-# service that no longer exists in compose.
-must_not_queue "a deleted exporter"          "exporters/snowflake/main.py"
-# ...but the mapping itself must still work for the exporters that remain.
-must_queue "a live exporter change"  singbox-exporter  "exporters/singbox/main.py"
+# A change to an exporter that IS in compose queues its rebuild.
+must_queue "the snowflake exporter"  snowflake-exporter  "exporters/snowflake/main.py"
+must_queue "a live exporter change"  singbox-exporter    "exporters/singbox/main.py"
+# But a path whose service is NOT in compose (deleted/unknown) must not be
+# suggested -- a needless build can OOM a 1 GB VPS. Regression: #295 deleted an
+# exporter yet the deletion diff still prompted `moav build <it>`.
+must_not_queue "an unknown/deleted exporter" "exporters/removed-legacy/main.py"
 
 # --- bind-mounted single files need a RECREATE, not a restart ----------------
 # A single-file mount follows the inode; git replaces the file, so the container


### PR DESCRIPTION
## Problem

The Snowflake dashboard's lifetime panels (People Served, Downloaded, Uploaded, cumulative bytes) read **near-zero even though the proxies relayed ~88 GB**. Root cause: PR #295 switched those panels to the proxy's native `/internal/metrics` counters, which are **in-memory and reset to zero on every proxy restart**. The traffic was relayed across sessions before the last restart, so the dashboard only ever shows since-last-restart.

## Fix — hybrid metrics

Keep the native endpoint for what it's uniquely good at, add an exporter for what it can't do:

| Source | Owns |
|---|---|
| native `/internal/metrics` (unchanged) | per-country connections, connection failures, **live throughput** (rate) |
| **new `snowflake-exporter`** | **cumulative** bytes relayed + connections served, surviving restarts |

`snowflake-exporter` parses the proxy's **persistent summary log** (`moav_snowflake_logs`, a named volume that survives container recreation) into monotonic counters. It also survives its **own** restarts via a small JSON state file (offset + running totals), and handles log rotation/truncation (keeps totals, re-reads from the top). Stdlib only, no docker socket, no egress; runs read-only on `moav_net`, scraped at `snowflake-exporter:9105`.

Metrics: `moav_snowflake_relayed_bytes_total{direction}` (already **bytes**) and `moav_snowflake_completed_connections_total`.

## Dashboard

Repointed the cumulative/total panels to the exporter and dropped their `*1024` (the exporter emits bytes; the native counters were KB). Country / success-rate / live-throughput / failure panels stay on native.

## Test

`tests/snowflake-metrics-test.sh` rewritten for the hybrid: asserts the exporter exists + is wired (compose/prometheus), the native endpoint is retained, cumulative panels don't read the resetting native counters, exporter panels don't double-scale, and includes an **exporter parse unit test** (KB/MB, ignores non-summary lines). Verified end-to-end locally: parses, reads incrementally, persists, and resumes across restart without double-count or reset. 19/19 pass.

## Deploy note

New service builds from source; on existing servers it needs `docker compose build snowflake-exporter && ... up -d`. On first run the exporter backfills the full historical total from the existing log.