### PR TITLE
ci: Claude PR review + issue triage (admin-triggered, advisory)

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,0 +1,88 @@
+name: Claude Issue Triage
+
+# Automated issue triage by Claude Code. It reads a new or existing issue,
+# applies labels from the repo's EXISTING label set, and posts one concise
+# triage comment. It is triage-only: it never edits code, opens a PR, commits,
+# or closes issues. Unlike PR review there is no bundled plugin — this is a
+# custom prompt driving the `gh` CLI, following the rubric in TRIAGE.md.
+#
+# ── Trigger model (start = admin-only) ──────────────────────────────────────
+# Runs only when a maintainer asks:
+#   • a maintainer comments `@claude triage` on an issue, or
+#   • a maintainer runs it from the Actions tab (Run workflow → issue number).
+# The `author_association` gate restricts the comment path to the org.
+# To auto-triage every new issue, uncomment the `issues` trigger below.
+#
+# ── Prerequisite ────────────────────────────────────────────────────────────
+# The same `CLAUDE_CODE_OAUTH_TOKEN` secret as the review workflow (set at the
+# org level), and the Claude GitHub App approved on the repo (it carries
+# `issues: write`).
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to triage"
+        required: true
+        type: string
+  # ── TWEAK: uncomment to auto-triage new issues ──
+  # issues:
+  #   types: [opened, reopened]
+
+concurrency:
+  group: claude-triage-${{ github.event.issue.number || github.event.inputs.issue }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    # A maintainer's `@claude triage` comment on an ISSUE (not a PR), OR a manual
+    # dispatch, OR (once enabled) a new issue. `author_association` keeps the
+    # comment path org-only.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'issues' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request == null &&
+       contains(github.event.comment.body, '@claude triage') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read       # read TRIAGE.md / AGENTS.md from the checkout
+      issues: write        # apply labels + post the triage comment
+      id-token: write      # authenticate as the Claude GitHub App
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Resolve issue number
+        id: issue
+        run: echo "number=${{ github.event.issue.number || github.event.inputs.issue }}" >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Triage GitHub issue #${{ steps.issue.outputs.number }} in ${{ github.repository }}.
+            First read TRIAGE.md (the rubric, including the security rules) and AGENTS.md (repo context).
+
+            Steps:
+            1. Read the issue: `gh issue view ${{ steps.issue.outputs.number }}`.
+            2. List existing labels: `gh label list`. Apply ONLY labels that already
+               exist — never invent one. Add labels with
+               `gh issue edit ${{ steps.issue.outputs.number }} --add-label "<label>"`. Use 1–3 at most.
+            3. Post ONE concise triage comment with
+               `gh issue comment ${{ steps.issue.outputs.number }} --body "..."`: restate the ask in a
+               line, name the likely area (CLI/lib · scripts/entrypoints · configs/compose ·
+               monitoring · docs), say what is still needed, and ask up to 2–3
+               clarifying questions if useful.
+
+            Hard limits (see TRIAGE.md): triage only — no code changes, no PRs, no
+            commits, do not close the issue. This is a censorship-circumvention
+            server: if the issue contains a secret, admin password, private key,
+            server IP, or a user's full share-URI/config, do NOT repeat it back;
+            flag it and ask the reporter to redact. Don't re-triage an issue you've
+            already commented on.
+          claude_args: '--max-turns 6 --allowedTools "Read,Bash(gh issue view:*),Bash(gh label list:*),Bash(gh issue edit:*),Bash(gh issue comment:*)"'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,85 @@
+name: Claude PR Review
+
+# Automated PR review by Claude Code (the official anthropics/claude-code-action
+# running the `code-review` plugin). It reads the PR diff, reasons over it along
+# the dimensions in REVIEW.md, and posts findings as inline review comments plus
+# a grouped summary. It is review-only: it never commits, pushes, or merges.
+#
+# ── Trigger model (start = admin-only) ──────────────────────────────────────
+# Right now it runs ONLY when a maintainer asks for it:
+#   • a maintainer comments `@claude review` on a PR, or
+#   • a maintainer runs it from the Actions tab (Run workflow → PR number).
+# The `author_association` gate below is what restricts it to the org.
+#
+# To move to the HYBRID model (auto on every PR + on-demand) once it's tuned,
+# uncomment the `pull_request` trigger and the diff-size guard marked TWEAK
+# below. Keep the comment/dispatch triggers so a maintainer can still re-run it.
+#
+# ── Prerequisite ────────────────────────────────────────────────────────────
+# A repo or org Actions secret `CLAUDE_CODE_OAUTH_TOKEN` (Claude subscription):
+# run `claude setup-token` locally and paste the token into
+# Settings → Secrets and variables → Actions. The MoaV org already sets this at
+# the org level, so this repo inherits it. See docs/devdocs/CLAUDE-REVIEW.md.
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to review"
+        required: true
+        type: string
+  # ── TWEAK: uncomment to enable automatic review (the hybrid model) ──
+  # pull_request:
+  #   types: [opened, ready_for_review, reopened]
+
+# One review at a time per PR; a newer request supersedes an in-flight one.
+concurrency:
+  group: claude-review-${{ github.event.issue.number || github.event.inputs.pr || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Run only for: a maintainer's `@claude review` comment on a PR, OR a manual
+    # dispatch, OR (once enabled) a pull_request event. `author_association`
+    # keeps the comment path org-only — OWNER/MEMBER/COLLABORATOR, not drive-bys.
+    # The pull_request branch carries a diff-size cost guard (additions < 800),
+    # so when you enable the auto trigger above it is already bounded; huge PRs
+    # skip auto-review but a maintainer can still run them on demand. Admin
+    # triggers (comment / dispatch) are deliberate and not size-capped.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.additions < 800) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude review') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # post inline review comments + the summary
+      issues: read
+      id-token: write        # authenticate as the Claude GitHub App
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Resolve PR number
+        id: pr
+        run: |
+          num="${{ github.event.issue.number || github.event.inputs.pr || github.event.pull_request.number }}"
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The bundled multi-agent reviewer. It reads REVIEW.md (severity +
+          # per-dimension rubric); REVIEW.md points it at AGENTS.md for the repo
+          # context (this repo uses AGENTS.md, not CLAUDE.md).
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}"
+          # The inline-comment MCP tool must be allow-listed here for the action
+          # to start its server, even though the skill also declares it.
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ cp .env.example .env      # DOMAIN, ACME_EMAIL, ADMIN_PASSWORD (top block)
 | `configs/` | `*.template` → rendered configs; Grafana dashboards under `configs/monitoring/…` |
 | `dockerfiles/`, `exporters/`, `admin/` | Image builds, Prometheus exporters, the FastAPI admin app |
 | `tests/*.sh` | Regression suite (one file per bug class) |
-| `docs/devdocs/` | E2E-TESTING, PROTOCOL-INTEGRATION-CHECKLIST, VERSION-BUMP-CHECKLIST |
+| `docs/devdocs/` | E2E-TESTING, PROTOCOL-INTEGRATION-CHECKLIST, VERSION-BUMP-CHECKLIST, CLAUDE-REVIEW |
 
 **Conventions that bite** (when editing bash): entrypoints run `set -eu` +
 pipefail (subshell-probed — `set -o pipefail` is fatal in dash even with

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,113 @@
+# Review rubric
+
+Instructions for the automated PR reviewer (Claude Code `code-review` plugin).
+Read this together with **`AGENTS.md`** (this repo uses AGENTS.md, not CLAUDE.md)
+and the dev docs under `docs/devdocs/`. MoaV is a single-host, Docker-Compose,
+multi-protocol censorship-circumvention server: `moav.sh` is a bash dispatcher
+over `lib/*.sh`, provisioning is bash + config templates, and the transports run
+as containers. Review spans shell correctness, the security/opsec posture, and
+the Docker/deploy surface — there is no application UI here.
+
+## Output
+
+- Post findings as **inline comments** on the exact `file:line`, and one
+  **grouped summary** comment organized by the dimensions below.
+- Lead the summary with a one-line verdict and the counts per dimension.
+- Cap **Nits at 5**; if there are more, say "plus N similar" in the summary.
+
+## Severity
+
+- **Important** — breaks behavior, corrupts state, or is unsafe to ship:
+  a destructive command without a guard, a config-file write that swaps
+  inode/owner and locks a daemon out, a broken revoke/reload path, unquoted
+  expansion that word-splits a path, or **any secret / admin password / private
+  key / server IP / share-URI reaching logs, a committed file, or an issue/PR**.
+- **Nit** — style, naming, small refactors, non-load-bearing comments.
+- **Pre-existing** — a real problem the PR did not introduce; report separately,
+  don't block on it.
+
+## Verification bar
+
+A finding must cite the `file:line` it's grounded in, not an inference from a
+name. If you can't point at the code, drop it or mark it a question. Prefer
+false negatives over confident false positives.
+
+---
+
+# Dimensions
+
+Each dimension is self-contained on purpose: the plan is to later split them into
+separate review agents/jobs, one per section. Keep findings tagged by dimension.
+
+## 1. Security & opsec
+
+This is a server people run to bypass censorship. Treat leaks as Important.
+
+- **No secrets in output or the repo**: `ADMIN_PASSWORD`, API keys, Reality/WG
+  private keys, `.env` values, a user's UUID/password or full share-URI, and
+  real server IPs must never be `echo`/`log`'d to stdout, baked into a committed
+  file, or printed where CI logs capture them. Everything under `state/` and
+  `outputs/` is secret.
+- **File permissions & ownership**: config writes preserve the original
+  inode/mode/owner (overwrite in place with `cat >`, not `mv`), never go
+  world-writable, and drop world-read on private-key files. Watch the admin
+  container (non-root uid) vs host-root (sudo) DAC interplay — a swapped owner
+  locks out the next write.
+- **Destructive actions are guarded**: `uninstall`, `user revoke`,
+  `docker volume rm`, `rm -rf` on a derived path — confirm intent, and never
+  widen a path that could `rm` outside the install dir.
+- Input that reaches a listener or a template is validated; no injection into a
+  generated config, no unquoted user-supplied value in a shell command.
+- No new fingerprintable surface (predictable ports/banners/timing) without
+  reason; new dependencies/images are justified and pinned.
+
+## 2. Correctness & bash safety
+
+Does the change do what the PR says, and hold up when a step fails?
+
+- Scripts keep `set -euo pipefail` (or justify not); no unquoted `$var`, no
+  `[ $x = ... ]` on possibly-empty values, arrays quoted as `"${arr[@]}"`.
+- **Idempotent & re-runnable**: add/revoke/regenerate can run twice without
+  corrupting configs or duplicating peers; a partial failure leaves a recoverable
+  state.
+- Error paths propagate (`|| return`/`exit`), no silent failure on a path that
+  matters; `set -e` isn't defeated by an unchecked pipeline.
+- `jq`/`awk`/`sed` edits produce valid output and are validated before replacing
+  the live file (the existing revoke/add scripts validate JSON before swap —
+  keep that).
+- Edge cases: empty user list, missing config, a service that isn't running,
+  IPv6, first-run vs upgrade.
+
+## 3. Tests
+
+- **Every bug fix ships a regression test in the same PR** (project policy —
+  see AGENTS.md). Tests live in `tests/` and are wired into `.github/workflows/ci.yml`.
+- Prefer a fast static/unit check (source a lib function, assert on a fixture, or
+  grep the behavior into place) over nothing when a full stack run isn't possible.
+- Assert the failure mode the fix addresses, not just the happy path.
+- Don't weaken or skip an existing test to make a change pass — fix the cause.
+  New tests must be registered in `ci.yml`, not just added to `tests/`.
+
+## 4. Docker & deploy
+
+- **Compose**: services land in the right profile; a new long-running service is
+  classified correctly (not treated as a one-shot), depends_on/healthchecks are
+  sound, and it's added to any service-count/classification test.
+- **Bind mounts**: single-file mounts have the inode-reload trap — the container
+  needs a restart, not a HUP, to see a replaced file. Flag config swaps that
+  assume live reload.
+- `.env` / `.env.example` stay in sync (a gated test enforces drift); version
+  vars and the `VERSION` file move together where required.
+- Entrypoints are re-entrant and don't chown/chmod host-owned paths in a way that
+  breaks the admin container or a sudo-less operator.
+- No image or port exposed to the host beyond what the change needs.
+
+---
+
+## Skip
+
+- Generated / vendored code, `outputs/`, `state/`, `configs/*/` runtime data,
+  `geoip/` data, build output, `*.min.*`, `__pycache__`.
+- Anything CI already enforces (shellcheck, the bash/python test suite, drift
+  gates) — don't re-litigate formatting.
+- Pure dependency/lockfile churn, unless a dependency itself is the concern.

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -1,0 +1,47 @@
+# Issue triage rubric
+
+Instructions for the automated issue triager (Claude Code via the GitHub
+Action). Read together with **`AGENTS.md`**. Triage only — never edit code, open
+a PR, or close an issue.
+
+## What to do (one pass)
+
+1. Read the issue. Classify it using the repo's **actual** label set — list the
+   labels first; never invent new ones.
+2. Apply the fitting label(s): typically one of `bug` / `enhancement` /
+   `question` / `documentation` / `duplicate`. Add `good first issue` or
+   `help wanted` only when clearly warranted. Leave `invalid` / `wontfix` for a
+   human unless it's unambiguous.
+3. Post **one concise triage comment**: a one-line restatement of the ask, the
+   likely area of the codebase, what's still needed to act on it, and — for bugs
+   — the minimal reproduction, the `moav version` / OS, and the logs missing.
+4. If it's a duplicate, link the original. If it's a question already answered in
+   the docs ([moav.sh/docs](https://moav.sh/docs) or `docs/`), link the doc.
+
+## Areas (name these in the comment, not as labels)
+
+- **CLI / lib** — `moav.sh` and `lib/*.sh` (install, users, cert, service,
+  doctor, donate, update, migrate).
+- **scripts / entrypoints** — `scripts/*.sh` (user-add/revoke, generate-user,
+  `*-entrypoint.sh` for each container).
+- **configs / compose** — `docker-compose.yml`, profiles, `configs/*` templates,
+  `.env` / `.env.example`.
+- **monitoring** — Prometheus/Grafana, exporters, dashboards.
+- **docs** — README, `docs/`, `docs/devdocs/` (user-facing docs live in the
+  moav-site repo).
+
+## Security & privacy (this is a censorship-circumvention server)
+
+- If an issue contains secrets, an admin password, a private key, a real server
+  IP, or a user's full share-URI / config, **flag it and ask the reporter to
+  redact** — do **not** echo the sensitive value back in your comment, and
+  suggest maintainers scrub the issue.
+- Treat anything that could deanonymize users, leak the owner's server, or add
+  fingerprintable surface as high-priority: label `bug` and note it needs a
+  maintainer's eyes.
+
+## Tone & limits
+
+- Helpful and short; at most 2–3 clarifying questions.
+- Don't re-triage an issue you've already commented on unless asked again.
+- You are advisory: a maintainer confirms the disposition.

--- a/docs/devdocs/CLAUDE-REVIEW.md
+++ b/docs/devdocs/CLAUDE-REVIEW.md
@@ -1,0 +1,90 @@
+# Automated PR review & issue triage with Claude
+
+Two GitHub Actions workflows run Claude Code on this repo:
+
+- **`.github/workflows/claude-review.yml`** — the official
+  [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action)
+  with the `code-review` plugin. It reads the PR diff, reviews it against
+  [`REVIEW.md`](../../REVIEW.md), and posts inline comments plus a grouped
+  summary. **Review-only** — it never commits, pushes, or merges.
+- **`.github/workflows/claude-issue-triage.yml`** — a custom prompt driving the
+  `gh` CLI. It reads an issue, applies labels from the repo's **existing** label
+  set, and posts one triage comment following [`TRIAGE.md`](../../TRIAGE.md).
+  **Triage-only** — it never edits code, opens a PR, or closes issues.
+
+Both are **advisory** (they don't block a merge) and augment human review — they
+don't replace it. The rubric points the reviewer at `AGENTS.md` for repo context
+(this repo uses `AGENTS.md`, not `CLAUDE.md`).
+
+## One-time setup: the token
+
+Auth is via a **Claude subscription** OAuth token (no API key needed):
+
+1. On a machine with Claude Code, run:
+   ```bash
+   claude setup-token
+   ```
+2. Add it in GitHub under **Settings → Secrets and variables → Actions**:
+   - Name: `CLAUDE_CODE_OAUTH_TOKEN`
+   - Value: the token
+
+   The MoaV org already sets this **at the org level**, so this repo inherits it
+   — no per-repo secret needed unless you want to override it.
+3. Approve the **Claude GitHub App** for the repo if prompted (the workflows
+   authenticate as that app to post comments/labels — no personal token).
+
+Usage counts against the subscriber's account.
+
+## How to trigger it (admin-only for now)
+
+Both run only when a maintainer asks — intentionally not on every PR/issue yet:
+
+- **Review:** comment `@claude review` on a PR, or Actions → *Claude PR Review* →
+  *Run workflow* → PR number. Re-comment after pushing to get a fresh pass.
+- **Triage:** comment `@claude triage` on an issue, or Actions → *Claude Issue
+  Triage* → *Run workflow* → issue number.
+
+Only org members with write access (`OWNER` / `MEMBER` / `COLLABORATOR`) can
+trigger via comment; other people's comments are ignored (the `author_association`
+gate in each workflow's `if:`).
+
+## Where to tweak
+
+### Turn on automatic review / triage (the "hybrid" model)
+
+Once the rubric is tuned and the signal-to-noise is good:
+
+- **Review:** uncomment the `pull_request` trigger in `claude-review.yml`. The
+  job's `if:` already carries a **diff-size guard** (`additions < 800`) on that
+  branch, so very large PRs skip auto-review (a maintainer can still run them on
+  demand). Adjust the threshold there.
+- **Triage:** uncomment the `issues` trigger in `claude-issue-triage.yml` to
+  triage every new issue.
+
+Keep the comment and manual triggers so a maintainer can still re-run on demand.
+Auto-on-open + on-demand is the hybrid model.
+
+### Split into per-dimension review agents
+
+`REVIEW.md` is written so each dimension (Security & opsec, Correctness & bash
+safety, Tests, Docker & deploy) is self-contained. To run them as separate,
+focused reviewers — e.g. a stricter security pass and a lighter style pass —
+duplicate the `review` job per dimension and scope each prompt to its section
+("review only the **Security & opsec** dimension of REVIEW.md"). Give each its
+own summary heading. Start with one combined pass (current setup); split only
+where a dimension earns its own cadence or gating.
+
+## Cost and noise
+
+- A run costs subscription usage; admin-gating keeps volume bounded while we
+  calibrate.
+- Nits are capped (see `REVIEW.md`); tighten severity there if reviews feel
+  noisy.
+- The check never blocks a merge. To gate on Important findings later, use a
+  branch-protection rule against the review output, not a failing job.
+
+## Sibling repos
+
+The same two workflows run on **moav-client** (Go/TypeScript rubric) and
+**moav-site** (docs/translation rubric). Each repo carries its own `REVIEW.md` /
+`TRIAGE.md`; the `CLAUDE_CODE_OAUTH_TOKEN` secret is shared at the org level.


### PR DESCRIPTION
Ports the Claude automation already running on **moav-client** and **moav-site** to the server repo, with a rubric rewritten for this codebase (bash + Docker + opsec) rather than Go/TS or docs.

## What's added

| File | Purpose |
|---|---|
| `.github/workflows/claude-review.yml` | PR review via `anthropics/claude-code-action` + `code-review` plugin. Posts inline comments + grouped summary. Review-only. |
| `.github/workflows/claude-issue-triage.yml` | Issue triage via a custom `gh`-CLI prompt. Labels from the existing set + one triage comment. Triage-only. |
| `REVIEW.md` | Review rubric — dimensions: **Security & opsec**, **Correctness & bash safety**, **Tests**, **Docker & deploy**. |
| `TRIAGE.md` | Triage rubric — server areas + the no-echo-secrets rule. |
| `docs/devdocs/CLAUDE-REVIEW.md` | Setup, triggers, and where to tweak. Linked from `AGENTS.md`. |

## Behavior

- **Admin-only** to start: `@claude review` on a PR / `@claude triage` on an issue (or the Actions *Run workflow* dispatch). The `author_association` gate limits comment triggers to `OWNER`/`MEMBER`/`COLLABORATOR`.
- **Advisory** — neither blocks a merge.
- Rubric points the reviewer at **`AGENTS.md`** (this repo has no `CLAUDE.md`).
- Auto-on-open triggers are present but commented, with a diff-size guard (`additions < 800`), ready to enable once the signal is tuned.

## Opsec tailoring

The rubric leads with the server's actual risks: secrets/admin-password/private-key/server-IP/share-URI never reaching logs or the repo; config writes preserving inode/mode/owner (the DAC landmines); guarded destructive commands; compose service-classification and the single-file bind-mount reload trap. Triage is told never to echo a leaked value back — flag and ask to redact.

## Prerequisite

`CLAUDE_CODE_OAUTH_TOKEN` is already set at the **org** level, so this repo inherits it — no per-repo secret needed. The Claude GitHub App must be approved on the repo to post comments/labels.

> Note: `claude-code-action` validates that the triggered workflow file matches the default branch, so the review/triage triggers only work **after** this merges to the base branch.