### PR TITLE
server ops: batch revoke single-reset (+ `--all`) and donation quota/resume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
         run: bash tests/enable-flag-gating-test.sh
       - name: donate-mode regenerate (missing per-user protocol)
         run: bash tests/donate-regenerate-test.sh
+      - name: donate quota stop + ledger resume
+        run: bash tests/donate-quota-resume-test.sh
       - name: ENABLE_CDN opt-in flag
         run: bash tests/cdn-flag-test.sh
       - name: CDN survives an upgrade (flag inference + path rotation)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
         run: bash tests/amneziawg-v3-test.sh
       - name: regenerate-users reloads WG/AWG
         run: bash tests/regenerate-reload-test.sh
+      - name: batch/--all revoke resets services once
+        run: bash tests/revoke-batch-reload-test.sh
       - name: doctor CDN detection + scrape targets
         run: bash tests/doctor-cdn-test.sh
       - name: snowflake native metrics + dashboard (#183)

--- a/lib/donate.sh
+++ b/lib/donate.sh
@@ -161,6 +161,18 @@ mahsanet_save_donation() {
     echo "$donations" > "$MAHSANET_DONATIONS_FILE"
 }
 
+# Already recorded in the ledger? Lets a re-run resume without re-submitting
+# (and re-burning quota on) configs that already went through. Keyed by
+# (user, protocol); `--force` bypasses this to re-donate a regenerated user.
+mahsanet_already_donated() {
+    local user="$1"
+    local protocol="$2"
+    [[ -f "$MAHSANET_DONATIONS_FILE" ]] || return 1
+    jq -e --arg u "$user" --arg p "$protocol" \
+        'any(.configs[]?; .user == $u and .protocol == $p)' \
+        "$MAHSANET_DONATIONS_FILE" >/dev/null 2>&1
+}
+
 cmd_donate_mahsanet_setup() {
     echo ""
     info "MahsaNet API Key Setup"
@@ -460,6 +472,7 @@ _get_donate_api_key() {
 
 cmd_donate_mahsanet_donate() {
     local api_key="$1"
+    local force="${2:-}"
 
     info "Validating API key..."
     if ! mahsanet_validate_key "$api_key"; then
@@ -568,11 +581,19 @@ cmd_donate_mahsanet_donate() {
     local donated=0
     local skipped=0
     local failed=0
+    local quota_hit=0
 
     for username in "${generated_users[@]}"; do
         local bundle_dir="outputs/bundles/$username"
 
         for protocol in $protocols; do
+            # Resume: skip anything already in the ledger unless --force.
+            if [[ -z "$force" ]] && mahsanet_already_donated "$username" "$protocol"; then
+                echo -e "  ${DIM}•${NC} $username/$protocol → already donated (skipping; --force to re-donate)"
+                skipped=$((skipped + 1))
+                continue
+            fi
+
             local link_file
             link_file=$(mahsanet_protocol_to_file "$protocol")
 
@@ -649,9 +670,19 @@ cmd_donate_mahsanet_donate() {
                     echo -e "  ${RED}✗${NC} $username/$protocol → failed after retry ($http_code)"
                 fi
             else
-                failed=$((failed + 1))
                 local err_msg
                 err_msg=$(echo "$body" | jq -r '.detail // .url // .non_field_errors // "unknown error"' 2>/dev/null || echo "HTTP $http_code")
+                # A submission quota (new donors capped at N configs) makes every
+                # remaining submit a guaranteed rejection — stop the run instead of
+                # hammering the API. The ledger already has what succeeded, so a
+                # later re-run resumes the rest.
+                if [[ "$http_code" == "400" ]] && \
+                   echo "$body" | grep -qiE 'submit up to|good-quality submission|can submit more'; then
+                    quota_hit=1
+                    echo -e "  ${YELLOW}⚠${NC} $username/$protocol → submission quota reached: $err_msg"
+                    break 2
+                fi
+                failed=$((failed + 1))
                 echo -e "  ${RED}✗${NC} $username/$protocol → failed ($http_code): $err_msg"
             fi
         done
@@ -665,6 +696,13 @@ cmd_donate_mahsanet_donate() {
     [[ $skipped -gt 0 ]] && echo -e "  Skipped: ${YELLOW}$skipped${NC}"
     [[ $failed -gt 0 ]] && echo -e "  Failed: ${RED}$failed${NC}"
     echo -e "${GREEN}════════════════════════════════════════════════════════════════${NC}"
+    if [[ $quota_hit -eq 1 ]]; then
+        echo ""
+        warn "Stopped early: MahsaNet submission quota reached."
+        echo -e "  New accounts are capped until you have a week of good-quality"
+        echo -e "  submissions. What already went through is recorded — re-run"
+        echo -e "  ${CYAN}moav donate${NC} later to resume the rest (donated configs are skipped)."
+    fi
 }
 
 _format_bytes_sh() {
@@ -975,6 +1013,16 @@ cmd_donate() {
             local key; key=$(_get_donate_api_key) || return 1
             cmd_donate_mahsanet_remove "$key"
             ;;
+        donate|submit)
+            # Non-wizard MahsaNet submit. `--force` re-donates configs already in
+            # the ledger (e.g. after regenerating a user); default resumes/skips.
+            local force=""
+            for _a in "$@"; do
+                case "$_a" in --force|-f) force="--force" ;; esac
+            done
+            local key; key=$(_get_donate_api_key) || return 1
+            cmd_donate_mahsanet_donate "$key" "$force"
+            ;;
         info|--info)
             cmd_donate_conduit_info
             ;;
@@ -986,6 +1034,7 @@ cmd_donate() {
             echo "Commands:"
             echo "  (none)     Interactive donation wizard"
             echo "  setup      Configure donation services (MahsaNet, Conduit, Snowflake)"
+            echo "  donate     Submit MahsaNet configs (add --force to re-donate skipped ones)"
             echo "  status     Show all donation services status and stats"
             echo "  list       List donated MahsaNet configs"
             echo "  delete     Select and delete specific MahsaNet configs"

--- a/lib/users.sh
+++ b/lib/users.sh
@@ -308,16 +308,44 @@ cmd_user() {
             ;;
         revoke|rm|remove|delete)
             if [[ -z "${1:-}" ]]; then
-                error "Usage: moav user revoke USERNAME [USERNAME2...]"
+                error "Usage: moav user revoke USERNAME [USERNAME2...] | --all [--yes]"
                 exit 1
             fi
             if [[ ! -x "./scripts/user-revoke.sh" ]]; then
                 error "User revoke script not found"
                 exit 1
             fi
-            for u in "$@"; do
-                ./scripts/user-revoke.sh "$u" || true
+            # Build the target list. `--all` enumerates every user from the
+            # authoritative bundle dirs (skipping the *-configs zip dirs).
+            revoke_targets=()
+            if [[ "$1" == "--all" ]]; then
+                if [[ -d outputs/bundles ]]; then
+                    for _d in outputs/bundles/*/; do
+                        [[ -d "$_d" ]] || continue
+                        _u="$(basename "$_d")"
+                        [[ "$_u" == *-configs || "$_u" == *-moav-configs || "$_u" == "." ]] && continue
+                        revoke_targets+=("$_u")
+                    done
+                fi
+                if [[ ${#revoke_targets[@]} -eq 0 ]]; then
+                    info "No users to revoke."
+                    exit 0
+                fi
+                warn "This will revoke ALL ${#revoke_targets[@]} user(s): ${revoke_targets[*]}"
+                if [[ "${2:-}" != "--yes" && "${2:-}" != "-y" ]]; then
+                    read -r -p "This is irreversible. Continue? [y/N] " _ans
+                    [[ "$_ans" == y* || "$_ans" == Y* ]] || { info "Aborted."; exit 0; }
+                fi
+            else
+                revoke_targets=("$@")
+            fi
+            # Revoke each with the per-user reload deferred, then reset the proxy
+            # services ONCE at the end -- revoking N users used to trigger N
+            # sing-box reload + xray/trusttunnel restart cycles.
+            for _u in "${revoke_targets[@]}"; do
+                ./scripts/user-revoke.sh "$_u" --no-reload || true
             done
+            [[ -x ./scripts/reload-proxy.sh ]] && ./scripts/reload-proxy.sh || true
             ;;
         package|pkg)
             if [[ -z "$username" ]]; then

--- a/scripts/reload-proxy.sh
+++ b/scripts/reload-proxy.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+# =============================================================================
+# Reload/restart the proxy services after user config changes.
+#
+# Split out of singbox-user-revoke.sh so a BATCH revoke can reload once at the
+# end instead of once per user (see `moav user revoke` in lib/users.sh and the
+# `--no-reload` flag on user-revoke.sh / singbox-user-revoke.sh). Reloading
+# sing-box and restarting xray/trusttunnel per user is what made revoking many
+# users slow.
+#
+# No arguments; each service is only touched if its config exists and it is
+# actually running.
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+source scripts/lib/common.sh
+
+XRAY_CONFIG="configs/xray/config.json"
+TRUSTTUNNEL_CREDS="configs/trusttunnel/credentials.toml"
+TELEMT_CONFIG="configs/telemt/config.toml"
+
+# sing-box (Reality, Trojan, AnyTLS, Hysteria2, Shadowsocks)
+if docker compose ps sing-box --status running 2>/dev/null | tail -n +2 | grep -q .; then
+    log_info "Reloading sing-box..."
+    if docker compose exec -T sing-box sing-box reload 2>/dev/null; then
+        log_info "sing-box reloaded"
+    else
+        docker compose restart sing-box
+    fi
+fi
+
+# Xray (XHTTP + XDNS)
+if [[ -f "$XRAY_CONFIG" ]] && docker compose --profile xhttp ps xray --status running 2>/dev/null | tail -n +2 | grep -q .; then
+    log_info "Restarting Xray..."
+    docker compose --profile xhttp restart xray
+fi
+
+# TrustTunnel
+if [[ -f "$TRUSTTUNNEL_CREDS" ]] && docker compose ps trusttunnel --status running 2>/dev/null | tail -n +2 | grep -q .; then
+    log_info "Restarting TrustTunnel..."
+    docker compose restart trusttunnel
+fi
+
+# telemt (Telegram MTProxy)
+if [[ -f "$TELEMT_CONFIG" ]] && docker compose --profile telegram ps telemt --status running 2>/dev/null | tail -n +2 | grep -q .; then
+    log_info "Restarting telemt..."
+    docker compose --profile telegram restart telemt
+fi

--- a/scripts/singbox-user-revoke.sh
+++ b/scripts/singbox-user-revoke.sh
@@ -11,10 +11,17 @@ cd "$SCRIPT_DIR/.."
 
 source scripts/lib/common.sh
 
-USERNAME="${1:-}"
+USERNAME=""
+NO_RELOAD=""
+for _a in "$@"; do
+    case "$_a" in
+        --no-reload) NO_RELOAD=1 ;;
+        *) [[ -z "$USERNAME" ]] && USERNAME="$_a" ;;
+    esac
+done
 
 if [[ -z "$USERNAME" ]]; then
-    echo "Usage: $0 <username>"
+    echo "Usage: $0 <username> [--no-reload]"
     exit 1
 fi
 
@@ -168,38 +175,11 @@ if [[ -f "$TELEMT_CONFIG" ]]; then
     fi
 fi
 
-# Reload sing-box
-if docker compose ps sing-box --status running 2>/dev/null | tail -n +2 | grep -q .; then
-    log_info "Reloading sing-box..."
-    if docker compose exec -T sing-box sing-box reload 2>/dev/null; then
-        log_info "sing-box reloaded"
-    else
-        docker compose restart sing-box
-    fi
-fi
-
-# Reload Xray (XHTTP + XDNS — picks up the revoked-user removal)
-if [[ -f "$XRAY_CONFIG" ]]; then
-    if docker compose --profile xhttp ps xray --status running 2>/dev/null | tail -n +2 | grep -q .; then
-        log_info "Restarting Xray..."
-        docker compose --profile xhttp restart xray
-    fi
-fi
-
-# Reload TrustTunnel (if running)
-if [[ -f "$TRUSTTUNNEL_CREDS" ]]; then
-    if docker compose ps trusttunnel --status running 2>/dev/null | tail -n +2 | grep -q .; then
-        log_info "Restarting TrustTunnel..."
-        docker compose restart trusttunnel
-    fi
-fi
-
-# Reload telemt (if running)
-if [[ -f "$TELEMT_CONFIG" ]]; then
-    if docker compose --profile telegram ps telemt --status running 2>/dev/null | tail -n +2 | grep -q .; then
-        log_info "Restarting telemt..."
-        docker compose --profile telegram restart telemt
-    fi
+# Reload the proxy services, unless the caller defers it. A batch revoke passes
+# --no-reload and reloads once at the end (see lib/users.sh), instead of a
+# sing-box reload + xray/trusttunnel restart per user.
+if [[ -z "$NO_RELOAD" ]]; then
+    "$SCRIPT_DIR/reload-proxy.sh"
 fi
 
 log_info "User '$USERNAME' revoked"

--- a/scripts/user-revoke.sh
+++ b/scripts/user-revoke.sh
@@ -18,8 +18,16 @@ cd "$SCRIPT_DIR/.."
 
 source scripts/lib/common.sh
 
-USERNAME="${1:-}"
-KEEP_BUNDLE="${2:-}"
+USERNAME=""
+KEEP_BUNDLE=""
+NO_RELOAD=""
+for _a in "$@"; do
+    case "$_a" in
+        --keep-bundle) KEEP_BUNDLE="--keep-bundle" ;;
+        --no-reload)   NO_RELOAD="--no-reload" ;;
+        *) [[ -z "$USERNAME" ]] && USERNAME="$_a" ;;
+    esac
+done
 
 if [[ -z "$USERNAME" ]]; then
     echo "Usage: $0 <username> [--keep-bundle]"
@@ -117,7 +125,7 @@ REVOKED=false
 # -----------------------------------------------------------------------------
 if proxy_user_exists; then
     log_info "[1/3] Revoking from proxy transports..."
-    if "$SCRIPT_DIR/singbox-user-revoke.sh" "$USERNAME"; then
+    if "$SCRIPT_DIR/singbox-user-revoke.sh" "$USERNAME" ${NO_RELOAD:+"$NO_RELOAD"}; then
         log_info "✓ Revoked from proxy transports"
         REVOKED=true
     else

--- a/tests/donate-quota-resume-test.sh
+++ b/tests/donate-quota-resume-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Regression test: MahsaNet donation must stop on the submission-quota rejection
+# and resume without re-submitting already-donated configs.
+#
+# The bug (found live): a new-donor quota cap comes back as HTTP 400
+# ("New donors can submit up to N configs..."). The old code only special-cased
+# 429, so the 400 fell through to the generic failure branch and the loop kept
+# firing every remaining config at the API — all guaranteed rejections. And a
+# re-run re-submitted everything, burning more of the same quota.
+#
+# Fix: a ledger-keyed skip (resume) + a quota-message stop (break 2), with
+# --force to re-donate on purpose.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DONATE="$ROOT/lib/donate.sh"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "donate: stop on quota, resume via ledger"
+
+# --- Unit: mahsanet_already_donated keys on (user, protocol) ------------------
+if ! command -v jq >/dev/null 2>&1; then
+    echo "  SKIP  jq not available for the ledger unit test"
+else
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    ledger="$tmp/donations.json"
+    cat > "$ledger" <<'JSON'
+{"configs":[{"id":"h1","user":"alice","protocol":"reality","donated_at":"2026-01-01T00:00:00Z"}]}
+JSON
+    # Source only the helper; override the ledger path.
+    # shellcheck disable=SC1090
+    ( source "$DONATE" >/dev/null 2>&1
+      MAHSANET_DONATIONS_FILE="$ledger"
+      mahsanet_already_donated alice reality ) \
+        && ok "recognizes an already-donated (user, protocol)" \
+        || bad "did not recognize a donated (user, protocol) — resume would re-submit it"
+
+    ( source "$DONATE" >/dev/null 2>&1
+      MAHSANET_DONATIONS_FILE="$ledger"
+      mahsanet_already_donated alice hysteria2 ) \
+        && bad "treated a NOT-yet-donated protocol as donated — resume would skip it" \
+        || ok "does not skip a protocol that hasn't been donated for that user"
+
+    ( source "$DONATE" >/dev/null 2>&1
+      MAHSANET_DONATIONS_FILE="$ledger"
+      mahsanet_already_donated bob reality ) \
+        && bad "treated a different user as donated" \
+        || ok "keys on the user, not just the protocol"
+
+    # Missing ledger must not error out or claim things are donated.
+    ( source "$DONATE" >/dev/null 2>&1
+      MAHSANET_DONATIONS_FILE="$tmp/nope.json"
+      mahsanet_already_donated alice reality ) \
+        && bad "claimed donated against a missing ledger" \
+        || ok "missing ledger => nothing donated (clean first run)"
+fi
+
+# --- Static: submit loop stops on the quota message, skips donated, --force ---
+if grep -q 'mahsanet_already_donated' "$DONATE" \
+   && grep -q 'if \[\[ -z "\$force" \]\] && mahsanet_already_donated' "$DONATE"; then
+    ok "submit loop skips ledger entries unless --force"
+else
+    bad "submit loop does not skip already-donated configs"
+fi
+
+if grep -qE 'submit up to\|good-quality submission\|can submit more' "$DONATE" \
+   && grep -q 'break 2' "$DONATE"; then
+    ok "quota-cap 400 stops the whole run (break 2), not just one config"
+else
+    bad "no quota-message stop — a capped run keeps hammering the API"
+fi
+
+if grep -q 'donate|submit)' "$DONATE" && grep -qE '\-\-force\|-f' "$DONATE"; then
+    ok "exposes --force to re-donate on purpose"
+else
+    bad "--force not wired through the donate command"
+fi
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED ($fail failed, $pass passed)"
+    exit 1
+fi
+echo "PASSED ($pass checks)"

--- a/tests/revoke-batch-reload-test.sh
+++ b/tests/revoke-batch-reload-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Regression test: batch `moav user revoke` must reset the proxy services ONCE
+# at the end, not once per user.
+#
+# The bug (found live): revoking N users looped `user-revoke.sh <u>` per user,
+# and each call reloaded sing-box + restarted xray/trusttunnel/telemt. Revoking
+# a whole server was N reload/restart cycles — minutes of churn and repeated
+# tunnel drops. Fix: the per-user revoke takes `--no-reload`, the batch loop
+# passes it, and the CLI calls `scripts/reload-proxy.sh` once after the loop.
+# `moav user revoke --all` enumerates every user and does the same single reset.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "user revoke: batch/--all resets the proxy services once at the end"
+
+USERS="$ROOT/lib/users.sh"
+USER_REVOKE="$ROOT/scripts/user-revoke.sh"
+SINGBOX_REVOKE="$ROOT/scripts/singbox-user-revoke.sh"
+RELOAD="$ROOT/scripts/reload-proxy.sh"
+
+# 1. The shared reload script exists, is executable, and touches the services.
+if [[ -x "$RELOAD" ]]; then
+    ok "scripts/reload-proxy.sh exists and is executable"
+else
+    bad "scripts/reload-proxy.sh missing or not executable"
+fi
+if grep -q 'sing-box reload' "$RELOAD" 2>/dev/null && grep -q 'restart xray' "$RELOAD" 2>/dev/null; then
+    ok "reload-proxy.sh reloads sing-box and restarts xray"
+else
+    bad "reload-proxy.sh does not reload the expected services"
+fi
+
+# 2. singbox-user-revoke.sh honors --no-reload (defers the reload to the caller).
+if grep -q -- '--no-reload' "$SINGBOX_REVOKE" 2>/dev/null; then
+    ok "singbox-user-revoke.sh accepts --no-reload"
+else
+    bad "singbox-user-revoke.sh does not accept --no-reload"
+fi
+# It must NOT inline the old sing-box reload block any more (that lived here and
+# fired per user); the reload goes through reload-proxy.sh, gated on --no-reload.
+if grep -q 'reload-proxy.sh' "$SINGBOX_REVOKE" 2>/dev/null; then
+    ok "singbox-user-revoke.sh delegates the reload to reload-proxy.sh"
+else
+    bad "singbox-user-revoke.sh still reloads inline (would fire per user in a batch)"
+fi
+
+# 3. user-revoke.sh passes --no-reload straight through to the singbox revoke.
+if grep -q 'singbox-user-revoke.sh' "$USER_REVOKE" 2>/dev/null \
+   && grep -q 'NO_RELOAD' "$USER_REVOKE" 2>/dev/null; then
+    ok "user-revoke.sh threads --no-reload to singbox-user-revoke.sh"
+else
+    bad "user-revoke.sh does not pass --no-reload down"
+fi
+
+# 4. The CLI revoke case: loop passes --no-reload, then reload-proxy.sh runs ONCE.
+block=$(awk '/revoke\|rm\|remove\|delete\)/,/^            ;;$/' "$USERS")
+if [[ -z "$block" ]]; then
+    bad "could not locate the revoke case in lib/users.sh"
+else
+    if printf '%s' "$block" | grep -q 'user-revoke.sh "\$_u" --no-reload'; then
+        ok "batch loop revokes each user with --no-reload"
+    else
+        bad "batch loop does NOT pass --no-reload — reloads fire per user again"
+    fi
+    # Exactly one reload-proxy.sh call after the loop.
+    reloads=$(printf '%s\n' "$block" | grep -c 'reload-proxy.sh')
+    if [[ "$reloads" -eq 1 ]]; then
+        ok "reload-proxy.sh is called exactly once for the whole batch"
+    else
+        bad "expected 1 reload-proxy.sh call in the revoke case, found $reloads"
+    fi
+    if printf '%s' "$block" | grep -q -- '--all'; then
+        ok "revoke supports --all (enumerate + confirm + single reset)"
+    else
+        bad "revoke does not support --all"
+    fi
+    # --all must require confirmation unless --yes is given (irreversible).
+    if printf '%s' "$block" | grep -q 'read -r -p'; then
+        ok "--all prompts for confirmation before revoking everyone"
+    else
+        bad "--all does not confirm — an accidental invocation wipes every user"
+    fi
+fi
+
+echo ""
+if [[ "$fail" -gt 0 ]]; then
+    echo "FAILED ($fail failed, $pass passed)"
+    exit 1
+fi
+echo "PASSED ($pass checks)"


### PR DESCRIPTION
Two operator-facing server improvements batched to `dev` for testing.

---

## 1. `moav user revoke`: one service reset per batch, plus `--all`

Batch revoke used to reload sing-box and restart xray/trusttunnel/telemt **once per user**. Revoking many users (or a whole server) was N reload/restart cycles — slow, and it dropped live tunnels repeatedly. Now the batch resets the proxy services **once**, at the end.

- **`scripts/reload-proxy.sh`** (new) — the reload/restart logic, extracted so a batch can reload once. Each service is only touched if its config exists and the container is running.
- **`scripts/singbox-user-revoke.sh`** — accepts `--no-reload`; the inline reload block is gone, delegated to `reload-proxy.sh` and gated on the flag.
- **`scripts/user-revoke.sh`** — threads `--no-reload` down to the sing-box revoke.
- **`lib/users.sh`** — the CLI `revoke` case revokes each target with `--no-reload`, then calls `reload-proxy.sh` once. Adds `moav user revoke --all` (enumerates users from `outputs/bundles/*`, skips the `*-configs` zip dirs, confirms unless `--yes`).

```
moav user revoke alice bob carol   # 3 users, ONE reset at the end
moav user revoke --all             # every user, confirm prompt, ONE reset
moav user revoke --all --yes       # skip the prompt (scripted teardown)
```

Single-user `moav user revoke alice` is unchanged.

Docs: MoaV-site `dev` (CLI reference + troubleshooting note).

## 2. `moav donate`: stop on MahsaNet submission quota, resume via ledger

A new-donor quota cap returns HTTP 400 (`"New donors can submit up to N configs..."`). The loop only special-cased 429, so the 400 fell through to the generic failure branch and **kept firing every remaining config at the API** — all guaranteed rejections. A re-run also re-submitted everything, burning more of the same quota.

- Detect the quota message on a 400 and **stop the whole run** (`break 2`), with a summary saying what was donated and that a re-run resumes the rest.
- `mahsanet_already_donated()` — skip `(user, protocol)` pairs already in `outputs/mahsanet-donations.json` so a re-run **resumes** instead of re-submitting.
- `moav donate submit --force` re-donates skipped configs (e.g. after regenerating a user).

---

## Tests

- `tests/revoke-batch-reload-test.sh` — 9 checks, batch/`--all` defers per-user reloads and resets exactly once.
- `tests/donate-quota-resume-test.sh` — 7 checks, ledger-keyed resume unit test + quota-stop/`--force` static checks.

Both wired into CI. `shellcheck --severity=error` clean on all touched scripts.