### PR TITLE
fix: rc.1 follow-ups — update -b tags, .env inline comments, telegram link preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -237,8 +237,10 @@ XDNS_METHOD=txt
 # Fake-TLS domain for DPI evasion (telemt mimics TLS to this domain).
 TELEMT_TLS_DOMAIN=dl.google.com
 # Per-user limits
-TELEMT_MAX_TCP_CONNS=100    # Max simultaneous TCP connections per user
-TELEMT_MAX_UNIQUE_IPS=10    # Max unique client IPs per user
+# Max simultaneous TCP connections per user
+TELEMT_MAX_TCP_CONNS=100
+# Max unique client IPs per user
+TELEMT_MAX_UNIQUE_IPS=10
 # -- Anti-DPI / traffic randomization --
 TELEMT_KEEPALIVE_RANDOM=true
 TELEMT_KEEPALIVE_JITTER=4
@@ -274,13 +276,17 @@ TELEMT_CLIENT_MSS_BULK=
 # =============================================================================
 
 # Psiphon Conduit
-CONDUIT_BANDWIDTH=100              # Mbps limit
-CONDUIT_MAX_COMMON_CLIENTS=200     # Max concurrent common proxy clients
+# Mbps limit
+CONDUIT_BANDWIDTH=100
+# Max concurrent common proxy clients
+CONDUIT_MAX_COMMON_CLIENTS=200
 # Auto-rebank Conduit lifetime-bandwidth offsets on restart (needs systemd + monitoring).
 CONDUIT_OFFSETS_AUTOUPDATE=true
 # Tor Snowflake
-SNOWFLAKE_BANDWIDTH=5       # Mbps limit
-SNOWFLAKE_CAPACITY=50        # Max concurrent clients
+# Mbps limit
+SNOWFLAKE_BANDWIDTH=5
+# Max concurrent clients
+SNOWFLAKE_CAPACITY=50
 # -- Mahsanet config donation (mahsaserver.com) --
 # Register at https://www.mahsaserver.com/, verify, then generate an API key.
 MAHSANET_API_KEY=
@@ -299,16 +305,31 @@ MAHSANET_ADS_URL=t.me/motherofallvpns
 # PORTS
 # =============================================================================
 
-PORT_HTTPS=443       # Reality (VLESS) + Hysteria2 (UDP)
-PORT_TROJAN=8443     # Trojan fallback
-PORT_ANYTLS=8445     # AnyTLS (only if ENABLE_ANYTLS=true)
-PORT_WIREGUARD=51820 # WireGuard (UDP)
-PORT_WSTUNNEL=8080   # WebSocket tunnel for WireGuard
-PORT_DNS=53          # dns-router public port - all DNS tunnels share this
-PORT_XDNS=5356       # xray XDNS secondary host port
-PORT_ADMIN=9443      # Admin dashboard
-PORT_CDN=2082        # CDN WebSocket (VLESS+WS)
-PORT_AMNEZIAWG=51821 # AmneziaWG (obfuscated WireGuard, UDP)
+# Inline comments are kept OFF these value lines on purpose: several .env
+# consumers read a port with a raw grep|cut and a trailing "# note" leaks into
+# the value (a client Endpoint once became "<ip>:51821 # AmneziaWG ..."). Keep
+# each note on its own line ABOVE the variable. Enforced by env-no-inline-comment-test.sh.
+
+# Reality (VLESS) + Hysteria2 (UDP)
+PORT_HTTPS=443
+# Trojan fallback
+PORT_TROJAN=8443
+# AnyTLS (only if ENABLE_ANYTLS=true)
+PORT_ANYTLS=8445
+# WireGuard (UDP)
+PORT_WIREGUARD=51820
+# WebSocket tunnel for WireGuard
+PORT_WSTUNNEL=8080
+# dns-router public port - all DNS tunnels share this
+PORT_DNS=53
+# xray XDNS secondary host port
+PORT_XDNS=5356
+# Admin dashboard
+PORT_ADMIN=9443
+# CDN WebSocket (VLESS+WS)
+PORT_CDN=2082
+# AmneziaWG (obfuscated WireGuard, UDP)
+PORT_AMNEZIAWG=51821
 # AmneziaWG v3.1: drop the cookie-reply packet for a bit more obfuscation. Costs
 # WireGuard's handshake-flood DoS defence, so default false (cookies on). Applied
 # on bootstrap / `moav regenerate-users`.
@@ -320,16 +341,23 @@ AWG_DISABLE_COOKIES=false
 # Set true only when every client uses the AmneziaWG app; changing it requires
 # re-issuing user bundles (moav regenerate-users) so client and server match.
 AMNEZIAWG_HEADER_PROTECTION=false
-PORT_TRUSTTUNNEL=4443 # TrustTunnel (HTTP/2 + QUIC)
-PORT_TELEMT=993      # Telegram MTProxy (fake-TLS on IMAPS port)
-PORT_XHTTP=2096      # XHTTP (VLESS+XHTTP+Reality via Xray-core)
-PORT_SS=8388         # Shadowsocks-2022 port
-PORT_SNELL=8389      # Snell (only if ENABLE_SNELL=true)
+# TrustTunnel (HTTP/2 + QUIC)
+PORT_TRUSTTUNNEL=4443
+# Telegram MTProxy (fake-TLS on IMAPS port)
+PORT_TELEMT=993
+# XHTTP (VLESS+XHTTP+Reality via Xray-core)
+PORT_XHTTP=2096
+# Shadowsocks-2022 port
+PORT_SS=8388
+# Snell (only if ENABLE_SNELL=true)
+PORT_SNELL=8389
 # Snell obfuscation mode (v5): none | http. http disguises traffic as plain
 # HTTP; the generated client config matches this.
 SNELL_OBFS=http
-PORT_GOOSE=8444      # GooseRelay exit endpoint (only if ENABLE_GOOSERELAY=true)
-PORT_GRAFANA=9444    # Grafana monitoring dashboard
+# GooseRelay exit endpoint (only if ENABLE_GOOSERELAY=true)
+PORT_GOOSE=8444
+# Grafana monitoring dashboard
+PORT_GRAFANA=9444
 
 # Shadowsocks-2022 cipher (AEAD-2022). MoaV runs multi-user (per-user PSKs),
 # supported only by the AES variants:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,10 @@ jobs:
         run: bash tests/tls-note-test.sh
       - name: moav cert (domainless no-op + install idempotency)
         run: bash tests/cert-test.sh
+      - name: moav update -b accepts a tag (release candidate)
+        run: bash tests/update-tag-test.sh
+      - name: .env has no inline comments on variable lines
+        run: bash tests/env-no-inline-comment-test.sh
       - name: release footer generator
         run: bash tests/release-footer-test.sh
       - name: release footer links resolve (network)

--- a/.github/workflows/telegram-notify.yml
+++ b/.github/workflows/telegram-notify.yml
@@ -67,6 +67,17 @@ jobs:
           fi
           python3 .github/scripts/telegram_format.py > message.txt
 
+          # Pin the link preview to OUR page (release/issue), never an external
+          # link that happens to appear first in the notes body — Telegram
+          # previews the first URL otherwise, so an App Store link in the client
+          # table was winning the card. Empty = the plain test, no preview.
+          PREVIEW_URL=""
+          case "$EVENT" in
+            release) PREVIEW_URL="$REL_URL" ;;
+            issues)  [ -s message.txt ] && PREVIEW_URL="$ISSUE_URL" ;;
+          esac
+          printf '%s' "$PREVIEW_URL" > preview_url.txt
+
       - name: Send to Telegram
         env:
           BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -82,12 +93,20 @@ jobs:
           # Optional: target a specific forum-supergroup topic (e.g. "github logs").
           EXTRA=()
           if [ -n "${TOPIC_ID}" ]; then EXTRA=(--data-urlencode "message_thread_id=${TOPIC_ID}"); fi
+          # Force the preview to our own page (release/issue). Falls back to no
+          # preview for the plain test. link_preview_options needs Bot API >= 7.0.
+          PREVIEW_URL="$(cat preview_url.txt 2>/dev/null || true)"
+          if [ -n "$PREVIEW_URL" ]; then
+            LPO="$(jq -cn --arg u "$PREVIEW_URL" '{url:$u, prefer_large_media:false}')"
+          else
+            LPO='{"is_disabled":true}'
+          fi
           echo "Sending $(wc -c < message.txt) bytes to Telegram${TOPIC_ID:+ (topic $TOPIC_ID)}…"
           curl -fsS -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${CHAT_ID}" \
             "${EXTRA[@]}" \
             --data-urlencode "text@message.txt" \
             -d parse_mode=HTML \
-            -d disable_web_page_preview=false \
+            --data-urlencode "link_preview_options=${LPO}" \
             -o /dev/null
           echo "Sent."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ sing-box 1.14, the new **Snell** protocol (on by default), opt-in Hysteria2 geck
   files) survived and the pull still aborted with "local changes would be
   overwritten by merge" even after Discard reported success. It now uses
   `git reset --hard`, which clears the index too.
+- **`moav update -b <ref>` now accepts a tag, not only a branch.** Switching an
+  install to a release candidate (`moav update -b v2.3.0-rc.1`) failed with
+  "Branch '…' does not exist" because the target was validated against branch
+  refs only. It now resolves tags too (fetching them first) and checks out a tag
+  in detached HEAD without attempting a pull.
+- **`.env` no longer carries inline comments on variable lines.** `moav update`
+  copied new options from `.env.example` verbatim, so a line like
+  `PORT_SNELL=8389 # Snell` reached the live `.env`; a consumer reading the value
+  with a raw `grep|cut` then folded the comment into it (the AmneziaWG port once
+  became `<ip>:51821 # AmneziaWG …`, so clients connected but relayed nothing).
+  Every note now sits on its own line in `.env.example`, the update path strips a
+  trailing inline comment defensively, and a CI gate keeps it that way.
+- **Telegram release notification pins its link preview to the release page.**
+  The preview showed whatever link appeared first in the notes body (e.g. a
+  client's App Store page) instead of the release. It now sets
+  `link_preview_options.url` to the release/issue URL. Same fix in moav-client.
 
 ## [2.2.4] - 2026-09-02
 

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -75,9 +75,9 @@ cmd_update() {
     current_branch=$(git -C "$install_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
     echo -e "  Current branch: ${CYAN}$current_branch${NC}"
 
-    # Show target branch if switching
+    # Show target branch/tag if switching
     if [[ -n "$target_branch" ]]; then
-        echo -e "  Target branch: ${GREEN}$target_branch${NC}"
+        echo -e "  Target (branch or tag): ${GREEN}$target_branch${NC}"
     fi
 
     # Warn if not on main branch (and not switching)
@@ -171,27 +171,53 @@ cmd_update() {
         warn "Failed to fetch, continuing with local data..."
     fi
 
-    # Switch branch if requested
+    # Switch branch or TAG if requested. `-b` accepts a tag too (e.g. a release
+    # candidate like v2.3.0-rc.1) — a tag lands in detached HEAD and is not pulled.
+    local switched_to_tag=""
     if [[ -n "$target_branch" && "$target_branch" != "$current_branch" ]]; then
-        info "Switching to branch: $target_branch"
+        info "Switching to: $target_branch"
 
-        # Check if branch exists (locally or on remote)
-        if ! git -C "$install_dir" show-ref --verify --quiet "refs/heads/$target_branch" 2>/dev/null && \
-           ! git -C "$install_dir" show-ref --verify --quiet "refs/remotes/origin/$target_branch" 2>/dev/null; then
-            error "Branch '$target_branch' does not exist"
+        # A newly-pushed rc tag may not be known locally yet.
+        git -C "$install_dir" fetch --tags origin 2>/dev/null || true
+
+        if git -C "$install_dir" show-ref --verify --quiet "refs/tags/$target_branch" 2>/dev/null; then
+            switched_to_tag=1
+        elif ! git -C "$install_dir" show-ref --verify --quiet "refs/heads/$target_branch" 2>/dev/null && \
+             ! git -C "$install_dir" show-ref --verify --quiet "refs/remotes/origin/$target_branch" 2>/dev/null; then
+            error "Branch or tag '$target_branch' does not exist"
             echo ""
             echo "Available branches:"
             git -C "$install_dir" branch -a | sed 's/^/  /' | head -15
+            echo ""
+            echo "Recent tags (release candidates and releases):"
+            git -C "$install_dir" tag --sort=-creatordate 2>/dev/null | head -8 | sed 's/^/  /'
             return 1
         fi
 
-        # Checkout the branch
+        # Checkout the branch or tag (a tag lands in detached HEAD).
         if ! git -C "$install_dir" checkout "$target_branch" 2>/dev/null; then
-            error "Failed to checkout branch '$target_branch'"
+            error "Failed to checkout '$target_branch'"
             return 1
         fi
-        success "Switched to branch: $target_branch"
+        success "Switched to: $target_branch"
         current_branch="$target_branch"
+    fi
+
+    # A tag is a fixed point (detached HEAD) — nothing to pull; the checkout
+    # already moved us to the exact code. Run the post-update checks and stop.
+    if [[ -n "$switched_to_tag" ]]; then
+        echo ""
+        local new_commit
+        new_commit=$(git -C "$install_dir" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+        success "Now at tag $target_branch ($new_commit)"
+        if [[ "$current_commit" != "$new_commit" ]]; then
+            exec "$SCRIPT_DIR/moav.sh" _post-update "$current_commit"
+        fi
+        check_component_versions
+        migrate_dns_tunnel_state
+        check_env_additions
+        print_post_update_apply_steps
+        return 0
     fi
 
     # Pull latest changes
@@ -652,6 +678,12 @@ check_env_additions() {
         local value_line
         value_line=$(grep "^${var}=" "$example_file" | head -1) || true
         [[ -z "$value_line" ]] && continue
+
+        # Never carry a trailing inline "# note" into the user's .env — raw
+        # grep|cut readers fold it into the value (a port once became
+        # "51821 # AmneziaWG ..."). .env.example keeps notes on their own line;
+        # this is the belt-and-suspenders for one that slips through.
+        value_line="$(printf '%s' "$value_line" | sed 's/[[:space:]]\{1,\}#.*$//')"
 
         # Get preceding comment lines (walk backwards)
         local line_num comments=""

--- a/tests/env-no-inline-comment-test.sh
+++ b/tests/env-no-inline-comment-test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Regression: .env variable lines must not carry a trailing inline "# comment".
+#
+# The bug (hit twice — AmneziaWG then Snell): a value line like
+#   PORT_AMNEZIAWG=51821 # AmneziaWG port
+# gets copied verbatim into the user's live .env by `moav update`
+# (check_env_additions), and .env consumers that read a value with a raw
+# grep|cut fold the comment into it — a client Endpoint became
+# "<ip>:51821 # AmneziaWG ...", so the app connected but relayed no traffic.
+#
+# Fix + guard: keep every note on its OWN line above the variable in
+# .env.example, and have check_env_additions strip any inline comment defensively.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXAMPLE="$ROOT/.env.example"
+U="$ROOT/lib/update.sh"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo ".env: no inline comments on variable lines"
+
+# 1. .env.example has no `KEY=value  # note` lines (whitespace before the #).
+hits="$(grep -nE '^[A-Z_][A-Z0-9_]*=.*[[:space:]]#' "$EXAMPLE" || true)"
+if [ -z "$hits" ]; then
+    ok ".env.example keeps every note on its own line"
+else
+    bad ".env.example still has inline comments on these variable lines:"
+    printf '%s\n' "$hits" | sed 's/^/          /'
+fi
+
+# 2. The update-time append strips a trailing inline comment defensively.
+if grep -qE "sed 's/\[\[:space:\]\].*#" "$U"; then
+    ok "check_env_additions strips a trailing inline comment before appending"
+else
+    bad "check_env_additions does not strip inline comments — a slipped-through note would reach .env"
+fi
+
+# 3. Functional proof the strip pattern keeps the value only.
+got="$(printf 'PORT_SNELL=8389      # Snell (only if ENABLE_SNELL=true)' | sed 's/[[:space:]]\{1,\}#.*$//')"
+if [ "$got" = "PORT_SNELL=8389" ]; then
+    ok "strip turns 'PORT_SNELL=8389   # note' into 'PORT_SNELL=8389'"
+else
+    bad "strip produced unexpected result: '$got'"
+fi
+
+echo ""
+if [ "$fail" -gt 0 ]; then echo "FAILED ($fail failed, $pass passed)"; exit 1; fi
+echo "PASSED ($pass checks)"

--- a/tests/update-tag-test.sh
+++ b/tests/update-tag-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Regression: `moav update -b <ref>` must accept a TAG (e.g. a release candidate
+# like v2.3.0-rc.1), not only a branch.
+#
+# The bug (found testing an RC on a live box): `moav update -b v2.3.0-rc.1` failed
+# with "Branch 'v2.3.0-rc.1' does not exist" because the switch only checked
+# refs/heads and refs/remotes/origin. A tag lands in detached HEAD and must not be
+# pulled, so it needs its own path.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+U="$ROOT/lib/update.sh"
+pass=0; fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+
+echo "moav update: -b accepts a tag (release candidate)"
+
+grep -q 'refs/tags/\$target_branch' "$U" \
+    && ok "resolves the target against refs/tags too" \
+    || bad "does not recognize tags — an rc tag is rejected as a missing branch"
+grep -q 'fetch --tags' "$U" \
+    && ok "fetches tags first (a freshly-pushed rc tag would be unknown otherwise)" \
+    || bad "does not fetch tags before resolving the target"
+if grep -q 'switched_to_tag' "$U"; then
+    ok "has a tag path (detached HEAD) that skips the pull"
+else
+    bad "no tag-specific path — it would try to 'git pull' a tag"
+fi
+
+# Functional: a tag checkout lands in detached HEAD and is not a branch you pull.
+if command -v git >/dev/null 2>&1; then
+    d="$(mktemp -d)"; trap 'rm -rf "$d"' EXIT
+    (
+        cd "$d" && git init -q && git config user.email t@t && git config user.name t
+        printf 'v1\n' > f && git add f && git commit -qm v1
+        git tag v0.0.1-rc.1
+        # the old check: is the tag a branch ref? (must be NO -> that was the bug)
+        git show-ref --verify --quiet refs/heads/v0.0.1-rc.1 && echo "ISBRANCH" || echo "NOTBRANCH"
+        # the new check: is it a tag ref? (must be YES)
+        git show-ref --verify --quiet refs/tags/v0.0.1-rc.1 && echo "ISTAG" || echo "NOTAG"
+        git checkout -q v0.0.1-rc.1 2>/dev/null && git symbolic-ref -q HEAD >/dev/null && echo "ONBRANCH" || echo "DETACHED"
+    ) > "$d/o" 2>/dev/null
+    grep -q '^NOTBRANCH$' "$d/o" && ok "a tag is not a branch ref (why the old check failed)" || bad "tag unexpectedly matched a branch ref"
+    grep -q '^ISTAG$'     "$d/o" && ok "a tag IS a refs/tags ref (what the fix checks)"       || bad "tag did not match refs/tags"
+    grep -q '^DETACHED$'  "$d/o" && ok "checking out a tag detaches HEAD (so we skip the pull)" || bad "tag checkout did not detach HEAD"
+else
+    printf '  SKIP  git unavailable for the functional check\n'
+fi
+
+echo ""
+if [ "$fail" -gt 0 ]; then echo "FAILED ($fail failed, $pass passed)"; exit 1; fi
+echo "PASSED ($pass checks)"


### PR DESCRIPTION
Three fixes surfaced while testing **v2.3.0-rc.1**. They land on `dev` for the final 2.3.0 (rc.1 is already tagged).

### 1. `moav update -b <ref>` accepts a tag
Testing an RC with `moav update -b v2.3.0-rc.1` failed with *"Branch '…' does not exist"* — the target was validated against branch refs only. It now:
- fetches tags first, resolves `refs/tags/<ref>` as well as branches,
- checks a tag out in detached HEAD and **skips the pull** (a tag is a fixed point),
- lists recent tags alongside branches when the target isn't found.

Workaround for rc.1 (which predates this fix): `cd /opt/moav && git fetch --tags origin && git checkout v2.3.0-rc.1 && moav build && moav start`.

Regression: `tests/update-tag-test.sh`.

### 2. No inline comments on `.env` variable lines
`check_env_additions` copied new options from `.env.example` **verbatim**, so a line like `PORT_SNELL=8389 # Snell` reached the user's live `.env`; consumers that read a value with a raw `grep|cut` then folded the comment into it — the same class as the AmneziaWG port bug (`<ip>:51821 # AmneziaWG …`, client connects but relays nothing).

- every note moved to its own line above the variable in `.env.example`,
- the update-time append strips a trailing inline comment defensively,
- CI gate `tests/env-no-inline-comment-test.sh` keeps it that way.

### 3. Telegram release preview pins to the release page
The notification previewed whatever link appeared **first** in the notes body (a client App Store link was winning the card). Switched from `disable_web_page_preview` to Bot API 7.0 `link_preview_options` with an explicit `url` = the release/issue page. **Same fix applied in moav-client** (separate PR).

---
Tests: new gates green locally; existing `update-discard`, `env-example`, `env-resolution` still pass. No breaking changes.