### PR TITLE
chore(components): bump Grafana (security) + telemt/Xray/slipstream/MasterDNS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,20 +158,20 @@ AMNEZIAWG_GO_VERSION=v3.1.20260828
 AWGTOOLS_VERSION=3.1.20260812
 # Slipstream (QUIC-over-DNS) - https://github.com/Mygod/slipstream-rust
 # Pre-built binaries: https://github.com/net2share/slipstream-rust-build/releases
-SLIPSTREAM_VERSION=2026.02.22.1
+SLIPSTREAM_VERSION=2026.04.22.1
 # telemt (Telegram MTProxy) - https://github.com/telemt/telemt/releases
-TELEMT_VERSION=3.5.5
+TELEMT_VERSION=3.5.7
 # dnstt (KCP+Noise DNS tunnel) - https://www.bamsoftware.com/software/dnstt/
 DNSTT_VERSION=v1.20260501.0
 # MasterDNS (advanced DNS tunnel) - https://github.com/masterking32/MasterDnsVPN
-MASTERDNS_VERSION=v2026.05.10.180256-27c7e11
+MASTERDNS_VERSION=v2026.06.13.234407-7de2476
 # GooseRelay (SOCKS5 over Google Apps Script) - https://github.com/kianmhz/GooseRelayVPN
 GOOSERELAY_VERSION=v1.7.1
 # Xray-core (VLESS+XHTTP+Reality+XDNS) - https://github.com/XTLS/Xray-core/releases
-XRAY_VERSION=v26.7.28
+XRAY_VERSION=v26.9.9
 # Monitoring stack versions (for moav build --local)
 PROMETHEUS_VERSION=3.14.0
-GRAFANA_VERSION=13.2.0
+GRAFANA_VERSION=13.2.1
 NODE_EXPORTER_VERSION=1.12.1
 CADVISOR_VERSION=0.60.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Component version bumps** (audit 2026-09-11):
+  - **Grafana 13.2.0 → [13.2.1](https://github.com/grafana/grafana/releases/tag/v13.2.1)** — upstream **security** fixes (CVE-2026-12704, CVE-2026-14199).
+  - **telemt 3.5.5 → [3.5.7](https://github.com/telemt/telemt/releases/tag/3.5.7)** — install-probe fix, websocket-lane recovery, macOS status-schema fixes.
+  - **Xray-core v26.7.28 → [v26.9.9](https://github.com/XTLS/Xray-core/releases/tag/v26.9.9)**.
+  - **slipstream 2026.02.22.1 → [v2026.04.22.1](https://github.com/net2share/slipstream-rust-build/releases/tag/v2026.04.22.1)** (server + client builds).
+  - **MasterDNS 2026.05.10 → [v2026.06.13](https://github.com/masterking32/MasterDnsVPN/releases/tag/v2026.06.13.234407-7de2476)** (release SHA256SUMS still verified at build).
+  - **TrustTunnelClient held at 1.0.49.** v1.1.5 swaps the QUIC stack (quiche → ngtcp2) while the server side stays 1.1.0, so it needs a live client/server compatibility test before bumping.
+
 ## [2.3.0] - 2026-09-03
 
 sing-box 1.14, the new **Snell** protocol (on by default), opt-in Hysteria2 gecko obfuscation, and a fix so `moav update` cleanly discards staged local changes. No breaking changes; keys, users, and certificates are untouched.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,7 +281,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.slipstream
       args:
-        SLIPSTREAM_VERSION: ${SLIPSTREAM_VERSION:-2026.02.22.1}
+        SLIPSTREAM_VERSION: ${SLIPSTREAM_VERSION:-2026.04.22.1}
     container_name: moav-slipstream
     restart: unless-stopped
     logging: *default-logging
@@ -316,7 +316,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.masterdns
       args:
-        MASTERDNS_VERSION: ${MASTERDNS_VERSION:-v2026.05.10.180256-27c7e11}
+        MASTERDNS_VERSION: ${MASTERDNS_VERSION:-v2026.06.13.234407-7de2476}
     container_name: moav-masterdns
     restart: unless-stopped
     logging: *default-logging
@@ -445,7 +445,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.telemt
       args:
-        TELEMT_VERSION: ${TELEMT_VERSION:-3.5.5}
+        TELEMT_VERSION: ${TELEMT_VERSION:-3.5.7}
     container_name: moav-telemt
     restart: unless-stopped
     logging: *default-logging
@@ -720,7 +720,7 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.xray
       args:
-        XRAY_VERSION: ${XRAY_VERSION:-v26.7.28}
+        XRAY_VERSION: ${XRAY_VERSION:-v26.9.9}
         GOPROXY: "${GOPROXY:-https://proxy.golang.org|https://goproxy.cn|direct}"
         GOSUMDB: "${GOSUMDB:-off}"
     container_name: moav-xray
@@ -1428,7 +1428,7 @@ services:
         WSTUNNEL_VERSION: ${WSTUNNEL_VERSION:-10.7.1}
         TRUSTTUNNEL_CLIENT_VERSION: ${TRUSTTUNNEL_CLIENT_VERSION:-1.0.49}
         AWGTOOLS_VERSION: ${AWGTOOLS_VERSION:-3.1.20260812}
-        SLIPSTREAM_VERSION: ${SLIPSTREAM_VERSION:-2026.02.22.1}
+        SLIPSTREAM_VERSION: ${SLIPSTREAM_VERSION:-2026.04.22.1}
         DNSTT_VERSION: ${DNSTT_VERSION:-v1.20260501.0}
     container_name: moav-client
     volumes:

--- a/dockerfiles/Dockerfile.client
+++ b/dockerfiles/Dockerfile.client
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM debian:bookworm-slim AS slipstream-builder
 
 ARG TARGETARCH
-ARG SLIPSTREAM_VERSION=2026.02.22.1
+ARG SLIPSTREAM_VERSION=2026.04.22.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates && \
     rm -rf /var/lib/apt/lists/*
@@ -80,7 +80,7 @@ ARG TARGETARCH
 
 # Versions - read from .env via docker-compose build args, with fallback defaults
 ARG SINGBOX_VERSION=1.14.0
-ARG XRAY_VERSION=26.7.28
+ARG XRAY_VERSION=26.9.9
 ARG WSTUNNEL_VERSION=10.7.1
 ARG TRUSTTUNNEL_VERSION=1.1.0
 

--- a/dockerfiles/Dockerfile.grafana
+++ b/dockerfiles/Dockerfile.grafana
@@ -7,7 +7,7 @@
 
 FROM alpine:3.21
 
-ARG GRAFANA_VERSION=13.2.0
+ARG GRAFANA_VERSION=13.2.1
 ARG TARGETARCH=amd64
 
 RUN apk add --no-cache ca-certificates tzdata bash wget

--- a/dockerfiles/Dockerfile.masterdns
+++ b/dockerfiles/Dockerfile.masterdns
@@ -15,7 +15,7 @@ ARG TARGETARCH
 
 # Version - read from .env via docker-compose build args, with fallback default.
 # Matches the MasterDNS build bundled in MahsaNG v16.
-ARG MASTERDNS_VERSION=v2026.05.10.180256-27c7e11
+ARG MASTERDNS_VERSION=v2026.06.13.234407-7de2476
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \

--- a/dockerfiles/Dockerfile.slipstream
+++ b/dockerfiles/Dockerfile.slipstream
@@ -11,7 +11,7 @@ FROM debian:bookworm-slim
 ARG TARGETARCH
 
 # Version - read from .env via docker-compose build args, with fallback default
-ARG SLIPSTREAM_VERSION=2026.02.22.1
+ARG SLIPSTREAM_VERSION=2026.04.22.1
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/dockerfiles/Dockerfile.telemt
+++ b/dockerfiles/Dockerfile.telemt
@@ -11,7 +11,7 @@ FROM alpine:3.21
 ARG TARGETARCH
 
 # Version - read from .env via docker-compose build args
-ARG TELEMT_VERSION=3.5.5
+ARG TELEMT_VERSION=3.5.7
 
 # Install runtime dependencies
 RUN apk add --no-cache \

--- a/dockerfiles/Dockerfile.xray
+++ b/dockerfiles/Dockerfile.xray
@@ -14,7 +14,7 @@ FROM golang:1.26-alpine AS builder
 RUN apk add --no-cache git wget unzip ca-certificates
 
 ARG XRAY_REPO=https://github.com/XTLS/Xray-core.git
-ARG XRAY_VERSION=v26.7.28
+ARG XRAY_VERSION=v26.9.9
 ARG TARGETARCH
 
 # Go module fetch resilience — used ONLY by the source-compile fallback below.


### PR DESCRIPTION
Component version audit (2026-09-11). Bumps every site (`.env.example`, `docker-compose.yml` build-arg defaults, Dockerfile `ARG` defaults):

| Component | From → To | Note |
|---|---|---|
| Grafana | 13.2.0 → [13.2.1](https://github.com/grafana/grafana/releases/tag/v13.2.1) | 🔴 **Security** — CVE-2026-12704, CVE-2026-14199 |
| telemt | 3.5.5 → [3.5.7](https://github.com/telemt/telemt/releases/tag/3.5.7) | install-probe + websocket-lane recovery |
| Xray-core | v26.7.28 → [v26.9.9](https://github.com/XTLS/Xray-core/releases/tag/v26.9.9) | server + client Dockerfiles |
| slipstream | 2026.02.22.1 → [v2026.04.22.1](https://github.com/net2share/slipstream-rust-build/releases/tag/v2026.04.22.1) | server + client builds |
| MasterDNS | v2026.05.10 → [v2026.06.13](https://github.com/masterking32/MasterDnsVPN/releases/tag/v2026.06.13.234407-7de2476) | release SHA256SUMS still verified at build |

**Held back — TrustTunnelClient 1.0.49 (not bumped).** v1.1.5 swaps the QUIC stack (quiche → ngtcp2) while the server side (`TrustTunnel`) stays 1.1.0. Bumping the client alone risks a protocol-incompat tunnel, so it needs a live client↔server test first (candidate for the e2e run).

### Merge sequencing
This is **2.3.1 content** (CHANGELOG `[Unreleased]`). **Hold merge until `v2.3.0` is tagged**, so the rc.2-tested surface stays frozen for 2.3.0. Exception: if the Grafana CVEs warrant it, fast-track this into 2.3.0 (would need an rc.3 to re-test the images).

Gated by CI (`docker compose config` + build). The image builds are the real validation — the e2e run will exercise them.